### PR TITLE
Add coveralls, requirements files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,9 @@ install:
 
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy mkl scipy pandas matplotlib pytest pylint sphinx numpydoc ipython
   - source activate test-environment
-  - pip install git+https://github.com/pymc-devs/pymc3
-  - pip install travis-sphinx==2.0.0
-  - pip install nbsphinx
-  - pip install sphinx_rtd_theme
+  - pip install -r requirements.txt
+  - pip install -r requirements-dev.txt
+  - pip install coveralls
 
 before_script:
 - "export DISPLAY=:99.0"
@@ -33,8 +32,9 @@ before_script:
 
 script:
   - pylint arviz/
-  - pytest
+  - pytest -xv arviz/tests/ --cov=arviz/
   - travis-sphinx build -n
 
 after_success:
   - travis-sphinx deploy
+  - coveralls

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,4 @@ pytest
 pytest-cov
 sphinx
 sphinx_rtd_theme
-travis-sphinx>=2.0.0
+travis-sphinx==2.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,10 @@
+git+https://github.com/pymc-devs/pymc3
+ipython
+nbsphinx
+numpydoc
+pylint
+pytest
+pytest-cov
+sphinx
+sphinx_rtd_theme
+travis-sphinx>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+scipy
+pandas
+matplotlib

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,17 @@
+import shutil
+import os
+
 from setuptools import setup, find_packages
 from setuptools.command.install import install
 from setuptools.command.develop import develop
-import sys
-import shutil
-import os
 from matplotlib import get_configdir
+
+
+PROJECT_ROOT = os.path.dirname(os.path.realpath(__file__))
+REQUIREMENTS_FILE = os.path.join(PROJECT_ROOT, 'requirements.txt')
+
+with open(REQUIREMENTS_FILE) as buff:
+    install_reqs = buff.read.splitlines()
 
 
 def copy_styles():
@@ -35,10 +42,7 @@ setup(
     author='ArviZ Developers',
     url="http://github.com/arviz-devs/arviz",
     packages=find_packages(),
-    install_requires=['matplotlib',
-                      'numpy',
-                      'scipy',
-                      'pandas'],
+    install_requires=install_reqs,
     include_package_data=True,
     cmdclass={
         'develop': DevelopStyles,


### PR DESCRIPTION
This activates coveralls (79% currently), and also might make writing documentation for new developers a little easier (`pip install -r requirements.txt`, `pip install -r requirements-dev.txt`).  

You are doing some cool conda stuff, but I do not know enough to set up an environment.yml or to write those instructions.

Note you will have to go to coveralls.io and activate the repo to start getting covered (and then you can get travis/coveralls badges on readme.md).