### PR TITLE
add jointplot

### DIFF
--- a/arviz/plots/__init__.py
+++ b/arviz/plots/__init__.py
@@ -8,3 +8,4 @@ from .parallelplot import parallelplot
 from .posteriorplot import posteriorplot
 from .traceplot import traceplot
 from .pairplot import pairplot
+from .jointplot import jointplot

--- a/arviz/plots/jointplot.py
+++ b/arviz/plots/jointplot.py
@@ -1,0 +1,108 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.ticker import NullFormatter
+from .kdeplot import kdeplot
+from ..utils import trace_to_dataframe
+from .plot_utils import _scale_text
+
+
+def jointplot(trace, varnames=None, figsize=None, text_size=None, hexbin=False, gridsize='auto', skip_first=0,
+              joint_kwargs=None, marginal_kwargs=None):
+    """
+    Plot a scatter or hexbin of two variables with their respective marginals distributions.
+
+    Parameters
+    ----------
+
+    trace : Pandas DataFrame or PyMC3 trace
+        Posterior samples
+    varnames : list of variable names
+        Variables to be plotted, if None all variable are plotted
+    figsize : figure size tuple
+        If None, size is (8, 8)
+    text_size: int
+        Text size for labels
+    hexbin : Boolean
+        If True draws an hexbin plot
+    gridsize : int or (int, int), optional.
+        Only works when hexbin is True.
+        The number of hexagons in the x-direction. The corresponding number of hexagons in the
+        y-direction is chosen such that the hexagons are approximately regular.
+        Alternatively, gridsize can be a tuple with two elements specifying the number of hexagons
+        in the x-direction and the y-direction.
+    skip_first : int
+        Number of first samples not shown in plots (burn-in)
+    """
+    trace = trace_to_dataframe(trace, combined=True)[skip_first:]
+
+    if figsize is None:
+        figsize = (8, 8)
+
+    if text_size is None:
+        text_size = _scale_text(figsize, text_size=text_size)
+
+    if len(varnames) > 2:
+        raise Exception('Number of variables to be plotted must 2')
+
+    if joint_kwargs is None:
+        joint_kwargs = {}
+
+    if marginal_kwargs is None:
+        marginal_kwargs = {}
+
+    plt.figure(figsize=figsize)
+
+    axjoin, axHistx, axHisty = _define_axes()
+
+    x_var_name = varnames[0]
+    y_var_name = varnames[1]
+
+    x = trace[x_var_name].values
+    y = trace[y_var_name].values
+
+    axjoin.set_xlabel(x_var_name)
+    axjoin.set_ylabel(y_var_name)
+
+    if hexbin:
+        if gridsize == 'auto':
+            gridsize = int(len(trace)**0.35)
+            print(gridsize)
+        axjoin.hexbin(x, y, mincnt=1, gridsize=gridsize, **joint_kwargs)
+        axjoin.grid(False)
+    else:
+        axjoin.scatter(x, y, **joint_kwargs)
+
+    if x.dtype.kind == 'i':
+        bins = range(x.min(), x.max() + 2)
+        axHistx.hist(x, bins=bins, **marginal_kwargs)
+    else:
+        kdeplot(x, ax=axHistx, **marginal_kwargs)
+    if y.dtype.kind == 'i':
+        bins = range(y.min(), y.max() + 2)
+        axHisty.hist(y, bins=bins, orientation='horizontal', **marginal_kwargs)
+    else:
+        kdeplot(y, ax=axHisty, rotated=True, **marginal_kwargs)
+
+    axHistx.set_xlim(axjoin.get_xlim())
+    axHisty.set_ylim(axjoin.get_ylim())
+
+
+def _define_axes():
+    left, width = 0.1, 0.65
+    bottom, height = 0.1, 0.65
+    bottom_h = left_h = left + width + 0.02
+
+    rect_join = [left, bottom, width, height]
+    rect_histx = [left, bottom_h, width, 0.2]
+    rect_histy = [left_h, bottom, 0.2, height]
+
+    axjoin = plt.axes(rect_join)
+    axHistx = plt.axes(rect_histx)
+    axHisty = plt.axes(rect_histy)
+
+    axHistx.xaxis.set_major_formatter(NullFormatter())
+    axHisty.yaxis.set_major_formatter(NullFormatter())
+    axHistx.set_yticks([])
+    axHisty.set_xticks([])
+
+    return axjoin, axHistx, axHisty

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -4,7 +4,8 @@ from scipy.signal import gaussian, convolve
 from scipy.stats import entropy
 
 
-def kdeplot(values, label=None, shade=0, color_shade=None, bw=4.5, ax=None, kwargs_shade=None, **kwargs):
+def kdeplot(values, label=None, shade=0, color_shade=None, bw=4.5, rotated=False,
+            ax=None, kwargs_shade=None, **kwargs):
     """
     1D KDE plot taking into account boundary conditions
 
@@ -40,10 +41,18 @@ def kdeplot(values, label=None, shade=0, color_shade=None, bw=4.5, ax=None, kwar
 
     density, l, u = fast_kde(values, bw)
     x = np.linspace(l, u, len(density))
+    if rotated:
+        x, density = density, x
+
     ax.plot(x, density, label=label, **kwargs)
-    ax.set_ylim(0, auto=True)
     if shade:
         ax.fill_between(x, density, alpha=shade, color=color_shade, **kwargs_shade)
+
+    if rotated:
+        ax.set_xlim(0, auto=True)
+    else:
+        ax.set_ylim(0, auto=True)
+
     return ax
 
 

--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -1,7 +1,7 @@
 import matplotlib.pyplot as plt
 from matplotlib import gridspec
 from matplotlib.ticker import NullFormatter
-from ..utils.utils import trace_to_dataframe, get_stats
+from ..utils.utils import trace_to_dataframe, get_stats, get_varnames
 from .plot_utils import _scale_text
 
 
@@ -23,7 +23,7 @@ def pairplot(trace, varnames=None, figsize=None, text_size=None, hexbin=False, g
         Text size for labels
     hexbin : Boolean
         If True draws an hexbin plot
-    gridsize : int or (int, int), optional, default is 1% of the number of samples.
+    gridsize : int or (int, int), optional
         Only works when hexbin is True.
         The number of hexagons in the x-direction. The corresponding number of hexagons in the
         y-direction is chosen such that the hexagons are approximately regular.
@@ -51,9 +51,7 @@ def pairplot(trace, varnames=None, figsize=None, text_size=None, hexbin=False, g
         divergent = get_stats(trace, 'diverging')
 
     trace = trace_to_dataframe(trace, combined=True)[skip_first:]
-
-    if varnames is None:
-        varnames = trace.columns
+    varnames = get_varnames(trace, varnames)
 
     if kwargs_divergences is None:
         kwargs_divergences = {}
@@ -77,7 +75,6 @@ def pairplot(trace, varnames=None, figsize=None, text_size=None, hexbin=False, g
             ax.hexbin(trace[varnames[0]], trace[varnames[1]], mincnt=1, gridsize=gridsize,
                       **kwargs)
             ax.grid(False)
-            ax.patch.set_facecolor('white')
         else:
             ax.scatter(trace[varnames[0]], trace[varnames[1]], **kwargs)
 
@@ -104,7 +101,6 @@ def pairplot(trace, varnames=None, figsize=None, text_size=None, hexbin=False, g
                 if hexbin:
                     ax.hexbin(var1, var2, mincnt=1, gridsize=gridsize, **kwargs)
                     ax.grid(False)
-
                 else:
                     ax.scatter(var1, var2, **kwargs)
 

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -48,3 +48,24 @@ def _scale_text(figsize, text_size):
             return figsize[0]
     else:
         return text_size
+
+def get_bins(x, max_bins=50, n=2):
+    """
+    Compute number of bins (or ticks)
+
+    Parameters
+    ----------
+    x : array
+        array to be binned
+    max_bins : int
+        maximum number of bins
+    n : int
+        when computing bins, this should be 2, when computing ticks this should be 1.
+    """
+    x_max, x_min = x.max(), x.min()
+    x_range = x_max - x_min
+    if  x_range > cutoff:
+        bins = range(x_min, x_max + n, int(x_range / 10))
+    else:
+        bins = range(x_min, x_max + n)
+    return bins

--- a/arviz/plots/traceplot.py
+++ b/arviz/plots/traceplot.py
@@ -2,7 +2,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from ..stats import hpd
 from .kdeplot import fast_kde, kdeplot
-from .plot_utils import identity_transform, get_axis, make_2d
+from .plot_utils import identity_transform, get_axis, make_2d, get_bins
 from ..utils import get_varnames, trace_to_dataframe
 
 
@@ -116,7 +116,7 @@ def _histplot_op(ax, data, shade=.35, prior=None, prior_shade=1, prior_style='--
     """Add a histogram for each column of the data to the provided axes."""
     hs = []
     for column in data.T:
-        bins = range(column.min(), column.max() + 2)
+        bins = get_bins(column)
         hs.append(ax.hist(column, bins=bins, alpha=shade, align='left',
                           density=True))
         if prior is not None:
@@ -124,7 +124,8 @@ def _histplot_op(ax, data, shade=.35, prior=None, prior_shade=1, prior_style='--
             x = np.arange(x_sample.min(), x_sample.max())
             p = prior.pmf(x)
             ax.step(x, p, where='mid', alpha=prior_shade, ls=prior_style)
-    ax.set_xticks(range(np.min(data), np.max(data) + 1))
+    xticks = get_bins(data, cutoff=10, n=1)
+    ax.set_xticks(xticks)
 
     return hs
 

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -2,7 +2,8 @@ from pandas import DataFrame
 import numpy as np
 import pymc3 as pm
 from pytest import raises
-from ..plots import densityplot, traceplot, energyplot, posteriorplot, autocorrplot, forestplot, parallelplot, pairplot
+from ..plots import (densityplot, traceplot, energyplot, posteriorplot, autocorrplot, forestplot,
+                     parallelplot, pairplot, jointplot)
 
 
 J = 8
@@ -43,6 +44,8 @@ def test_plots():
     with raises(ValueError):
         parallelplot(trace0)
     assert parallelplot(short_trace)
+
+    jointplot(short_trace, varnames=['mu', 'tau'])
 
 
 def test_pairplot():


### PR DESCRIPTION
New jointplot, it could be implemented as part of pairplot, with a _marginals_ arguments, but for now I am adding it as a standalone plot.  

```python
az.jointplot(trace, varnames=['e', 'd'])
```
![scatter](https://user-images.githubusercontent.com/1338958/39455885-4f3f0018-4cb9-11e8-9237-f24590ce5922.png)

```python
az.jointplot(trace, varnames=['e', 'd'], hexbin=True)
```
![hexbin](https://user-images.githubusercontent.com/1338958/39455884-4f0390b4-4cb9-11e8-8916-a1cc83f34107.png)

This PR also adds:

* kdeplot: new `rotated` argument
* gridsize is now computed as len(trace)**0.35, instead of 1% of samples
* pairplot: small fix, use `get_varnames` to handle varnames