### PR TITLE
Fix/unify autocorr interface

### DIFF
--- a/arviz/plots/autocorrplot.py
+++ b/arviz/plots/autocorrplot.py
@@ -3,6 +3,7 @@ import numpy as np
 
 from .plot_utils import _scale_text, default_grid, make_label, xarray_var_iter
 from ..utils import convert_to_xarray
+from ..stats.diagnostics import autocorr
 
 
 def autocorrplot(posterior, var_names=None, max_lag=100, symmetric_plot=False, combined=False,
@@ -56,13 +57,10 @@ def autocorrplot(posterior, var_names=None, max_lag=100, symmetric_plot=False, c
     for (var_name, selection, x), ax in zip(plotters, axes.flatten()):
         if combined:
             x = x.flatten()
-        y = x - x.mean()
-        y = np.correlate(y, y, mode=2)
-        y = y / np.abs(y).max()
-        midpoint = len(y) // 2
+        y = autocorr(x)
         ax.vlines(x=np.arange(min_lag, max_lag),
-                  ymin=np.zeros(max_lag - min_lag),
-                  ymax=y[midpoint + min_lag:midpoint + max_lag],
+                  ymin=0,
+                  ymax=y[min_lag:max_lag],
                   lw=linewidth)
         ax.hlines(0, min_lag, max_lag, 'steelblue')
         ax.set_title(make_label(var_name, selection), fontsize=textsize)

--- a/arviz/plots/autocorrplot.py
+++ b/arviz/plots/autocorrplot.py
@@ -46,12 +46,12 @@ def autocorrplot(posterior, var_names=None, max_lag=100, combined=False,
 
     axes = np.atleast_2d(axes)  # in case of only 1 plot
     for (var_name, selection, x), ax in zip(plotters, axes.flatten()):
-        x_ = x
+        x_prime = x
 
         if combined:
-            x_ = x.flatten()
+            x_prime = x.flatten()
 
-        y = autocorr(x_)
+        y = autocorr(x_prime)
 
         ax.vlines(x=np.arange(0, max_lag),
                   ymin=0, ymax=y[0:max_lag],

--- a/arviz/plots/autocorrplot.py
+++ b/arviz/plots/autocorrplot.py
@@ -45,7 +45,6 @@ def autocorrplot(posterior, var_names=None, max_lag=100, combined=False,
     _, axes = plt.subplots(rows, cols, figsize=figsize, squeeze=False, sharex=True, sharey=True)
 
     axes = np.atleast_2d(axes)  # in case of only 1 plot
-    ax = None
     for (var_name, selection, x), ax in zip(plotters, axes.flatten()):
         x_ = x
 
@@ -61,7 +60,8 @@ def autocorrplot(posterior, var_names=None, max_lag=100, combined=False,
         ax.set_title(make_label(var_name, selection), fontsize=textsize)
         ax.tick_params(labelsize=textsize)
 
-    if ax is not None:
-        ax.set_xlim(0, max_lag)
-        ax.set_ylim(-1, 1)
-    return ax
+    if axes.size > 0:
+        axes[0, 0].set_xlim(0, max_lag)
+        axes[0, 0].set_ylim(-1, 1)
+
+    return axes

--- a/arviz/stats/diagnostics.py
+++ b/arviz/stats/diagnostics.py
@@ -106,7 +106,7 @@ def _get_neff(trace_value):
     return ess
 
 
-def _autocorr(x):
+def autocorr(x):
     """
     Compute autocorrelation using FFT for every lag for the input array
     https://en.wikipedia.org/wiki/autocorrelation#Efficient_computation
@@ -142,7 +142,7 @@ def _autocov(x):
     -------
     acov: Numpy array same size as the input array
     """
-    acorr = _autocorr(x)
+    acorr = autocorr(x)
     varx = np.var(x, ddof=1) * (len(x) - 1) / len(x)
     acov = acorr * varx
     return acov

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -40,7 +40,7 @@ class TestPlots(object):
 
     def test_autocorrplot(self):
         for obj in (self.short_trace, self.fit):
-            assert autocorrplot(obj)[0, 0].get_geometry() == (6, 6, 36)
+            assert autocorrplot(obj).shape == (6, 6)
 
     def test_forestplot(self):
         for obj in (self.short_trace, self.fit, [self.short_trace, self.fit]):


### PR DESCRIPTION
Following previous discussion in issue #141 this pull request fixes inconsistencies between autocorrelation computation in `az.stats.diagnostics.autocorr` (previously `az.stats.diagnostics._autocorr`) and `az.stats.plots.autocorrplot`. The notions of autocorrelation computation differed previously, in this pull request we settle for the (recently thoroughly discussed) notion as (recently, in February 2018) implemented in `az.stats.diagnostics.autocorr`, `pymc3.stats._autocorr` and `stan::math::autocorrelation`. 

As proof of concept and to make differences between old and new interface visible, consider the following plots:

New:
![autocorrplot_new](https://user-images.githubusercontent.com/6368040/43183329-09a8e522-8fe5-11e8-8a67-eff11d3e2d6f.png)

Previous:
![autocorrplot_old](https://user-images.githubusercontent.com/6368040/43183332-0e4b482c-8fe5-11e8-95cc-b5ae120a7688.png)


