### PR TITLE
Update jointplot to use xarray

### DIFF
--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -2,7 +2,7 @@ import matplotlib.pyplot as plt
 from pandas import DataFrame
 import numpy as np
 import pymc3 as pm
-from pytest import raises
+import pytest
 
 from .helpers import eight_schools_params, load_cached_models
 from ..plots import (densityplot, traceplot, energyplot, posteriorplot, autocorrplot, forestplot,
@@ -51,17 +51,19 @@ class TestPlots(object):
             assert axes.shape == (1,)
 
     def test_energyplot(self):
-        with raises(AttributeError):
+        with pytest.raises(AttributeError):
             energyplot(self.df_trace)
         assert energyplot(self.short_trace)
 
     def test_parallelplot(self):
-        with raises(ValueError):
+        with pytest.raises(ValueError):
             parallelplot(self.df_trace)
         assert parallelplot(self.short_trace)
 
-    def test_jointplot(self):
-        jointplot(self.short_trace, varnames=['mu', 'tau'])
+    @pytest.mark.parametrize('kind', ['scatter', 'hexbin'])
+    def test_jointplot(self, kind):
+        for obj in (self.short_trace, self.fit):
+            jointplot(obj, var_names=('mu', 'tau'), kind=kind)
 
     def test_pairplot(self):
         pairplot(self.short_trace, varnames=['theta__0', 'theta__1'], divergences=True,

--- a/examples/jointplot.py
+++ b/examples/jointplot.py
@@ -8,5 +8,11 @@ import arviz as az
 
 az.style.use('arviz-darkgrid')
 
-trace = az.utils.load_trace('data/non_centered_eight_trace.gzip')
-az.jointplot(trace, kind='hexbin', varnames=('tau', 'mu'))
+
+data = az.load_data('data/non_centered_eight.nc')
+
+az.jointplot(data,
+             var_names=['theta'],
+             coords={'school': ['Choate', 'Phillips Andover']},
+             kind='hexbin',
+             figsize=(10, 10))


### PR DESCRIPTION
Fixes #125 

This keeps most of the current code.  The biggest difference is when specifying `var_names`, you also pass in `coords` for slicing.  If we find that pleasant (and I do!), we might go back and update the rest of the API to follow that.  For example, the new example in the gallery is 

```python
az.jointplot(data,
             var_names=['theta'],
             coords={'school': ['Choate', 'Phillips Andover']},
             kind='hexbin')
```
![image](https://user-images.githubusercontent.com/2295568/42787686-998fd0c8-8929-11e8-8c6a-23d208ca2a2c.png)
