### PR TITLE
add parallelplot

### DIFF
--- a/arviz/plots/__init__.py
+++ b/arviz/plots/__init__.py
@@ -4,5 +4,6 @@ from .densityplot import densityplot
 from .energyplot import energyplot
 from .forestplot import forestplot
 from .kdeplot import kdeplot
+from .parallelplot import parallelplot
 from .posteriorplot import posteriorplot
 from .traceplot import traceplot

--- a/arviz/plots/energyplot.py
+++ b/arviz/plots/energyplot.py
@@ -40,9 +40,6 @@ def energyplot(trace, kind='kde', figsize=None, legend=True, shade=0.35, bw=4.5,
     """
 
     energy = get_stats(trace, 'energy')
-    
-    if ax is None:
-        _, ax = plt.subplots(figsize=figsize)
 
     series = [('Marginal energy distribution', energy - energy.mean()),
               ('Energy transition distribution', np.diff(energy))]
@@ -77,3 +74,5 @@ def energyplot(trace, kind='kde', figsize=None, legend=True, shade=0.35, bw=4.5,
 
     if legend:
         ax.legend()
+
+    return ax

--- a/arviz/plots/parallelplot.py
+++ b/arviz/plots/parallelplot.py
@@ -1,0 +1,65 @@
+import matplotlib.pyplot as plt
+from arviz.utils import trace_to_dataframe, get_varnames, get_stats
+
+
+def parallelplot(trace, varnames=None, figsize=None, textsize=14, legend=True, colornd='k',
+                 colord='C1', shadend=.025, ax=None):
+    """
+    A parallel coordinates plot showing posterior points with and without divergences
+
+    Parameters
+    ----------
+    trace : Pandas DataFrame or PyMC3 trace
+        Posterior samples
+    varnames : list of variable names
+        Variables to be plotted, if None all variable are plotted. Can be used to change the order
+        of the plotted variables
+    figsize : figure size tuple
+        If None, size is (12 x 6)
+    textsize : int
+        Text size of the axis ticks (Default:14)
+    legend : bool
+        Flag for plotting legend (defaults to True)
+    colornd : valid matplotlib color
+        color for non-divergent points. Defaults to 'k'
+    colord : valid matplotlib color
+        color for divergent points. Defaults to 'C1'
+    shadend : float
+        Alpha blending value for non-divergent points, between 0 (invisible) and 1 (opaque).
+        Defaults to .025
+        
+    ax : axes
+        Matplotlib axes.
+
+    Returns
+    -------
+    ax : matplotlib axes
+    """
+    divergent = get_stats(trace, 'diverging')
+    trace = trace_to_dataframe(trace)
+    varnames = get_varnames(trace, varnames)
+
+    if len(varnames) < 2:
+        raise ValueError('This plot needs at least two variables')
+
+    trace = trace[varnames]
+
+    if figsize is None:
+        figsize = (12, 6)
+
+    if ax is None:
+        _, ax = plt.subplots(figsize=figsize)
+
+    ax.plot(trace.values[divergent == 0].T, color=colornd, alpha=shadend)
+    ax.plot(trace.values[divergent == 1].T, color=colord, lw=1)
+
+    ax.tick_params(labelsize=textsize)
+    ax.set_xticks(range(trace.shape[1]))
+    ax.set_xticklabels(varnames)
+
+    if legend:
+        ax.plot([], color=colornd, label='non-divergent')
+        ax.plot([], color=colord, label='divergent')
+        ax.legend(fontsize=textsize)
+
+    return ax

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -8,7 +8,7 @@ from ..utils import trace_to_dataframe, expand_variable_names
 from .plot_utils import identity_transform
 
 
-def posteriorplot(trace, varnames=None, transform=identity_transform, figsize=None, text_size=14,
+def posteriorplot(trace, varnames=None, transform=identity_transform, figsize=None, textsize=14,
                   alpha=0.05, round_to=1, point_estimate='mean', rope=None, ref_val=None,
                   kind='kde', bw=4.5, bins=None, skip_first=0, ax=None, **kwargs):
     """
@@ -24,7 +24,7 @@ def posteriorplot(trace, varnames=None, transform=identity_transform, figsize=No
         Function to transform data (defaults to identity)
     figsize : tuple
         Figure size. If None, size is (12, num of variables * 2)
-    text_size : int
+    textsize : int
         Text size of the point_estimates, axis ticks, and HPD (Default:14)
     alpha : float
         Defines range for High Posterior Density
@@ -85,15 +85,15 @@ def posteriorplot(trace, varnames=None, transform=identity_transform, figsize=No
         tr_values = transform(trace[v])
         _plot_posterior_op(tr_values, ax=a, bw=bw, bins=bins, kind=kind, point_estimate=point_estimate,
                            round_to=round_to, alpha=alpha, ref_val=ref_val[idx], rope=rope[idx],
-                           text_size=_scale_text(figsize, text_size), **kwargs)
-        a.set_title(v, fontsize=_scale_text(figsize, text_size))
+                           textsize=_scale_text(figsize, textsize), **kwargs)
+        a.set_title(v, fontsize=_scale_text(figsize, textsize))
 
     plt.tight_layout()
     return ax
 
 
 def _plot_posterior_op(trace_values, ax, bw, bins, kind, point_estimate, round_to, alpha, ref_val, rope,
-                       text_size=16, **kwargs):
+                       textsize=16, **kwargs):
     """
     Artist to draw posterior.
     """
@@ -107,14 +107,14 @@ def _plot_posterior_op(trace_values, ax, bw, bins, kind, point_estimate, round_t
                                                  ref_val,
                                                  format_as_percent(greater_than_ref_probability, 1))
         ax.axvline(ref_val, ymin=0.02, ymax=.75, color='C1', linewidth=4, alpha=0.65)
-        ax.text(trace_values.mean(), plot_height * 0.6, ref_in_posterior, size=text_size,
+        ax.text(trace_values.mean(), plot_height * 0.6, ref_in_posterior, size=textsize,
                 horizontalalignment='center')
 
     def display_rope(rope):
         ax.plot(rope, (plot_height * 0.02, plot_height * 0.02),
                 linewidth=20, color='C2', alpha=0.75)
         text_props = dict(
-            size=text_size, horizontalalignment='center', color='C2')
+            size=textsize, horizontalalignment='center', color='C2')
         ax.text(rope[0], plot_height * 0.14, rope[0], **text_props)
         ax.text(rope[1], plot_height * 0.14, rope[1], **text_props)
 
@@ -139,20 +139,20 @@ def _plot_posterior_op(trace_values, ax, bw, bins, kind, point_estimate, round_t
                                                                           point_value=point_value, round_to=round_to)
 
         ax.text(point_value, plot_height * 0.8, point_text,
-                size=text_size, horizontalalignment='center')
+                size=textsize, horizontalalignment='center')
 
     def display_hpd():
         hpd_intervals = hpd(trace_values, alpha=alpha)
         ax.plot(hpd_intervals, (plot_height * 0.02, plot_height * 0.02), linewidth=4, color='k')
         ax.text(hpd_intervals[0], plot_height * 0.07,
                 hpd_intervals[0].round(round_to),
-                size=text_size, horizontalalignment='right')
+                size=textsize, horizontalalignment='right')
         ax.text(hpd_intervals[1], plot_height * 0.07,
                 hpd_intervals[1].round(round_to),
-                size=text_size, horizontalalignment='left')
+                size=textsize, horizontalalignment='left')
         ax.text((hpd_intervals[0] + hpd_intervals[1]) / 2, plot_height * 0.2,
                 format_as_percent(1 - alpha) + ' HPD',
-                size=text_size, horizontalalignment='center')
+                size=textsize, horizontalalignment='center')
 
     def format_axes():
         ax.yaxis.set_ticklabels([])
@@ -163,7 +163,7 @@ def _plot_posterior_op(trace_values, ax, bw, bins, kind, point_estimate, round_t
         ax.yaxis.set_ticks_position('none')
         ax.xaxis.set_ticks_position('bottom')
         ax.tick_params(axis='x', direction='out', width=1, length=3,
-                       color='0.5', labelsize=text_size)
+                       color='0.5', labelsize=textsize)
         ax.spines['bottom'].set_color('0.5')
 
     def set_key_if_doesnt_exist(d, key, value):
@@ -195,16 +195,16 @@ def _plot_posterior_op(trace_values, ax, bw, bins, kind, point_estimate, round_t
         display_rope(rope)
 
 
-def _scale_text(figsize, text_size):
+def _scale_text(figsize, textsize):
     """Scale text to figsize."""
 
-    if text_size is None and figsize is not None:
+    if textsize is None and figsize is not None:
         if figsize[0] <= 11:
             return 12
         else:
             return figsize[0]
     else:
-        return text_size
+        return textsize
 
 
 def _create_axes_grid(figsize, trace):


### PR DESCRIPTION
While a parallel coordinates plot could be more general this implementation is tailored to help diagnose NUTS samples. See this [page](https://docs.pymc.io/notebooks/Diagnosing_biased_Inference_with_Divergences.html) and this [paper](https://arxiv.org/abs/1709.01449) for details.

This PR also make change in other files:

* Remove duplicated code from energyplot
* Rename `text_size` argument in `posteriorplot` to `textsize` (for consistence with other argument names)
* More test for plots (still not very thorough).