### PR TITLE
Add posterior predictive checks plot

### DIFF
--- a/arviz/plots/__init__.py
+++ b/arviz/plots/__init__.py
@@ -10,3 +10,4 @@ from .traceplot import traceplot
 from .pairplot import pairplot
 from .jointplot import jointplot
 from .khatplot import khatplot
+from .ppcplot import ppcplot

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -73,8 +73,39 @@ def get_bins(ary, max_bins=50, fenceposts=2):
     """
     x_max, x_min = ary.max(), ary.min()
     x_range = x_max - x_min
-    if  x_range > max_bins:
+    if x_range > max_bins:
         bins = range(x_min, x_max + fenceposts, int(x_range / 10))
     else:
         bins = range(x_min, x_max + fenceposts)
     return bins
+
+
+def _create_axes_grid(figsize, trace):
+    """
+    Parameters
+    ----------
+    figsize : tuple
+        Figure size.
+    trace : dict or DataFrame
+        dictionary with ppc samples of DataFrame with posterior samples
+    Returns
+    -------
+    fig : matplotlib figure
+    ax : matplotlib axes
+    """
+    if isinstance(trace, dict):
+        l_trace = len(trace)
+    else:
+        l_trace = trace.shape[1]
+    if l_trace == 1:
+        fig, ax = plt.subplots(figsize=figsize)
+    else:
+        n_rows = np.ceil(l_trace / 2.0).astype(int)
+        if figsize is None:
+            figsize = (12, n_rows * 2.5)
+        fig, ax = plt.subplots(n_rows, 2, figsize=figsize)
+        ax = ax.reshape(2 * n_rows)
+        if l_trace % 2 == 1:
+            ax[-1].set_axis_off()
+            ax = ax[:-1]
+    return fig, ax

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -5,7 +5,7 @@ from . import kdeplot
 from .kdeplot import fast_kde
 from ..stats import hpd
 from ..utils import trace_to_dataframe, expand_variable_names
-from .plot_utils import  _scale_text
+from .plot_utils import _scale_text, _create_axes_grid
 
 
 def posteriorplot(trace, varnames=None, figsize=None, textsize=None, alpha=0.05, round_to=1,
@@ -196,19 +196,3 @@ def _plot_posterior_op(trace_values, ax, bw, linewidth, bins, kind, point_estima
         display_ref_val(ref_val)
     if rope is not None:
         display_rope(rope)
-
-
-def _create_axes_grid(figsize, trace):
-    l_trace = trace.shape[1]
-    if l_trace == 1:
-        fig, ax = plt.subplots(figsize=figsize)
-    else:
-        n_rows = np.ceil(l_trace / 2.0).astype(int)
-        if figsize is None:
-            figsize = (12, n_rows * 2.5)
-        fig, ax = plt.subplots(n_rows, 2, figsize=figsize)
-        ax = ax.reshape(2 * n_rows)
-        if l_trace % 2 == 1:
-            ax[-1].set_axis_off()
-            ax = ax[:-1]
-    return fig, ax

--- a/arviz/plots/ppcplot.py
+++ b/arviz/plots/ppcplot.py
@@ -1,0 +1,72 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from .kdeplot import kdeplot
+from .plot_utils import _scale_text, _create_axes_grid
+
+
+def ppcplot(data, ppc_sample, kind='kde', mean=True, figsize=None, textsize=None, ax=None):
+    """
+    Plot for Posterior Predictive Checks
+
+    Parameters
+    ----------
+    data : Array-like
+        Observed values
+    ppc_samples : dict
+        Posterior predictive check samples
+    kind : str
+        Type of plot to display (kde or cumulative)
+    mean : bool
+        Whether or not to plot the mean ppc distribution. Defaults to True
+    figsize : figure size tuple
+        If None, size is (6, 5)
+    textsize: int
+        Text size for labels. If None it will be auto-scaled based on figsize.
+    ax: axes
+        Matplotlib axes
+
+    Returns
+    -------
+    ax : matplotlib axes
+    """
+    if figsize is None:
+        figsize = (6, 5)
+
+    if ax is None:
+        _, ax = _create_axes_grid(figsize, ppc_sample)
+
+    textsize, linewidth, _ = _scale_text(figsize, textsize)
+
+    for ax_, (var, ppss) in zip(np.atleast_1d(ax), ppc_sample.items()):
+        if kind == 'kde':
+            kdeplot(data, color='k', lw=linewidth, label='{}'.format(var), ax=ax_, zorder=3)
+            for pps in ppss:
+                kdeplot(pps, alpha=0.2, color='C5', lw=linewidth, ax=ax_)
+            ax_.plot([], color='C5', label='{}_pps'.format(var))
+            if mean:
+                kdeplot(ppss, color='C0', ls='--', lw=linewidth, label='mean {}_pps'.format(var),
+                        ax=ax_)
+            ax_.set_xlabel(var, fontsize=textsize)
+            ax_.set_yticks([])
+
+        elif kind == 'cumulative':
+            ax_.plot(*_ecdf(data), color='k', lw=linewidth, label='{}'.format(var), zorder=3)
+            for pps in ppss:
+                ax_.plot(*_ecdf(pps), alpha=0.2, color='C5', lw=linewidth)
+            ax_.plot([], color='C5', label='{}_pps'.format(var))
+            if mean:
+                ax_.plot(*_ecdf(ppss.flatten()), color='C0', ls='--', lw=linewidth,
+                         label='mean {}_pps'.format(var))
+            ax_.set_xlabel(var, fontsize=textsize)
+            ax_.set_yticks([0, 0.5, 1])
+        ax_.legend(fontsize=textsize)
+        ax_.tick_params(labelsize=textsize)
+
+    return ax
+
+
+def _ecdf(data):
+    len_data = len(data)
+    data_s = np.sort(data)
+    cdf = np.arange(1, len_data + 1) / len_data
+    return data_s, cdf

--- a/arviz/plots/ppcplot.py
+++ b/arviz/plots/ppcplot.py
@@ -1,5 +1,4 @@
 import numpy as np
-import matplotlib.pyplot as plt
 from .kdeplot import kdeplot
 from .plot_utils import _scale_text, _create_axes_grid
 

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -4,22 +4,24 @@ import pymc3 as pm
 from pytest import raises
 
 from ..plots import (densityplot, traceplot, energyplot, posteriorplot, autocorrplot, forestplot,
-                     parallelplot, pairplot, jointplot)
+                     parallelplot, pairplot, jointplot, ppcplot)
 
 
 class TestPlots(object):
     @classmethod
     def setup_class(cls):
         num_schools = 8
-        y = np.asarray([28., 8., -3., 7., -1., 1., 18., 12.])
+        cls.y = np.asarray([28., 8., -3., 7., -1., 1., 18., 12.])
         sigma = np.asarray([15., 10., 16., 11., 9., 11., 10., 18.])
         with pm.Model():
             mu = pm.Normal('mu', mu=0, sd=5)
             tau = pm.HalfCauchy('tau', beta=5)
             theta = pm.Normal('theta', mu=mu, sd=tau, shape=num_schools)
-            pm.Normal('obs', mu=theta, sd=sigma, observed=y)
+            pm.Normal('obs', mu=theta, sd=sigma, observed=cls.y)
             cls.short_trace = pm.sample(600, chains=2)
+            cls.sample_ppc = pm.sample_ppc(cls.short_trace, 100)
         cls.df_trace = DataFrame({'a': np.random.poisson(2.3, 100)})
+
 
     def test_density_plot(self):
         assert densityplot(self.df_trace).shape == (1,)
@@ -63,3 +65,6 @@ class TestPlots(object):
                  kwargs_divergences={'marker': '*', 'c': 'C'})
         pairplot(self.short_trace, kind='hexbin', varnames=['theta__0', 'theta__1'],
                  cmap='viridis', textsize=20)
+
+    def test_ppcplot(self):
+        ppcplot(self.y, self.sample_ppc)


### PR DESCRIPTION
Potentially this could be a very flexible plot, this is just a first step. At this point it can generate just two plots `kind=kde` and `kind=cumulative`.
![lala1](https://user-images.githubusercontent.com/1338958/40196138-fe46d408-59e5-11e8-8a98-3ecd7c6044e1.png)

![lala0](https://user-images.githubusercontent.com/1338958/40196145-04685596-59e6-11e8-80da-05898cbd7001.png)

I also made two small changes to kdeplot:

* a new cumulative argument (ppcplot does not use this option, but the empirical cdf)
* a small change to better handle samples with few data points


