### PR TITLE
load_trace and save_trace are under az.utils

### DIFF
--- a/doc/notebooks/Introduction.ipynb
+++ b/doc/notebooks/Introduction.ipynb
@@ -32,7 +32,7 @@
    "source": [
     "Most or ArviZ functions require a `trace` as the main argument. Currently ArviZ will work with either a PyMC3 `trace` or a Pandas DataFrame. Internally ArviZ turns the former into the latter. To show some of the functionality or ArviZ we are going to load a previously saved trace. Arviz can save traces as (optionally compressed) csv files.\n",
     "\n",
-    "    az.save_trace(trace)"
+    "    az.utils.save_trace(trace)"
    ]
   },
   {
@@ -134,7 +134,7 @@
     }
    ],
    "source": [
-    "trace = az.load_trace('trace.gzip')\n",
+    "trace = az.utils.load_trace('trace.gzip')\n",
     "trace.head()"
    ]
   },
@@ -226,7 +226,7 @@
     }
    ],
    "source": [
-    "az.load_trace('trace.gzip', combined=True).head()"
+    "az.utils.load_trace('trace.gzip', combined=True).head()"
    ]
   },
   {


### PR DESCRIPTION
`load_trace` and `save_trace` are in `az.utils`, not the top-level `az` namespace.