### PR TITLE
Traceplot supports xarray

### DIFF
--- a/arviz/plots/autocorrplot.py
+++ b/arviz/plots/autocorrplot.py
@@ -6,7 +6,7 @@ from ..utils import convert_to_xarray
 
 
 def autocorrplot(posterior, var_names=None, max_lag=100, symmetric_plot=False, combined=False,
-                 figsize=None, textsize=None, skip_first=0):
+                 figsize=None, textsize=None):
     """
     Bar plot of the autocorrelation function for a posterior.
 
@@ -29,15 +29,12 @@ def autocorrplot(posterior, var_names=None, max_lag=100, symmetric_plot=False, c
         Note this is not used if ax is supplied.
     textsize: int
         Text size for labels, titles and lines. If None it will be autoscaled based on figsize.
-    skip_first : int, optional
-        Number of first samples not shown in plots (burn-in).
 
     Returns
     -------
     ax : matplotlib axes
     """
     data = convert_to_xarray(posterior)
-    data = data.where(data.draw >= skip_first).dropna('draw')
 
     if symmetric_plot:
         min_lag = -max_lag
@@ -49,7 +46,7 @@ def autocorrplot(posterior, var_names=None, max_lag=100, symmetric_plot=False, c
 
     if figsize is None:
         figsize = (3 * cols, 2.5 * rows)
-    textsize, linewidth, _ = _scale_text(figsize, textsize, 1)
+    textsize, linewidth, _ = _scale_text(figsize, textsize, 1.5)
 
     _, axes = plt.subplots(rows, cols, figsize=figsize, squeeze=False, sharex=True, sharey=True)
 
@@ -57,6 +54,8 @@ def autocorrplot(posterior, var_names=None, max_lag=100, symmetric_plot=False, c
     y_min = 0
     ax = None
     for (var_name, selection, x), ax in zip(plotters, axes.flatten()):
+        if combined:
+            x = x.flatten()
         y = x - x.mean()
         y = np.correlate(y, y, mode=2)
         y = y / np.abs(y).max()

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -27,9 +27,12 @@ class TestPlots(object):
         for obj in (self.short_trace, self.fit):
             assert densityplot(obj).shape == (18, 1)
 
-    def test_traceplot(self):
-        assert traceplot(self.df_trace).shape == (1, 2)
-        assert traceplot(self.short_trace).shape == (18, 2)
+    @pytest.mark.parametrize('combined', [True, False])
+    def test_traceplot(self, combined):
+        for obj in (self.short_trace, self.fit):
+            axes = traceplot(obj, var_names=('mu', 'tau'),
+                             combined=combined, lines=[('mu', {}, [1, 2])])
+            assert axes.shape == (2, 2)
 
     def test_posteriorplot(self):
         # posteriorplot(self.df_trace).shape == (1,)

--- a/examples/traceplot.py
+++ b/examples/traceplot.py
@@ -8,5 +8,5 @@ import arviz as az
 
 az.style.use('arviz-darkgrid')
 
-trace = az.utils.load_trace('data/centered_eight_trace.gzip')
-az.traceplot(trace, varnames=('tau', 'theta__0', 'mu__0'))
+data = az.load_data('data/non_centered_eight.nc')
+az.traceplot(data, var_names=('tau', 'mu'))

--- a/examples/traceplot.py
+++ b/examples/traceplot.py
@@ -2,7 +2,7 @@
 Traceplot
 =========
 
-_thumb: .8, .8
+_thumb: .1, .8
 """
 import arviz as az
 


### PR DESCRIPTION
Looks quite similar to the current implementation.  Two big differences:

1. I removed the `prior` argument. It seemed hard to understand how to use, hard to implement, and I'd rather wait and accept an xarray dataset there (perhaps similar to how forestplot just accepts multiple datasets?)

2. The `lines` argument now looks like `[('theta', {'school': ['Choate', 'Phillips Andover']}, [0, 1, 8])]`.  The first two arguments say which plots the lines should go on, and the last argument says where the vlines go.

Here's the example that goes in the documentation:

![image](https://user-images.githubusercontent.com/2295568/42950476-19bbd3fe-8b42-11e8-8c8b-3f00ff837b5c.png)
