### PR TITLE
Netcdf4 required to build docs

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ git+https://github.com/pymc-devs/pymc3
 git+https://github.com/stan-dev/pystan
 ipython
 nbsphinx
+netcdf4
 numpydoc
 pylint
 pytest


### PR DESCRIPTION
This seemed to get installed with `xarray` on my machine, but it is keeping docs from building.