### PR TITLE
Update densityplot to use xarray

### DIFF
--- a/arviz/plots/autocorrplot.py
+++ b/arviz/plots/autocorrplot.py
@@ -1,7 +1,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
-from .plot_utils import _scale_text, default_grid, selection_to_string, xarray_var_iter
+from .plot_utils import _scale_text, default_grid, make_label, xarray_var_iter
 from ..utils import convert_to_xarray
 
 
@@ -66,7 +66,7 @@ def autocorrplot(posterior, var_names=None, max_lag=100, symmetric_plot=False, c
                   ymax=y[midpoint + min_lag:midpoint + max_lag],
                   lw=linewidth)
         ax.hlines(0, min_lag, max_lag, 'steelblue')
-        ax.set_title('{} ({})'.format(var_name, selection_to_string(selection)), fontsize=textsize)
+        ax.set_title(make_label(var_name, selection), fontsize=textsize)
         ax.tick_params(labelsize=textsize)
         y_min = min(y_min, y.min())
 

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -145,6 +145,24 @@ def selection_to_string(selection):
     return ', '.join(['{}: {}'.format(k, v) for k, v in selection.items()])
 
 
+def make_label(var_name, selection):
+    """Consistent labelling for plots
+
+    Parameters
+    ----------
+    var_name : str
+       Name of the variable
+
+    selection : dict[Any] -> Any
+        Coordinates of the variable
+
+    Returns
+    -------
+    str
+        A text representation of the label
+    """
+    return f'{var_name} ({selection_to_string(selection)})'
+
 
 def xarray_var_iter(data, var_names=None, combined=False):
     """Converts xarray data to an iterator over vectors

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -21,8 +21,8 @@ class TestPlots(object):
 
 
     def test_density_plot(self):
-        assert densityplot(self.df_trace).shape == (1,)
-        assert densityplot(self.short_trace).shape == (18,)
+        for obj in (self.short_trace, self.fit):
+            assert densityplot(obj).shape == (18, 1)
 
     def test_traceplot(self):
         assert traceplot(self.df_trace).shape == (1, 2)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -49,9 +49,9 @@ Contributions and issue reports are very welcome at `the github repository
                 <img src="_static/traceplot_thumb.png">
             </div>
             </a>
-            <a href="examples/energyplot.html">
+            <a href="examples/densityplot.html">
             <div class="col-md-4 thumbnail">
-                <img src="_static/energyplot_thumb.png">
+                <img src="_static/densityplot_thumb.png">
             </div>
             <a href="examples/jointplot.html">
             <div class="col-md-4 thumbnail">

--- a/examples/densityplot.py
+++ b/examples/densityplot.py
@@ -8,5 +8,7 @@ import arviz as az
 
 az.style.use('arviz-darkgrid')
 
-trace = az.utils.load_trace('data/centered_eight_trace.gzip')
-az.densityplot(trace, varnames=('tau', 'theta__0'))
+centered_data = az.load_data('data/centered_eight.nc')
+non_centered_data = az.load_data('data/non_centered_eight.nc')
+az.densityplot([centered_data, non_centered_data], ['Centered', 'Non Centered'],
+                var_names=['theta'], shade=0.1, alpha=0.01)


### PR DESCRIPTION
This also allows direct comparisons of posteriors from `PyStan` and `PyMC3`, which is part of the goal of the whole `xarray` exercise.  These are from the non centered eight schools model fit with default arguments.

I also added this plot to the front page of http://arviz-devs.github.io/arviz/ because it looks nice!

![image](https://user-images.githubusercontent.com/2295568/41946310-ce5270e0-797f-11e8-9ac6-04b02cbf5871.png)
