### PR TITLE
Add altair traceplot

### DIFF
--- a/arviz/utils/__init__.py
+++ b/arviz/utils/__init__.py
@@ -1,2 +1,3 @@
 from .utils import (trace_to_dataframe, get_stats, expand_variable_names, get_varnames,
-                    _create_flat_names, log_post_trace, save_trace, load_trace)
+                    _create_flat_names, log_post_trace, save_trace, load_trace,
+                    untransform_varnames)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ PROJECT_ROOT = os.path.dirname(os.path.realpath(__file__))
 REQUIREMENTS_FILE = os.path.join(PROJECT_ROOT, 'requirements.txt')
 
 with open(REQUIREMENTS_FILE) as buff:
-    install_reqs = buff.read.splitlines()
+    install_reqs = buff.read().splitlines()
 
 
 def copy_styles():


### PR DESCRIPTION
This adds an argument to `arviz.traceplot` that outputs an altair plot instead of a matplotlib one.  Let me know if you would like to surface it in some other way.

This also adds a utility function to make the traceplot that might be useful in the main traceplot, if you would like it to look more like the main 'pymc3' one.

Here is a comparison of the two:

![image](https://user-images.githubusercontent.com/2295568/40337661-d503af60-5d3e-11e8-9045-479445d16556.png)
