### PR TITLE
Add DictToXarray

### DIFF
--- a/arviz/utils/xarray_utils.py
+++ b/arviz/utils/xarray_utils.py
@@ -88,9 +88,10 @@ class DictToXarray(Converter):
             The coordinates are those passed in and ('chain', 'draw')
         """
         if chains is None:
-            varnames = list(obj.keys())
-            val = obj[varnames[0]]
-            self.chains = val.shape[-1] if val.ndim > 1 else 1
+            try:
+                self.chains = min(val.shape[1] for val in obj.values())
+            except IndexError:
+                self.chains = 1
         else:
             self.chains = chains
 

--- a/arviz/utils/xarray_utils.py
+++ b/arviz/utils/xarray_utils.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod, abstractstaticmethod
+from abc import ABC, abstractmethod
 import re
 from copy import deepcopy as copy
 

--- a/arviz/utils/xarray_utils.py
+++ b/arviz/utils/xarray_utils.py
@@ -88,10 +88,9 @@ class DictToXarray(Converter):
             The coordinates are those passed in and ('chain', 'draw')
         """
         if chains is None:
-            try:
-                self.chains = min(val.shape[1] for val in obj.values())
-            except IndexError:
-                self.chains = 1
+            varnames = list(obj.keys())
+            val = obj[varnames[0]]
+            self.chains = val.shape[-1] if val.ndim > 1 else 1
         else:
             self.chains = chains
 

--- a/arviz/utils/xarray_utils.py
+++ b/arviz/utils/xarray_utils.py
@@ -71,6 +71,12 @@ class DictToXarray(Converter):
         Parameters
         ----------
         obj : dict[str, iterable]
+            A dictionary containing the samples from the posterior
+            distribution. The shape of the values should be
+            (draws, chains, *shape), where draws is the number of draws from the
+            posterior in a chain, chains is the number of chains, and shape is
+            the shape of the random variable.  If there is only one chain,
+            the shape of the values can be (draws, *shape)
         coords : dict[str, iterable]
             A dictionary containing the values that are used as index. The key
             is the name of the dimension, the values are the index values.

--- a/arviz/utils/xarray_utils.py
+++ b/arviz/utils/xarray_utils.py
@@ -78,9 +78,8 @@ class DictToXarray(Converter):
             A mapping from variables to a tuple corresponding to
             the shape of the variable, where the elements of the tuples are
             the names of the coordinate dimensions.
-        chains : int or None
-            The number of chains that were sampled.  If None, we attempt to
-            infer this from the shape of the data.
+        chains : int
+            The number of chains that were sampled.
 
         Returns
         -------
@@ -88,10 +87,7 @@ class DictToXarray(Converter):
             The coordinates are those passed in and ('chain', 'draw')
         """
         if chains is None:
-            try:
-                self.chains = min(val.shape[1] for val in obj.values())
-            except IndexError:
-                self.chains = 1
+            raise ValueError('Must specify the number of chains')
         else:
             self.chains = chains
 

--- a/arviz/utils/xarray_utils.py
+++ b/arviz/utils/xarray_utils.py
@@ -33,12 +33,14 @@ def convert_to_xarray(obj, coords=None, dims=None):
 
     if isinstance(obj, xr.Dataset):
         return obj
+    elif isinstance(obj, dict):
+        return DictToXarray(obj, coords, dims).to_xarray()
     elif obj.__class__.__name__ == 'StanFit4Model':  # ugly, but doesn't make PyStan a requirement
         return PyStanToXarray(obj, coords, dims).to_xarray()
     elif obj.__class__.__name__ == 'MultiTrace':  # ugly, but doesn't make PyMC3 a requirement
         return PyMC3ToXarray(obj, coords, dims).to_xarray()
     else:
-        raise TypeError('Can only convert PyStan or PyMC3 object to xarray, not {}'.format(
+        raise TypeError('Can only convert PyStan, PyMC3, or dict objects to xarray, not {}'.format(
             obj.__class__.__name__))
 
 
@@ -60,6 +62,137 @@ class Converter(ABC):
     @abstractmethod
     def verify_coords_dims(self):
         return
+
+
+class DictToXarray(Converter):
+    def __init__(self, obj, coords=None, dims=None):
+        """Convert a dict to an xarray dataset.
+
+        Parameters
+        ----------
+        obj : dict[str, iterable]
+        coords : dict[str, iterable]
+            A dictionary containing the values that are used as index. The key
+            is the name of the dimension, the values are the index values.
+        dims : dict[str, Tuple(str)]
+            A mapping from variables to a tuple corresponding to
+            the shape of the variable, where the elements of the tuples are
+            the names of the coordinate dimensions.
+
+        Returns
+        -------
+        xarray.Dataset
+            The coordinates are those passed in and ('chain', 'draw')
+        """
+        super().__init__(obj, coords=coords, dims=dims)
+
+    def to_xarray(self):
+        data = xr.Dataset(coords=self.coords)
+        base_dims = ['chain', 'draw']
+
+        for key in self.varnames:
+            vals = self.obj[key]
+            if len(vals.shape) == 1:
+                vals = np.expand_dims(vals, axis=1)
+            vals = np.swapaxes(vals, 0, 1)
+            dims_str = base_dims + self.dims[key]
+            try:
+                coords = {v: self.coords[v] for v in dims_str if v in self.coords}
+                data[key] = xr.DataArray(vals, coords=coords, dims=dims_str)
+            except (KeyError, ValueError) as exc:
+                if not self.verified:
+                    raise TypeError(self.warning) from exc
+                else:
+                    raise exc
+
+        return data
+
+    @staticmethod
+    def default_varnames_coords_dims(obj, coords, dims):
+        """Set up varnames, coordinates, and dimensions for .to_xarray function
+
+        obj : dict[str, iterable]
+        coords : dict[str, iterable]
+            A dictionary containing the values that are used as index. The key
+            is the name of the dimension, the values are the index values.
+        dims : dict[str, Tuple(str)]
+            A mapping from pymc3 variables to a tuple corresponding to
+            the shape of the variable, where the elements of the tuples are
+            the names of the coordinate dimensions.
+
+        Returns
+        -------
+        iterable[str]
+            The non-transformed variable names from the trace
+        dict[str, iterable]
+            Default coordinates for the trace
+        dict[str, Tuple(str)]
+            Default dimensions for the xarray
+        """
+        varnames = list(obj.keys())
+        if coords is None:
+            coords = {}
+
+        coords['draw'] = np.arange(obj[varnames[0]].shape[0]) # assume no thinning or warmup
+        coords['chain'] = np.arange(coords.pop('chains', 1))
+        coords = {key: xr.IndexVariable((key,), data=vals) for key, vals in coords.items()}
+
+        if dims is None:
+            dims = {}
+
+        for varname in varnames:
+            if varname not in dims:
+                vals = obj[varname]
+                if len(vals.shape) == 1:
+                    vals = np.expand_dims(vals, axis=1)
+                vals = np.swapaxes(vals, 0, 1)
+                shape_len = len(vals.shape)
+                if shape_len == 2:
+                    dims[varname] = []
+                else:
+                    dims[varname] = [f"{varname}_dim_{idx}" for idx in range(1, shape_len-2+1)]
+
+        return varnames, coords, dims
+
+    def verify_coords_dims(self):
+        """Light checking and guessing on the structure of an xarray for a dict
+
+        Returns
+        -------
+        bool
+            Whether it passes the check
+        str
+            Warning string in case it does not pass
+        """
+        inferred_coords = copy(self.coords)
+        inferred_dims = copy(self.dims)
+        for key in ('draw', 'chain'):
+            inferred_coords.pop(key)
+        global_coords = {}
+        throw = False
+
+        for varname in self.varnames:
+            vals = self.obj[varname]
+            if len(vals.shape) == 1:
+                vals = np.expand_dims(vals, axis=1)
+            vals = np.swapaxes(vals, 0, 1)
+            shapes = [d for shape in self.coords.values() for d in shape.shape]
+            for idx, shape in enumerate(vals[0].shape[1:], 1):
+                try:
+                    shapes.remove(shape)
+                except ValueError:
+                    throw = True
+                    if shape not in global_coords:
+                        global_coords[shape] = f'{varname}_dim_{idx}'
+                    key = global_coords[shape]
+                    inferred_dims[varname].append(key)
+                    if key not in inferred_coords:
+                        inferred_coords[key] = f'np.arange({shape})'
+        if throw:
+            inferred_dims = {k: v for k, v in inferred_dims.items() if v}
+            msg = f'Bad arguments! Try setting\ncoords={inferred_coords}\ndims={inferred_dims}'
+            return False, msg
+        return True, ''
 
 
 class PyMC3ToXarray(Converter):


### PR DESCRIPTION
Convert `dict` objects of posterior samples to `xarray`.  Needs tests.  See this [notebook](https://gist.github.com/AustinRochford/3b92f5b162d33b3981c8c966ee059239) showing basic equivalence between `DictToXarray` and `PyStanToXarray`.

Needs:
- [x] Better documentation and error messages around specifying `chains` in `coords`.
- [ ] Tests