### PR TITLE
forestplot: add effective sample size

### DIFF
--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -32,7 +32,9 @@ def test_plots():
     assert autocorrplot(short_trace).shape == (10, 2)
 
     assert forestplot(trace0).get_geometry() == (1, 1)
-    assert forestplot(short_trace).get_geometry() == (1, 2)
+    assert forestplot(short_trace).get_geometry() == (1, 3)
+    assert forestplot(short_trace, rhat=False).get_geometry() == (1, 2)
+    assert forestplot(short_trace, neff=False).get_geometry() == (1, 2)
 
     with raises(AttributeError):
         energyplot(trace0)


### PR DESCRIPTION
Now forestplot looks closer to the graphical version of `summary` :-)

![forestplot](https://user-images.githubusercontent.com/1338958/39381844-e5c52e90-4a39-11e8-9854-6c29d2b1ccb1.png)

