### PR TITLE
Add more linting

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -56,7 +56,12 @@ confidence=
 # --disable=W"
 disable=missing-docstring,
         no-else-return,
-        len-as-condition
+        len-as-condition,
+        too-many-arguments,
+        too-many-locals,
+        too-many-branches,
+        too-many-statements,
+        no-self-use
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -232,7 +237,9 @@ good-names=i,
            ax,
            x,
            y,
+           gs,
            bw,
+           ic,
            dx,
            mu,
            tr,

--- a/arviz/plots/autocorrplot.py
+++ b/arviz/plots/autocorrplot.py
@@ -51,13 +51,13 @@ def autocorrplot(trace, varnames=None, max_lag=100, symmetric_plot=False, combin
 
     max_lag = min(len(trace) - 1, max_lag)
 
-    for i, v in enumerate(varnames):
+    for i, varname in enumerate(varnames):
         for j in range(nchains):
             if nchains == 1:
-                d = trace[v].values
+                data = trace[varname].values
             else:
-                d = trace[v].values[:, j]
-            ax[i, j].acorr(d, detrend=plt.mlab.detrend_mean, maxlags=max_lag, lw=linewidth)
+                data = trace[varname].values[:, j]
+            ax[i, j].acorr(data, detrend=plt.mlab.detrend_mean, maxlags=max_lag, lw=linewidth)
 
             if j == 0:
                 ax[i, j].set_ylabel("correlation", fontsize=textsize)
@@ -69,8 +69,8 @@ def autocorrplot(trace, varnames=None, max_lag=100, symmetric_plot=False, combin
                 ax[i, j].set_xlim(0, max_lag)
 
             if nchains > 1:
-                ax[i, j].set_title("{0} (chain {1})".format(v, j), fontsize=textsize)
+                ax[i, j].set_title("{0} (chain {1})".format(varname, j), fontsize=textsize)
             else:
-                ax[i, j].set_title(v, fontsize=textsize)
+                ax[i, j].set_title(varname, fontsize=textsize)
             ax[i, j].tick_params(labelsize=textsize)
     return ax

--- a/arviz/plots/energyplot.py
+++ b/arviz/plots/energyplot.py
@@ -77,8 +77,8 @@ def energyplot(trace, kind='kde', bfmi=True, figsize=None, legend=True, fill_alp
         raise ValueError('Plot type {} not recognized.'.format(kind))
 
     if bfmi:
-        for idx, v in enumerate(e_bfmi(trace)):
-            plt.plot([], label='chain {:>2} BFMI = {:.2f}'.format(idx, v), alpha=0)
+        for idx, val in enumerate(e_bfmi(trace)):
+            plt.plot([], label='chain {:>2} BFMI = {:.2f}'.format(idx, val), alpha=0)
 
     ax.set_xticks([])
     ax.set_yticks([])

--- a/arviz/plots/khatplot.py
+++ b/arviz/plots/khatplot.py
@@ -3,14 +3,14 @@ import numpy as np
 from .plot_utils import _scale_text
 
 
-def khatplot(ks, figsize=None, textsize=None, ax=None, hlines_kwargs=None, **kwargs):
+def khatplot(khats, figsize=None, textsize=None, ax=None, hlines_kwargs=None, **kwargs):
     R"""
-    Plot Paretto tail indices.
+    Plot Pareto tail indices.
 
     Parameters
     ----------
-    ks : array
-      Paretto tail indices.
+    khats : array
+      Pareto tail indices.
     figsize : figure size tuple
       If None, size is (8, 4)
     textsize: int
@@ -18,7 +18,9 @@ def khatplot(ks, figsize=None, textsize=None, ax=None, hlines_kwargs=None, **kwa
     ax: axes
       Matplotlib axes
     hlines_kwargs: dictionary
-      Aditional keywords passed to ax.hlines
+      Additional keywords passed to ax.hlines
+    kwargs :
+      Additional keywords passed to ax.scatter
 
     Returns
     -------
@@ -32,19 +34,19 @@ def khatplot(ks, figsize=None, textsize=None, ax=None, hlines_kwargs=None, **kwa
     if hlines_kwargs is None:
         hlines_kwargs = {}
 
-    textsize, linewidth, ms = _scale_text(figsize, textsize=textsize)
+    textsize, linewidth, markersize = _scale_text(figsize, textsize=textsize)
 
     if ax is None:
         _, ax = plt.subplots(1, 1, figsize=figsize)
 
-    ax.hlines([0, .5, .7, 1], xmin=-1, xmax=len(ks)+1,
-              alpha=.25, **hlines_kwargs)
+    ax.hlines([0, .5, .7, 1], xmin=-1, xmax=len(khats)+1,
+              alpha=.25, linewidth=linewidth, **hlines_kwargs)
 
-    alphas = .5 + .5*(ks > .5)
-    rgba_c = np.zeros((len(ks), 4))
+    alphas = .5 + .5*(khats > .5)
+    rgba_c = np.zeros((len(khats), 4))
     rgba_c[:, 2] = .8
     rgba_c[:, 3] = alphas
-    ax.scatter(np.arange(len(ks)), ks, c=rgba_c, marker='+', linewidth=ms)
+    ax.scatter(np.arange(len(khats)), khats, c=rgba_c, marker='+', markersize=markersize, **kwargs)
     ax.set_xlabel('Data point', fontsize=textsize)
     ax.set_ylabel(r'Shape parameter κ', fontsize=textsize)
     ax.tick_params(labelsize=textsize)

--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -80,11 +80,11 @@ def pairplot(trace, varnames=None, figsize=None, textsize=None, kind='scatter', 
         if kind == 'scatter':
             ax.scatter(trace[varnames[0]], trace[varnames[1]], s=markersize, **kwargs)
         else:
-            hb = ax.hexbin(trace[varnames[0]], trace[varnames[1]], mincnt=1, gridsize=gridsize,
-                           **kwargs)
+            hexbin = ax.hexbin(trace[varnames[0]], trace[varnames[1]], mincnt=1, gridsize=gridsize,
+                               **kwargs)
             ax.grid(False)
             if colorbar:
-                cbar = plt.colorbar(hb, ticks=[hb.norm.vmin, hb.norm.vmax], ax=ax)
+                cbar = plt.colorbar(hexbin, ticks=[hexbin.norm.vmin, hexbin.norm.vmax], ax=ax)
                 cbar.ax.set_yticklabels(['low', 'high'], fontsize=textsize)
 
         if divergences:
@@ -113,10 +113,12 @@ def pairplot(trace, varnames=None, figsize=None, textsize=None, kind='scatter', 
                 else:
                     ax.grid(False)
                     if i == j == 0 and colorbar:
-                        hb = ax.hexbin(var1, var2, mincnt=1, gridsize=gridsize, **kwargs)
+                        hexbin = ax.hexbin(var1, var2, mincnt=1, gridsize=gridsize, **kwargs)
                         divider = make_axes_locatable(ax)
                         cax = divider.append_axes('right', size='7%', pad=0.1)
-                        cbar = plt.colorbar(hb, ticks=[hb.norm.vmin, hb.norm.vmax], cax=cax)
+                        cbar = plt.colorbar(hexbin,
+                                            ticks=[hexbin.norm.vmin, hexbin.norm.vmax],
+                                            cax=cax)
                         cbar.ax.set_yticklabels(['low', 'high'], fontsize=textsize)
                         divider.append_axes('top', size='7%', pad=0.1).set_axis_off()
 

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -85,11 +85,11 @@ def posteriorplot(trace, varnames=None, figsize=None, textsize=None, alpha=0.05,
     elif np.ndim(rope) == 1:
         rope = [rope] * var_num
 
-    for idx, (a, v) in enumerate(zip(np.atleast_1d(ax), trace.columns)):
-        _plot_posterior_op(trace[v], ax=a, bw=bw, linewidth=linewidth, bins=bins, kind=kind,
+    for idx, (ax_, col) in enumerate(zip(np.atleast_1d(ax), trace.columns)):
+        _plot_posterior_op(trace[col], ax=ax_, bw=bw, linewidth=linewidth, bins=bins, kind=kind,
                            point_estimate=point_estimate, round_to=round_to, alpha=alpha,
                            ref_val=ref_val[idx], rope=rope[idx], textsize=textsize, **kwargs)
-        a.set_title(v, fontsize=textsize)
+        ax_.set_title(col, fontsize=textsize)
 
     plt.tight_layout()
     return ax
@@ -130,8 +130,8 @@ def _plot_posterior_op(trace_values, ax, bw, linewidth, bins, kind, point_estima
             point_value = trace_values.mean()
         elif point_estimate == 'mode':
             if isinstance(trace_values.iloc[0], float):
-                density, l, u = fast_kde(trace_values, bw)
-                x = np.linspace(l, u, len(density))
+                density, lower, upper = fast_kde(trace_values, bw)
+                x = np.linspace(lower, upper, len(density))
                 point_value = x[np.argmax(density)]
             else:
                 point_value = mode(trace_values.round(round_to))[0][0]
@@ -166,10 +166,6 @@ def _plot_posterior_op(trace_values, ax, bw, linewidth, bins, kind, point_estima
                        color='0.5', labelsize=textsize)
         ax.spines['bottom'].set_color('0.5')
 
-    def set_key_if_doesnt_exist(d, key, value):
-        if key not in d:
-            d[key] = value
-
     if kind == 'kde' and isinstance(trace_values.iloc[0], float):
         kdeplot(trace_values,
                 fill_alpha=kwargs.pop('alpha', 1),
@@ -187,8 +183,8 @@ def _plot_posterior_op(trace_values, ax, bw, linewidth, bins, kind, point_estima
                 ax.set_xlim(xmin - 0.5, xmax + 0.5)
             else:
                 bins = 'auto'
-        set_key_if_doesnt_exist(kwargs, 'align', 'left')
-        set_key_if_doesnt_exist(kwargs, 'color', 'C0')
+        kwargs.setdefault('align', 'left')
+        kwargs.setdefault('color', 'C0')
         ax.hist(trace_values, bins=bins, alpha=0.35, **kwargs)
 
     plot_height = ax.get_ylim()[1]
@@ -207,11 +203,11 @@ def _create_axes_grid(figsize, trace):
     if l_trace == 1:
         fig, ax = plt.subplots(figsize=figsize)
     else:
-        n = np.ceil(l_trace / 2.0).astype(int)
+        n_rows = np.ceil(l_trace / 2.0).astype(int)
         if figsize is None:
-            figsize = (12, n * 2.5)
-        fig, ax = plt.subplots(n, 2, figsize=figsize)
-        ax = ax.reshape(2 * n)
+            figsize = (12, n_rows * 2.5)
+        fig, ax = plt.subplots(n_rows, 2, figsize=figsize)
+        ax = ax.reshape(2 * n_rows)
         if l_trace % 2 == 1:
             ax[-1].set_axis_off()
             ax = ax[:-1]

--- a/arviz/plots/traceplot.py
+++ b/arviz/plots/traceplot.py
@@ -117,37 +117,37 @@ def traceplot(trace, varnames=None, figsize=None, textsize=None, lines=None, com
 
 def _histplot_op(ax, data, shade=.35, prior=None, prior_shade=1, prior_style='--'):
     """Add a histogram for each column of the data to the provided axes."""
-    hs = []
+    hists = []
     for column in data.T:
         bins = get_bins(column)
-        hs.append(ax.hist(column, bins=bins, alpha=shade, align='left',
-                          density=True))
+        hists.append(ax.hist(column, bins=bins, alpha=shade, align='left',
+                             density=True))
         if prior is not None:
             x_sample = prior.rvs(1000)
             x = np.arange(x_sample.min(), x_sample.max())
-            p = prior.pmf(x)
-            ax.step(x, p, where='mid', alpha=prior_shade, ls=prior_style)
+            pmf = prior.pmf(x)
+            ax.step(x, pmf, where='mid', alpha=prior_shade, ls=prior_style)
     xticks = get_bins(data, max_bins=10, fenceposts=1)
     ax.set_xticks(xticks)
 
-    return hs
+    return hists
 
 
 def _kdeplot_op(ax, data, bw, linewidth, prior=None, prior_shade=1, prior_style='--'):
     """Get a list of density and likelihood plots, if a prior is provided."""
-    ls = []
-    pls = []
+    densities = []
+    priors = []
     errored = []
     for i, col in enumerate(data.T):
         try:
-            density, l, u = fast_kde(col, bw)
-            x = np.linspace(l, u, len(density))
-            ls.append(ax.plot(x, density, lw=linewidth))
+            density, lower, upper = fast_kde(col, bw)
+            x = np.linspace(lower, upper, len(density))
+            densities.append(ax.plot(x, density, lw=linewidth))
             if prior is not None:
                 x_sample = prior.rvs(10000)
                 x = np.linspace(x_sample.min(), x_sample.max(), 1000)
-                p = prior.pdf(x)
-                pls.append(ax.plot(x, p, alpha=prior_shade, ls=prior_style))
+                pdf = prior.pdf(x)
+                priors.append(ax.plot(x, pdf, alpha=prior_shade, ls=prior_style))
 
         except ValueError:
             errored.append(str(i))
@@ -157,4 +157,4 @@ def _kdeplot_op(ax, data, bw, linewidth, prior=None, prior_shade=1, prior_style=
                 bbox={'facecolor': 'red', 'alpha': 0.5, 'pad': 10},
                 style='italic')
 
-    return ls, pls
+    return densities, priors

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -34,7 +34,7 @@ def bfmi(trace):
     """
     energy = np.atleast_2d(get_stats(trace, 'energy', combined=False))
 
-    return np.square(np.diff(energy, 1)).mean(1) / np.var(energy, 1)
+    return np.square(np.diff(energy, axis=1)).mean(axis=1) / np.var(energy, axis=1)
 
 
 def compare(model_dict, ic='waic', method='stacking', b_samples=1000,
@@ -126,8 +126,8 @@ def compare(model_dict, ic='waic', method='stacking', b_samples=1000,
     ic_i = '{}_i'.format(ic)
 
     ics = pd.DataFrame()
-    for m, t in model_dict.items():
-        ics = ics.append(ic_func(t, m, pointwise=True))
+    for model, trace in model_dict.items():
+        ics = ics.append(ic_func(trace, model, pointwise=True))
     ics.index = names
     ics.sort_values(by=ic, inplace=True)
 

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -10,9 +10,9 @@ from ..stats import bfmi, compare, hpd, r2_score, summary, waic, psislw
 
 
 def fake_trace(n_samples):
-    a = np.repeat((1, 5, 10), n_samples)
-    b = np.repeat((1, 5, 1), n_samples)
-    data = np.random.beta(a, b).reshape(-1, n_samples//2)
+    alpha = np.repeat((1, 5, 10), n_samples)
+    beta = np.repeat((1, 5, 1), n_samples)
+    data = np.random.beta(alpha, beta).reshape(-1, n_samples//2)
     trace = pd.DataFrame(data.T, columns=['a', 'a', 'b', 'b', 'c', 'c'])
     return trace
 
@@ -91,8 +91,8 @@ def test_waic():
     x_obs = np.arange(6)
 
     with pm.Model() as model:
-        p = pm.Beta('p', 1., 1., transform=None)
-        pm.Binomial('x', 5, p, observed=x_obs)
+        prob = pm.Beta('p', 1., 1., transform=None)
+        pm.Binomial('x', 5, prob, observed=x_obs)
 
         step = pm.Metropolis()
         trace = pm.sample(100, step)
@@ -113,6 +113,6 @@ def test_waic():
                         actual_waic_se, decimal=2)
 
 def test_psis():
-    lw = np.random.randn(20000, 10)
-    _, ks = psislw(lw)
-    assert_array_less(ks, .5)
+    linewidth = np.random.randn(20000, 10)
+    _, khats = psislw(linewidth)
+    assert_array_less(khats, .5)


### PR DESCRIPTION
This leaves only `stats.stats` and `stats.diagnostics` to be linted before I can stop making these nitpicky changes.  

A few conditions I turned off can be useful when writing maintainable functions (`too-many-locals`, `too-many-statements`, `too-many-branches`), but it seemed like too big a change to take those on.