### PR TITLE
change r2_score

### DIFF
--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -25,7 +25,7 @@ def test_r2_score():
     x = np.linspace(0, 1, 100)
     y = np.random.normal(x, 1)
     res = stats.linregress(x, y)
-    assert_almost_equal(res.rvalue ** 2, r2_score(y, res.intercept + res.slope * x).r2_median, 2)
+    assert_almost_equal(res.rvalue ** 2, r2_score(y, res.intercept + res.slope * x).r2, 2)
 
 
 class TestCompare(object):


### PR DESCRIPTION
This is an alternative way to compute r2. This version provides a much more better agreement with the one computed by `stats.linregress`. Just an example.

```python
np.random.seed(1)
N = 100
alpha_real = 2.5
beta_real = 0.9
eps_real = np.random.normal(0, 100, size=N)

x = np.random.normal(10, 1, N)
y_real = alpha_real + beta_real * x 
y = y_real + eps_real

x = np.random.normal(10, 1, N)
y_real = alpha_real + beta_real * x 
y = y_real + eps_real

with pm.Model() as model:
    α = pm.Normal('α', mu=0, sd=1000)
    β = pm.Normal('β', mu=0, sd=1000)
    ϵ = pm.HalfCauchy('ϵ', 50)

    μ = pm.Deterministic('μ', α + β * x)
    y_pred = pm.Normal('y_pred', mu=μ, sd=ϵ, observed=y)
    
    trace = pm.sample(1000)

ppc = pm.sample_ppc(trace, samples=1000, model=model)
```

With the previous version we get 0.34, with the new one 0.01 (in agreement with `stats.linregress` and common sense). I guess the intuition is that the previous version reflects the fact that even when x and y have a lower correlation the model is capable of generating _reasonable_ values of y, in the sense that they are very spread. While the new version reflects better the fact that the correlation of the data is indeed low.
