### PR TITLE
Refactor xarray utilties

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ addons:
   apt_packages:
     - pandoc
 
+cache:
+  directories:
+    - $HOME/.theano
+    - $HOME/miniconda
 
 install:
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,18 +14,10 @@ cache:
 
 install:
   - sudo apt-get update
-  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
+  - . ./scripts/install_miniconda.sh
   - conda info -a
+  - . ./scripts/create_testenv.sh
 
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy mkl scipy pandas matplotlib pytest pylint sphinx numpydoc ipython
-  - source activate test-environment
-  - pip install .
-  - pip install -r requirements-dev.txt
   - pip install coveralls
 
 before_script:

--- a/arviz/tests/test_xarray_utils.py
+++ b/arviz/tests/test_xarray_utils.py
@@ -1,27 +1,69 @@
+# pylint: disable=no-member
 import numpy as np
 #import pytest
 
-from ..compat import pymc3 as pm
-from ..utils.xarray_utils import pymc3_to_xarray, default_varnames_coords_dims, verify_coords_dims
+import pymc3 as pm
+import pystan
+
+from ..utils.xarray_utils import convert_to_xarray, PyMC3ToXarray, PyStanToXarray
+
+def eight_schools_params():
+    """Share setup for eight schools"""
+
+    data = {
+        'J': 8,
+        'y': np.array([28., 8., -3., 7., -1., 1., 18., 12.]),
+        'sigma': np.array([15., 10., 16., 11., 9., 11., 10., 18.]),
+    }
+    draws = 500
+    chains = 2
+    return data, draws, chains
 
 
-class TestXarrayUtils(object):
+def pystan_noncentered_schools(data, draws, chains):
+    schools_code = '''
+        data {
+            int<lower=0> J;
+            real y[J];
+            real<lower=0> sigma[J];
+            }
 
-    @classmethod
-    def setup_class(cls):
-        # Data of the Eight Schools Model
-        cls.J = 8
-        y = np.array([28., 8., -3., 7., -1., 1., 18., 12.])
-        sigma = np.array([15., 10., 16., 11., 9., 11., 10., 18.])
-        cls.draws = 500
-        cls.chains = 2
-        with pm.Model():
-            mu = pm.Normal('mu', mu=0, sd=5)
-            tau = pm.HalfCauchy('tau', beta=5)
-            theta_tilde = pm.Normal('theta_tilde', mu=0, sd=1, shape=cls.J)
-            theta = pm.Deterministic('theta', mu + tau * theta_tilde)
-            pm.Normal('obs', mu=theta, sd=sigma, observed=y)
-            cls.trace = pm.sample(cls.draws, chains=cls.chains)
+            parameters {
+            real mu;
+            real<lower=0> tau;
+            real theta_tilde[J];
+            }
+
+            transformed parameters {
+            real theta[J];
+            for (j in 1:J)
+                theta[j] = mu + tau * theta_tilde[j];
+            }
+
+            model {
+            mu ~ normal(0, 5);
+            tau ~ cauchy(0, 5);
+            theta_tilde ~ normal(0, 1);
+            y ~ normal(theta, sigma);
+        }'''
+    stan_model = pystan.StanModel(model_code=schools_code)
+    return stan_model.sampling(data=data,
+                               iter=draws,
+                               warmup=0,
+                               chains=chains)
+
+
+def pymc3_noncentered_schools(data, draws, chains):
+    with pm.Model():
+        mu = pm.Normal('mu', mu=0, sd=5)
+        tau = pm.HalfCauchy('tau', beta=5)
+        theta_tilde = pm.Normal('theta_tilde', mu=0, sd=1, shape=data['J'])
+        theta = pm.Deterministic('theta', mu + tau * theta_tilde)
+        pm.Normal('obs', mu=theta, sd=data['sigma'], observed=data['y'])
+        return pm.sample(draws, chains=chains)
+
+
+class CheckXarrayUtils(object):
 
     def check_varnames_coords_dims(self, varnames, coords, dims):
         expected_varnames = {'mu', 'tau', 'theta_tilde', 'theta'}
@@ -34,47 +76,82 @@ class TestXarrayUtils(object):
             assert varname in dims
 
     def test_default_varnames(self):
-        varnames, coords, dims = default_varnames_coords_dims(self.trace, None, None)
+        varnames, coords, dims = self.cls.default_varnames_coords_dims(self.obj, None, None)
         self.check_varnames_coords_dims(varnames, coords, dims)
 
     def test_default_varnames_bad(self):
-        varnames, coords, dims = default_varnames_coords_dims(self.trace, {'a': range(2)}, None)
+        varnames, coords, dims = self.cls.default_varnames_coords_dims(self.obj,
+                                                                       {'a': range(2)},
+                                                                       None)
         self.check_varnames_coords_dims(varnames, coords, dims)
         assert 'a' in coords
 
     def test_verify_coords_dims(self):
-        varnames, coords, dims = default_varnames_coords_dims(self.trace, None, None)
+        varnames, coords, dims = self.cls.default_varnames_coords_dims(self.obj, None, None)
         self.check_varnames_coords_dims(varnames, coords, dims)
 
         # Both theta_tilde and theta need another coordinate
-        good, message = verify_coords_dims(varnames, self.trace, coords, dims)
+        good, message = self.cls(self.obj, coords, dims).verify_coords_dims()
         assert not good
         assert 'theta_tilde' in message
         assert 'theta' in message
 
     def test_verify_coords_dims_good(self):
-        varnames, coords, dims = default_varnames_coords_dims(
-            self.trace,
-            {'school': np.arange(self.J)},
+        varnames, coords, dims = self.cls.default_varnames_coords_dims(
+            self.obj,
+            {'school': np.arange(self.data['J'])},
             {'theta': ['school'], 'theta_tilde': ['school']}
         )
         self.check_varnames_coords_dims(varnames, coords, dims)
 
         # Both theta_tilde and theta need another coordinate
-        good, _ = verify_coords_dims(varnames, self.trace, coords, dims)
+        good, _ = self.cls(self.obj, coords, dims).verify_coords_dims()
         assert good
 
-    def test_pymc3_to_xarray(self):
-        data = pymc3_to_xarray(
-            self.trace,
-            {'school': np.arange(self.J)},
+    def test_to_xarray(self):
+        data = self.cls(
+            self.obj,
+            {'school': np.arange(self.data['J'])},
+            {'theta': ['school'], 'theta_tilde': ['school']}
+        ).to_xarray()
+        assert data.draw.shape == (self.draws,)
+        assert data.chain.shape == (self.chains,)
+        assert data.school.shape == (self.data['J'],)
+        assert data.theta.shape == (self.chains, self.draws, self.data['J'])
+
+    def test_convert_to_xarray(self):
+        # This does not use the class, and should work for all converters
+        data = convert_to_xarray(
+            self.obj,
+            {'school': np.arange(self.data['J'])},
             {'theta': ['school'], 'theta_tilde': ['school']}
         )
         assert data.draw.shape == (self.draws,)
         assert data.chain.shape == (self.chains,)
-        assert data.school.shape == (self.J,)
-        assert data.theta.shape == (self.chains, self.draws, self.J)
+        assert data.school.shape == (self.data['J'],)
+        assert data.theta.shape == (self.chains, self.draws, self.data['J'])
+
 
     #def test_pymc3_to_xarray_bad(self):
     #    with pytest.raises(TypeError):
     #        pymc3_to_xarray(self.trace, None, None)
+
+
+class TestPyMC3XarrayUtils(CheckXarrayUtils):
+
+    @classmethod
+    def setup_class(cls):
+        # Data of the Eight Schools Model
+        cls.data, cls.draws, cls.chains = eight_schools_params()
+        cls.obj = pymc3_noncentered_schools(cls.data, cls.draws, cls.chains)
+        cls.cls = PyMC3ToXarray
+
+
+class TestPyStanXarrayUtils(CheckXarrayUtils):
+
+    @classmethod
+    def setup_class(cls):
+        # Data of the Eight Schools Model
+        cls.data, cls.draws, cls.chains = eight_schools_params()
+        cls.obj = pystan_noncentered_schools(cls.data, cls.draws, cls.chains)
+        cls.cls = PyStanToXarray

--- a/arviz/utils/__init__.py
+++ b/arviz/utils/__init__.py
@@ -2,4 +2,4 @@ from .utils import (trace_to_dataframe, get_stats, expand_variable_names, get_va
                     _create_flat_names, log_post_trace, save_trace, load_trace,
                     untransform_varnames)
 
-from .xarray_utils import pymc3_to_xarray
+from .xarray_utils import convert_to_xarray

--- a/arviz/utils/xarray_utils.py
+++ b/arviz/utils/xarray_utils.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod, abstractstaticmethod
 import re
 from copy import deepcopy as copy
 
@@ -7,12 +8,15 @@ import xarray as xr
 from arviz.compat import pymc3 as pm
 
 
-def pymc3_to_xarray(trace, coords=None, dims=None):
-    """Convert a pymc3 trace to an xarray dataset.
+def convert_to_xarray(obj, coords=None, dims=None):
+    """Convert a supported object to an xarray dataset.
+
+    This function sends `obj` to the right conversion function. It is idempotent,
+    in that it will return xarray.Datasets unchanged.
 
     Parameters
     ----------
-    trace : pymc3 trace
+    obj : An object from PyStan or PyMC3 to convert
     coords : dict[str, iterable]
         A dictionary containing the values that are used as index. The key
         is the name of the dimension, the values are the index values.
@@ -27,293 +31,314 @@ def pymc3_to_xarray(trace, coords=None, dims=None):
         The coordinates are those passed in and ('chain', 'draw')
     """
 
-    varnames, coords, dims = default_varnames_coords_dims(trace, coords, dims)
-
-    verified, warning = verify_coords_dims(varnames, trace, coords, dims)
-
-    data = xr.Dataset(coords=coords)
-    base_dims = ['chain', 'draw']
-    for key in varnames:
-        vals = trace.get_values(key, combine=False, squeeze=False)
-        vals = np.array(vals)
-        dims_str = base_dims + dims[key]
-        try:
-            data[key] = xr.DataArray(vals,
-                                     coords={v: coords[v] for v in dims_str if v in coords},
-                                     dims=dims_str)
-        except KeyError as exc:
-            if not verified:
-                raise TypeError(warning) from exc
-            else:
-                raise exc
-
-    return data
+    if isinstance(obj, xr.Dataset):
+        return obj
+    elif obj.__class__.__name__ == 'StanFit4Model':  # ugly, but doesn't make PyStan a requirement
+        return PyStanToXarray(obj, coords, dims).to_xarray()
+    elif obj.__class__.__name__ == 'MultiTrace':  # ugly, but doesn't make PyMC3 a requirement
+        return PyMC3ToXarray(obj, coords, dims).to_xarray()
+    else:
+        raise TypeError('Can only convert PyStan or PyMC3 object to xarray, not {}'.format(
+            obj.__class__.__name__))
 
 
-def default_varnames_coords_dims(trace, coords, dims):
-    """Set up varnames, coordinates, and dimensions for .to_xarray function
+class Converter(ABC):
+    def __init__(self, obj, coords=None, dims=None):
+        self.obj = obj
+        # pylint: disable=assignment-from-none
+        self.varnames, self.coords, self.dims = self.default_varnames_coords_dims(obj, coords, dims)
+        self.verified, self.warning = self.verify_coords_dims()
 
-    trace : pymc3 trace
-    coords : dict[str, iterable]
-        A dictionary containing the values that are used as index. The key
-        is the name of the dimension, the values are the index values.
-    dims : dict[str, Tuple(str)]
-        A mapping from pymc3 variables to a tuple corresponding to
-        the shape of the variable, where the elements of the tuples are
-        the names of the coordinate dimensions.
+    @abstractmethod
+    def to_xarray(self):
+        pass
 
-    Returns
-    -------
-    iterable[str]
-        The non-transformed variable names from the trace
-    dict[str, iterable]
-        Default coordinates for the trace
-    dict[str, Tuple(str)]
-        Default dimensions for the xarray
-    """
-    varnames = pm.utils.get_default_varnames(trace.varnames, include_transformed=False)
-    if coords is None:
-        coords = {}
+    @abstractstaticmethod
+    def default_varnames_coords_dims(obj, coords, dims):  # pylint: disable=unused-argument
+        return
 
-    coords['draw'] = np.arange(len(trace))
-    coords['chain'] = np.arange(trace.nchains)
-    coords = {key: xr.IndexVariable((key,), data=vals) for key, vals in coords.items()}
+    @abstractmethod
+    def verify_coords_dims(self):
+        return
 
-    if dims is None:
-        dims = {}
 
-    for varname in varnames:
-        if varname not in dims:
-            vals = trace.get_values(varname, combine=False, squeeze=False)
+class PyMC3ToXarray(Converter):
+    def __init__(self, trace, coords=None, dims=None):
+        """Convert a pymc3 trace to an xarray dataset.
+
+        Parameters
+        ----------
+        trace : pymc3 trace
+        coords : dict[str, iterable]
+            A dictionary containing the values that are used as index. The key
+            is the name of the dimension, the values are the index values.
+        dims : dict[str, Tuple(str)]
+            A mapping from pymc3 variables to a tuple corresponding to
+            the shape of the variable, where the elements of the tuples are
+            the names of the coordinate dimensions.
+
+        Returns
+        -------
+        xarray.Dataset
+            The coordinates are those passed in and ('chain', 'draw')
+        """
+        super().__init__(trace, coords=coords, dims=dims)
+
+    def to_xarray(self):
+        varnames, coords, dims = self.varnames, self.coords, self.dims
+
+        data = xr.Dataset(coords=coords)
+        base_dims = ['chain', 'draw']
+        for key in varnames:
+            vals = self.obj.get_values(key, combine=False, squeeze=False)
             vals = np.array(vals)
-            shape_len = len(vals.shape)
-            if shape_len == 2:
-                dims[varname] = []
-            else:
-                dims[varname] = [f"{varname}_dim_{idx}" for idx in range(1, shape_len-2+1)]
-
-    return varnames, coords, dims
-
-
-def verify_coords_dims(varnames, trace, coords, dims):
-    """Light checking and guessing on the structure of an xarray for a PyMC3 trace
-
-    Parameters
-    ----------
-    varnames : iterable[string]
-        list of dims for the xarray
-    trace : pymc3.Multitrace
-        trace from pymc3 run
-    coords : dict
-        output of `default_varnames_coords_dims`
-    dims : dict
-        output of `default_varnames_coords_dims`
-
-    Returns
-    -------
-    bool
-        Whether it passes the check
-    str
-        Warning string in case it does not pass
-    """
-    inferred_coords = copy(coords)
-    inferred_dims = copy(dims)
-    for key in ('draw', 'chain'):
-        inferred_coords.pop(key)
-    global_coords = {}
-    throw = False
-
-    for varname in varnames:
-        vals = trace.get_values(varname, combine=False, squeeze=False)
-        shapes = [d for shape in coords.values() for d in shape.shape]
-        for idx, shape in enumerate(vals[0].shape[1:], 1):
+            dims_str = base_dims + dims[key]
             try:
-                shapes.remove(shape)
-            except ValueError:
-                throw = True
-                if shape not in global_coords:
-                    global_coords[shape] = f'{varname}_dim_{idx}'
-                key = global_coords[shape]
-                inferred_dims[varname].append(key)
-                if key not in inferred_coords:
-                    inferred_coords[key] = f'np.arange({shape})'
-    if throw:
-        inferred_dims = {k: v for k, v in inferred_dims.items() if v}
-        msg = 'Bad arguments! Try setting\ncoords={inferred_coords}\ndims={inferred_dims}'.format(
-            inferred_coords=inferred_coords, inferred_dims=inferred_dims)
-        return False, msg
-    return True, ''
+                data[key] = xr.DataArray(vals,
+                                         coords={v: coords[v] for v in dims_str if v in coords},
+                                         dims=dims_str)
+            except KeyError as exc:
+                if not self.verified:
+                    raise TypeError(self.warning) from exc
+                else:
+                    raise exc
+
+        return data
+
+    @staticmethod
+    def default_varnames_coords_dims(obj, coords, dims):
+        """Set up varnames, coordinates, and dimensions for .to_xarray function
+
+        obj : pymc3 trace
+        coords : dict[str, iterable]
+            A dictionary containing the values that are used as index. The key
+            is the name of the dimension, the values are the index values.
+        dims : dict[str, Tuple(str)]
+            A mapping from pymc3 variables to a tuple corresponding to
+            the shape of the variable, where the elements of the tuples are
+            the names of the coordinate dimensions.
+
+        Returns
+        -------
+        iterable[str]
+            The non-transformed variable names from the trace
+        dict[str, iterable]
+            Default coordinates for the trace
+        dict[str, Tuple(str)]
+            Default dimensions for the xarray
+        """
+        varnames = pm.utils.get_default_varnames(obj.varnames, include_transformed=False)
+        if coords is None:
+            coords = {}
+
+        coords['draw'] = np.arange(len(obj))
+        coords['chain'] = np.arange(obj.nchains)
+        coords = {key: xr.IndexVariable((key,), data=vals) for key, vals in coords.items()}
+
+        if dims is None:
+            dims = {}
+
+        for varname in varnames:
+            if varname not in dims:
+                vals = obj.get_values(varname, combine=False, squeeze=False)
+                vals = np.array(vals)
+                shape_len = len(vals.shape)
+                if shape_len == 2:
+                    dims[varname] = []
+                else:
+                    dims[varname] = [f"{varname}_dim_{idx}" for idx in range(1, shape_len-2+1)]
+
+        return varnames, coords, dims
+
+    def verify_coords_dims(self):
+        """Light checking and guessing on the structure of an xarray for a PyMC3 trace
+
+        Returns
+        -------
+        bool
+            Whether it passes the check
+        str
+            Warning string in case it does not pass
+        """
+        inferred_coords = copy(self.coords)
+        inferred_dims = copy(self.dims)
+        for key in ('draw', 'chain'):
+            inferred_coords.pop(key)
+        global_coords = {}
+        throw = False
+
+        for varname in self.varnames:
+            vals = self.obj.get_values(varname, combine=False, squeeze=False)
+            shapes = [d for shape in self.coords.values() for d in shape.shape]
+            for idx, shape in enumerate(vals[0].shape[1:], 1):
+                try:
+                    shapes.remove(shape)
+                except ValueError:
+                    throw = True
+                    if shape not in global_coords:
+                        global_coords[shape] = f'{varname}_dim_{idx}'
+                    key = global_coords[shape]
+                    inferred_dims[varname].append(key)
+                    if key not in inferred_coords:
+                        inferred_coords[key] = f'np.arange({shape})'
+        if throw:
+            inferred_dims = {k: v for k, v in inferred_dims.items() if v}
+            msg = f'Bad arguments! Try setting\ncoords={inferred_coords}\ndims={inferred_dims}'
+            return False, msg
+        return True, ''
 
 
-def pystan_to_xarray(fit, coords=None, dims=None):
-    """Convert a PyStan StanFit4Model-object to an xarray dataset.
+class PyStanToXarray(Converter):
+    def __init__(self, fit, coords=None, dims=None):
+        """Convert a PyStan StanFit4Model-object to an xarray dataset.
 
-    Parameters
-    ----------
-    fit : StanFit4Model
-    coords : dict[str, iterable]
-        A dictionary containing the values that are used as index. The key
-        is the name of the dimension, the values are the index values.
-    dims : dict[str, Tuple(str)]
-        A mapping from pymc3 variables to a tuple corresponding to
-        the shape of the variable, where the elements of the tuples are
-        the names of the coordinate dimensions.
+        Parameters
+        ----------
+        fit : StanFit4Model
+        coords : dict[str, iterable]
+            A dictionary containing the values that are used as index. The key
+            is the name of the dimension, the values are the index values.
+        dims : dict[str, Tuple(str)]
+            A mapping from pymc3 variables to a tuple corresponding to
+            the shape of the variable, where the elements of the tuples are
+            the names of the coordinate dimensions.
 
-    Returns
-    -------
-    xarray.Dataset
-        The coordinates are those passed in and ('chain', 'draw')
-    """
-    #fit._verify_has_samples()
-    if fit.mode == 1:
-        return "Stan model '{}' is of mode 'test_grad';\n"\
-               "sampling is not conducted.".format(fit.model_name)
-    elif fit.mode == 2:
-        return "Stan model '{}' does not contain samples.".format(fit.model_name)
+        Returns
+        -------
+        xarray.Dataset
+            The coordinates are those passed in and ('chain', 'draw')
+        """
+        super().__init__(fit, coords=coords, dims=dims)
 
-    varnames, coords, dims = pystan_varnames_coords_dims(fit, coords, dims)
+    def to_xarray(self):
+        fit = self.obj
+        #infer dtypes
+        pattern = r"int(?:\[.*\])*\s*(.)(?:\s*[=;]|(?:\s*<-))"
+        # assume "generated_quantities" appears only once
+        generated_quantities = fit.get_stancode().split("generated quantities")[-1]
+        dtypes = re.findall(pattern, generated_quantities)
+        dtypes = {item : 'int' for item in dtypes if item in self.varnames}
 
-    verified, warning = pystan_verify_coords_dims(varnames, fit, coords, dims)
+        data = xr.Dataset(coords=self.coords)
+        base_dims = ['chain', 'draw']
 
-    #infer dtypes
-    pattern = r"int(?:\[.*\])*\s*(.)(?:\s*[=;]|(?:\s*<-))"
-    # assume "generated_quantities" appears only once
-    generated_quantities = fit.get_stancode().split("generated quantities")[-1]
-    dtypes = re.findall(pattern, generated_quantities)
-    dtypes = {item : 'int' for item in dtypes if item in varnames}
-
-    data = xr.Dataset(coords=coords)
-    base_dims = ['chain', 'draw']
-
-    for key in varnames:
-        var_dtype = {key : 'int'} if key in dtypes else {}
-        vals = fit.extract(key, dtypes=var_dtype, permuted=False)[key]
-        if len(vals.shape) == 1:
-            vals = np.expand_dims(vals, axis=1)
-        vals = np.swapaxes(vals, 0, 1)
-        dims_str = base_dims + dims[key]
-        try:
-            data[key] = xr.DataArray(vals,
-                                     coords={v: coords[v] for v in dims_str if v in coords},
-                                     dims=dims_str)
-        except (KeyError, ValueError) as exc:
-            if not verified:
-                raise TypeError(warning) from exc
-            else:
-                raise exc
-
-    return data
-
-def pystan_varnames_coords_dims(fit, coords, dims):
-    """Set up varnames, coordinates, and dimensions for .to_xarray function
-
-    fit : StanFit4Model
-    coords : dict[str, iterable]
-        A dictionary containing the values that are used as index. The key
-        is the name of the dimension, the values are the index values.
-    dims : dict[str, Tuple(str)]
-        A mapping from pymc3 variables to a tuple corresponding to
-        the shape of the variable, where the elements of the tuples are
-        the names of the coordinate dimensions.
-
-    Returns
-    -------
-    iterable[str]
-        The non-transformed variable names from the trace
-    dict[str, iterable]
-        Default coordinates for the trace
-    dict[str, Tuple(str)]
-        Default dimensions for the xarray
-    """
-    varnames = fit.model_pars
-    if coords is None:
-        coords = {}
-
-    coords['draw'] = np.arange(fit.sim['n_save'][0]-fit.sim['warmup']) # assume no thinning
-    coords['chain'] = np.arange(fit.sim['chains'])
-    coords = {key: xr.IndexVariable((key,), data=vals) for key, vals in coords.items()}
-
-    if dims is None:
-        dims = {}
-
-    for varname in varnames:
-        if varname not in dims:
-            vals = fit.extract(varname, permuted=False)[varname]
+        for key in self.varnames:
+            var_dtype = {key : 'int'} if key in dtypes else {}
+            vals = fit.extract(key, dtypes=var_dtype, permuted=False)[key]
             if len(vals.shape) == 1:
                 vals = np.expand_dims(vals, axis=1)
             vals = np.swapaxes(vals, 0, 1)
-            shape_len = len(vals.shape)
-            if shape_len == 2:
-                dims[varname] = []
-            else:
-                dims[varname] = [f"{varname}_dim_{idx}" for idx in range(1, shape_len-2+1)]
-
-    return varnames, coords, dims
-
-def pystan_verify_coords_dims(varnames, fit, coords, dims):
-    """Light checking and guessing on the structure of an xarray for a PyStan fit
-
-    Parameters
-    ----------
-    varnames : iterable[string]
-        list of dims for the xarray
-    fit : StanFit4Model
-        fit from PyStan sampling
-    coords : dict
-        output of `default_varnames_coords_dims`
-    dims : dict
-        output of `default_varnames_coords_dims`
-
-    Returns
-    -------
-    bool
-        Whether it passes the check
-    str
-        Warning string in case it does not pass
-    """
-    #fit._verify_has_samples()
-    if fit.mode == 1:
-        return "Stan model '{}' is of mode 'test_grad';\n"\
-               "sampling is not conducted.".format(fit.model_name)
-    elif fit.mode == 2:
-        return "Stan model '{}' does not contain samples.".format(fit.model_name)
-
-    inferred_coords = copy(coords)
-    inferred_dims = copy(dims)
-    for key in ('draw', 'chain'):
-        inferred_coords.pop(key)
-    global_coords = {}
-    throw = False
-
-    #infer dtypes
-    pattern = r"int(?:\[.*\])*\s*(.)(?:\s*[=;]|(?:\s*<-))"
-    # assume "generated_quantities" appears only once
-    generated_quantities = fit.get_stancode().split("generated quantities")[-1]
-    dtypes = re.findall(pattern, generated_quantities)
-    dtypes = {item : 'int' for item in dtypes if item in varnames}
-
-    for varname in varnames:
-        var_dtype = {varname : 'int'} if varname in dtypes else {}
-        # no support for pystan <= 2.17.1
-        vals = fit.extract(varname, dtypes=var_dtype, permuted=False)[varname]
-        if len(vals.shape) == 1:
-            vals = np.expand_dims(vals, axis=1)
-        vals = np.swapaxes(vals, 0, 1)
-        shapes = [d for shape in coords.values() for d in shape.shape]
-        for idx, shape in enumerate(vals[0].shape[1:], 1):
+            dims_str = base_dims + self.dims[key]
             try:
-                shapes.remove(shape)
-            except ValueError:
-                throw = True
-                if shape not in global_coords:
-                    global_coords[shape] = f'{varname}_dim_{idx}'
-                key = global_coords[shape]
-                inferred_dims[varname].append(key)
-                if key not in inferred_coords:
-                    inferred_coords[key] = f'np.arange({shape})'
-    if throw:
-        inferred_dims = {k: v for k, v in inferred_dims.items() if v}
-        msg = 'Bad arguments! Try setting\ncoords={inferred_coords}\ndims={inferred_dims}'.format(
-            inferred_coords=inferred_coords, inferred_dims=inferred_dims)
-        return False, msg
-    return True, ''
+                coords = {v: self.coords[v] for v in dims_str if v in self.coords}
+                data[key] = xr.DataArray(vals, coords=coords, dims=dims_str)
+            except (KeyError, ValueError) as exc:
+                if not self.verified:
+                    raise TypeError(self.warning) from exc
+                else:
+                    raise exc
+
+        return data
+
+    @staticmethod
+    def default_varnames_coords_dims(obj, coords, dims):
+        """Set up varnames, coordinates, and dimensions for .to_xarray function
+
+        obj : StanFit4Model
+        coords : dict[str, iterable]
+            A dictionary containing the values that are used as index. The key
+            is the name of the dimension, the values are the index values.
+        dims : dict[str, Tuple(str)]
+            A mapping from pymc3 variables to a tuple corresponding to
+            the shape of the variable, where the elements of the tuples are
+            the names of the coordinate dimensions.
+
+        Returns
+        -------
+        iterable[str]
+            The non-transformed variable names from the trace
+        dict[str, iterable]
+            Default coordinates for the trace
+        dict[str, Tuple(str)]
+            Default dimensions for the xarray
+        """
+        varnames = obj.model_pars
+        if coords is None:
+            coords = {}
+
+        coords['draw'] = np.arange(obj.sim['n_save'][0] - obj.sim['warmup']) # assume no thinning
+        coords['chain'] = np.arange(obj.sim['chains'])
+        coords = {key: xr.IndexVariable((key,), data=vals) for key, vals in coords.items()}
+
+        if dims is None:
+            dims = {}
+
+        for varname in varnames:
+            if varname not in dims:
+                vals = obj.extract(varname, permuted=False)[varname]
+                if len(vals.shape) == 1:
+                    vals = np.expand_dims(vals, axis=1)
+                vals = np.swapaxes(vals, 0, 1)
+                shape_len = len(vals.shape)
+                if shape_len == 2:
+                    dims[varname] = []
+                else:
+                    dims[varname] = [f"{varname}_dim_{idx}" for idx in range(1, shape_len-2+1)]
+
+        return varnames, coords, dims
+
+    def verify_coords_dims(self):
+        """Light checking and guessing on the structure of an xarray for a PyStan fit
+
+        Returns
+        -------
+        bool
+            Whether it passes the check
+        str
+            Warning string in case it does not pass
+        """
+        fit = self.obj
+        if fit.mode == 1:
+            return "Stan model '{}' is of mode 'test_grad';\n"\
+                "sampling is not conducted.".format(fit.model_name)
+        elif fit.mode == 2:
+            return "Stan model '{}' does not contain samples.".format(fit.model_name)
+
+        inferred_coords = copy(self.coords)
+        inferred_dims = copy(self.dims)
+        for key in ('draw', 'chain'):
+            inferred_coords.pop(key)
+        global_coords = {}
+        throw = False
+
+        #infer dtypes
+        pattern = r"int(?:\[.*\])*\s*(.)(?:\s*[=;]|(?:\s*<-))"
+        # assume "generated_quantities" appears only once
+        generated_quantities = fit.get_stancode().split("generated quantities")[-1]
+        dtypes = re.findall(pattern, generated_quantities)
+        dtypes = {item : 'int' for item in dtypes if item in self.varnames}
+
+        for varname in self.varnames:
+            var_dtype = {varname : 'int'} if varname in dtypes else {}
+            # no support for pystan <= 2.17.1
+            vals = fit.extract(varname, dtypes=var_dtype, permuted=False)[varname]
+            if len(vals.shape) == 1:
+                vals = np.expand_dims(vals, axis=1)
+            vals = np.swapaxes(vals, 0, 1)
+            shapes = [d for shape in self.coords.values() for d in shape.shape]
+            for idx, shape in enumerate(vals[0].shape[1:], 1):
+                try:
+                    shapes.remove(shape)
+                except ValueError:
+                    throw = True
+                    if shape not in global_coords:
+                        global_coords[shape] = f'{varname}_dim_{idx}'
+                    key = global_coords[shape]
+                    inferred_dims[varname].append(key)
+                    if key not in inferred_coords:
+                        inferred_coords[key] = f'np.arange({shape})'
+        if throw:
+            inferred_dims = {k: v for k, v in inferred_dims.items() if v}
+            msg = f'Bad arguments! Try setting\ncoords={inferred_coords}\ndims={inferred_dims}'
+            return False, msg
+        return True, ''

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 git+https://github.com/pymc-devs/pymc3
+git+https://github.com/stan-dev/pystan
 ipython
 nbsphinx
 numpydoc

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -ex # fail on first error, print commands
+
+command -v conda >/dev/null 2>&1 || {
+  echo "Requires conda but it is not installed.  Run install_miniconda.sh." >&2;
+  exit 1;
+}
+
+ENVNAME="testenv"
+PYTHON_VERSION=${PYTHON_VERSION:-3.6} # if no python specified, use 3.6
+
+if conda env list | grep -q ${ENVNAME}
+then
+    echo "Environment ${ENVNAME} already exists, keeping up to date"
+else
+    conda create -n ${ENVNAME} --yes pip python=${PYTHON_VERSION}
+    source activate ${ENVNAME}
+fi
+conda install --yes numpy scipy pandas matplotlib pytest pylint sphinx numpydoc ipython xarray mkl-service
+
+pip install --upgrade pip
+
+#  Install editable using the setup.py
+pip install -e .
+pip install -r requirements-dev.txt

--- a/scripts/install_miniconda.sh
+++ b/scripts/install_miniconda.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -e # fail on first error
+
+if conda --version > /dev/null 2>&1; then
+   echo "conda appears to already be installed"
+   exit 0
+ fi
+
+INSTALL_FOLDER="$HOME/miniconda"
+
+
+if [ ! -d $INSTALL_FOLDER ] || [ ! -e $INSTALL_FOLDER/bin/conda ]; then
+  if [ "$(uname)" == "Darwin" ]; then
+    URL_OS="MacOSX"
+  elif [ "$(expr substr "$(uname -s)" 1 5)" == "Linux" ]; then
+    URL_OS="Linux"
+  elif [ "$(expr substr "$(uname -s)" 1 10)" == "MINGW32_NT" ]; then
+    URL_OS="Windows"
+  fi
+
+  echo "Downloading miniconda for $URL_OS"
+  DOWNLOAD_PATH="miniconda.sh"
+  wget http://repo.continuum.io/miniconda/Miniconda3-latest-$URL_OS-x86_64.sh -O ${DOWNLOAD_PATH};
+
+  echo "Installing miniconda to $INSTALL_FOLDER"
+  # install miniconda to home folder
+  bash ${DOWNLOAD_PATH} -b -f -p $INSTALL_FOLDER
+
+  # tidy up
+  rm ${DOWNLOAD_PATH}
+else
+  echo "Miniconda already installed at ${INSTALL_FOLDER}.  Updating, adding to path and exiting"
+fi
+
+export PATH="$INSTALL_FOLDER/bin:$PATH"
+echo "Adding $INSTALL_FOLDER to PATH.  Consider adding it in your .rc file as well."
+conda update -q -y conda


### PR DESCRIPTION
This does a few things to get ready to port functions to `xarray`:

- in `xarray_utils`, there is an abstract base class so that `PyMC3ToXarray` and `PyStanToXarray` have the same interface
- Adds a function `convert_to_xarray` that dispatches code to the correct converter
- Adds `pystan` to the travis build
- Tests the `PyStanToXarray` code (in the exact way the `PyMC3ToXarray` code is tested)

I have `autocorrplot` mostly ready to go after this lands.