### PR TITLE
Add optional dependency class

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -61,7 +61,8 @@ disable=missing-docstring,
         too-many-locals,
         too-many-branches,
         too-many-statements,
-        no-self-use
+        no-self-use,
+        too-few-public-methods
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/arviz/compat/__init__.py
+++ b/arviz/compat/__init__.py
@@ -1,0 +1,4 @@
+#pylint: disable=invalid-name
+from .optional_dep import OptionalDep
+pymc3 = OptionalDep('pymc3')
+altair = OptionalDep('altair')

--- a/arviz/compat/optional_dep.py
+++ b/arviz/compat/optional_dep.py
@@ -1,0 +1,32 @@
+import importlib
+import sys
+
+
+class OptionalDep(object):
+    """Wrapper for optional library dependencies.
+
+    Note that since only __getattr__ is implemented, if this object implements
+    methods, those will be used *before* the true library is called.
+
+    For example
+
+    class PyMC3(OptionalDep):
+        def trace_to_dataframe(*args, **kwargs):
+            ...
+
+    pm = PyMC3()
+    pm.trace_to_dataframe(trace)  # calls the OptionalDep method
+    pm.Normal('x', 0, 1)  # calls pymc3.Normal
+    """
+    def __init__(self, name):
+        self.__name = name
+        self.__module = None
+
+    def __getattr__(self, name):
+        if self.__module is None:
+            try:
+                self.__module = importlib.import_module(self.__name)
+            except ModuleNotFoundError:
+                raise ModuleNotFoundError(
+                    'Failed to import optional module {}'.format(self.__name), sys.exc_info()[0])
+        return getattr(self.__module, name)


### PR DESCRIPTION
This is a way to use methods from `pymc3` or `altair` when it is clear the user wishes to use such a method.  For example, if the user passes a `pymc3` trace, I think it would be fair to use a method from `arviz.compat.pymc3`.  

I also plan to use this to implement some methods using `arviz`.

![image](https://user-images.githubusercontent.com/2295568/40283301-127b9f38-5c4a-11e8-8b7a-c5b698c70da7.png)
