### PR TITLE
Add xarray trace conversion for PyMC3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_script:
 
 script:
   - pylint arviz/
-  - pytest -xv arviz/tests/ --cov=arviz/
+  - pytest -v arviz/tests/ --cov=arviz/
   - travis-sphinx build --nowarn --source=doc
 
 after_success:

--- a/arviz/tests/test_xarray_utils.py
+++ b/arviz/tests/test_xarray_utils.py
@@ -1,0 +1,80 @@
+import numpy as np
+import pytest
+
+from ..compat import pymc3 as pm
+from ..utils.xarray_utils import pymc3_to_xarray, default_varnames_coords_dims, verify_coords_dims
+
+
+class TestXarrayUtils(object):
+
+    @classmethod
+    def setup_class(cls):
+        # Data of the Eight Schools Model
+        cls.J = 8
+        y = np.array([28., 8., -3., 7., -1., 1., 18., 12.])
+        sigma = np.array([15., 10., 16., 11., 9., 11., 10., 18.])
+        cls.draws = 500
+        cls.chains = 2
+        with pm.Model():
+            mu = pm.Normal('mu', mu=0, sd=5)
+            tau = pm.HalfCauchy('tau', beta=5)
+            theta_tilde = pm.Normal('theta_tilde', mu=0, sd=1, shape=cls.J)
+            theta = pm.Deterministic('theta', mu + tau * theta_tilde)
+            pm.Normal('obs', mu=theta, sd=sigma, observed=y)
+            cls.trace = pm.sample(cls.draws, chains=cls.chains)
+
+    def check_varnames_coords_dims(self, varnames, coords, dims):
+        expected_varnames = {'mu', 'tau', 'theta_tilde', 'theta'}
+        assert set(varnames) == expected_varnames
+
+        assert 'chain' in coords
+        assert 'draw' in coords
+
+        for varname in expected_varnames:
+            assert varname in dims
+
+    def test_default_varnames(self):
+        varnames, coords, dims = default_varnames_coords_dims(self.trace, None, None)
+        self.check_varnames_coords_dims(varnames, coords, dims)
+
+    def test_default_varnames_bad(self):
+        varnames, coords, dims = default_varnames_coords_dims(self.trace, {'a': range(2)}, None)
+        self.check_varnames_coords_dims(varnames, coords, dims)
+        assert 'a' in coords
+
+    def test_verify_coords_dims(self):
+        varnames, coords, dims = default_varnames_coords_dims(self.trace, None, None)
+        self.check_varnames_coords_dims(varnames, coords, dims)
+
+        # Both theta_tilde and theta need another coordinate
+        good, message = verify_coords_dims(varnames, self.trace, coords, dims)
+        assert not good
+        assert 'theta_tilde' in message
+        assert 'theta' in message
+
+    def test_verify_coords_dims_good(self):
+        varnames, coords, dims = default_varnames_coords_dims(
+            self.trace,
+            {'school': np.arange(self.J)},
+            {'theta': ['school'], 'theta_tilde': ['school']}
+        )
+        self.check_varnames_coords_dims(varnames, coords, dims)
+
+        # Both theta_tilde and theta need another coordinate
+        good, _ = verify_coords_dims(varnames, self.trace, coords, dims)
+        assert good
+
+    def test_pymc3_to_xarray(self):
+        data = pymc3_to_xarray(
+            self.trace,
+            {'school': np.arange(self.J)},
+            {'theta': ['school'], 'theta_tilde': ['school']}
+        )
+        assert data.draw.shape == (self.draws,)
+        assert data.chain.shape == (self.chains,)
+        assert data.school.shape == (self.J,)
+        assert data.theta.shape == (self.chains, self.draws, self.J)
+
+    def test_pymc3_to_xarray_bad(self):
+        with pytest.raises(TypeError):
+            pymc3_to_xarray(self.trace, None, None)

--- a/arviz/utils/__init__.py
+++ b/arviz/utils/__init__.py
@@ -1,3 +1,5 @@
 from .utils import (trace_to_dataframe, get_stats, expand_variable_names, get_varnames,
                     _create_flat_names, log_post_trace, save_trace, load_trace,
                     untransform_varnames)
+
+from .xarray_utils import pymc3_to_xarray

--- a/arviz/utils/xarray_utils.py
+++ b/arviz/utils/xarray_utils.py
@@ -1,0 +1,131 @@
+import numpy as np
+import xarray as xr
+
+from arviz.compat import pymc3 as pm
+
+
+def pymc3_to_xarray(trace, coords=None, dims=None):
+    """Convert a pymc3 trace to an xarray dataset.
+
+    Parameters
+    ----------
+    trace : pymc3 trace
+    coords : dict[str, iterable]
+        A dictionary containing the values that are used as index. The key
+        is the name of the dimension, the values are the index values.
+    dims : dict[str, Tuple(str)]
+        A mapping from pymc3 variables to a tuple corresponding to
+        the shape of the variable, where the elements of the tuples are
+        the names of the coordinate dimensions.
+
+    Returns
+    -------
+    xarray.Dataset
+        The coordinates are those passed in and ('chain', 'draw')
+    """
+
+    varnames, coords, dims = default_varnames_coords_dims(trace, coords, dims)
+
+    verified, warning = verify_coords_dims(varnames, trace, coords, dims)
+
+    data = xr.Dataset(coords=coords)
+    base_dims = ['chain', 'draw']
+    for key in varnames:
+        vals = trace.get_values(key, combine=False, squeeze=False)
+        vals = np.array(vals)
+        dims_str = base_dims + dims[key]
+        try:
+            data[key] = xr.DataArray(vals, coords={v: coords[v] for v in dims_str}, dims=dims_str)
+        except KeyError as exc:
+            if not verified:
+                raise TypeError(warning) from exc
+            else:
+                raise exc
+
+    return data
+
+
+def default_varnames_coords_dims(trace, coords, dims):
+    """Set up varnames, coordinates, and dimensions for .to_xarray function
+
+    trace : pymc3 trace
+    coords : dict[str, iterable]
+        A dictionary containing the values that are used as index. The key
+        is the name of the dimension, the values are the index values.
+    dims : dict[str, Tuple(str)]
+        A mapping from pymc3 variables to a tuple corresponding to
+        the shape of the variable, where the elements of the tuples are
+        the names of the coordinate dimensions.
+
+    Returns
+    -------
+    iterable[str]
+        The non-transformed variable names from the trace
+    dict[str, iterable]
+        Default coordinates for the trace
+    dict[str, Tuple(str)]
+        Default dimensions for the xarray
+    """
+    varnames = pm.utils.get_default_varnames(trace.varnames, include_transformed=False)
+    if coords is None:
+        coords = {}
+
+    coords['draw'] = np.arange(len(trace))
+    coords['chain'] = np.arange(trace.nchains)
+    coords = {key: xr.IndexVariable((key,), data=vals) for key, vals in coords.items()}
+
+    if dims is None:
+        dims = {}
+
+    for varname in varnames:
+        dims.setdefault(varname, [])
+
+    return varnames, coords, dims
+
+
+def verify_coords_dims(varnames, trace, coords, dims):
+    """Light checking and guessing on the structure of an xarray for a PyMC3 trace
+
+    Parameters
+    ----------
+    varnames : iterable[string]
+        list of dims for the xarray
+    trace : pymc3.Multitrace
+        trace from pymc3 run
+    coords : dict
+        output of `default_varnames_coords_dims`
+    dims : dict
+        output of `default_varnames_coords_dims`
+
+    Returns
+    -------
+    bool
+        Whether it passes the check
+    str
+        Warning string in case it does not pass
+    """
+    inferred_coords = coords.copy()
+    inferred_dims = dims.copy()
+    for key in ('draw', 'chain'):
+        inferred_coords.pop(key)
+    global_coords = {}
+    throw = False
+
+    for varname in varnames:
+        vals = trace.get_values(varname, combine=False, squeeze=False)
+        shapes = [d for shape in coords.values() for d in shape.shape]
+        for idx, shape in enumerate(vals[0].shape[1:], 1):
+            try:
+                shapes.remove(shape)
+            except ValueError:
+                throw = True
+                if shape not in global_coords:
+                    global_coords[shape] = f'{varname}_dim_{idx}'
+                key = global_coords[shape]
+                inferred_dims[varname].append(key)
+                if key not in inferred_coords:
+                    inferred_coords[key] = f'np.arange({shape})'
+    if throw:
+        inferred_dims = {k: v for k, v in inferred_dims.items() if v}
+        return False, f'Bad arguments! Try setting\ncoords={inferred_coords}\ndims={inferred_dims}'
+    return True, ''

--- a/arviz/utils/xarray_utils.py
+++ b/arviz/utils/xarray_utils.py
@@ -127,6 +127,7 @@ def verify_coords_dims(varnames, trace, coords, dims):
                     inferred_coords[key] = f'np.arange({shape})'
     if throw:
         inferred_dims = {k: v for k, v in inferred_dims.items() if v}
-        return False, 'Bad arguments! Try setting\ncoords={inferred_coords}\ndims={inferred_dims}'.format(
+        msg = 'Bad arguments! Try setting\ncoords={inferred_coords}\ndims={inferred_dims}'.format(
             inferred_coords=inferred_coords, inferred_dims=inferred_dims)
+        return False, msg
     return True, ''

--- a/arviz/utils/xarray_utils.py
+++ b/arviz/utils/xarray_utils.py
@@ -127,5 +127,6 @@ def verify_coords_dims(varnames, trace, coords, dims):
                     inferred_coords[key] = f'np.arange({shape})'
     if throw:
         inferred_dims = {k: v for k, v in inferred_dims.items() if v}
-        return False, f'Bad arguments! Try setting\ncoords={inferred_coords}\ndims={inferred_dims}'
+        return False, 'Bad arguments! Try setting\ncoords={inferred_coords}\ndims={inferred_dims}'.format(
+            inferred_coords=inferred_coords, inferred_dims=inferred_dims)
     return True, ''

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
+matplotlib
 numpy
 scipy
 pandas
-matplotlib
+xarray


### PR DESCRIPTION
This uses @aseyboldt 's code, as well as a bit of the details from #97 (including the recommendation to use `draw` over `sample`).  Example usage is [here](https://gist.github.com/ColCarroll/c607842947b08bc44d4e1588e6bef98d).  Note that it is not automated, but gives reasonably helpful error messages in certain cases.

I erred on the side of writing too many tests so that as the "spec" changes over there, it will be easier to update this code.

Definitely understand if you want to cut a release or wait for the conversation to settle before merging, but I thought an implementation might help (and I want to start converting the plotting functions to use `xarray`).  