### PR TITLE
[WIP] Add some sample figures in docs

### DIFF
--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -58,6 +58,32 @@ def posteriorplot(trace, varnames=None, figsize=None, textsize=None, alpha=0.05,
     -------
     ax : matplotlib axes
 
+    Examples
+    --------
+    Show one example plot for reference
+
+    .. plot::
+        :context: close-figs
+
+        >>> import numpy as np
+        >>> import pandas as pd
+        >>> import arviz as az
+        >>> np.random.seed(0)
+        >>> trace = pd.DataFrame({"mu":np.random.randn(100), "theta":np.random.randn(100)})
+        >>> az.posteriorplot(trace, varnames=["mu", "theta"])
+
+    Change a parameter and show another plot to show what happens
+
+    .. plot::
+        :context: close-figs
+
+        >>> import numpy as np
+        >>> import pandas as pd
+        >>> import arviz as az
+        >>> np.random.seed(0)
+        >>> trace = pd.DataFrame({"mu":np.random.randn(100), "theta":np.random.randn(100)})
+        >>> az.posteriorplot(trace, varnames=["mu", "theta"], kind="hist")
+
     """
 
     trace = trace_to_dataframe(trace[skip_first:], combined=True)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -33,6 +33,8 @@ import arviz
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 sys.path.insert(0, os.path.abspath('sphinxext'))
+
+
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
@@ -49,6 +51,13 @@ extensions = [
     'IPython.sphinxext.ipython_console_highlighting',
     'gallery_generator',
 ]
+
+# Copy plot options from Seaborn
+# Include the example source for plots in API docs
+plot_include_source = True
+plot_formats = [("png", 90)]
+plot_html_show_formats = False
+plot_html_show_source_link = False
 
 # Generate API documentation when building
 autosummary_generate = True


### PR DESCRIPTION
While trying working on the pull request for prior distribution plots in pymc3, I thought it would be helpful both for me and others to have more documentation on what various plotting options, similar to how Seaborn's documentation.

To that extent I tried it out. Attached is a exported PDF of the documentation to illustrate the change.

If this is welcome I would be happy to continue with this PR until the documentation is comprehensive.  Any feedback positive or negative would be appreciated!

Seaborn Inspiration
https://seaborn.pydata.org/generated/seaborn.distplot.html

[arviz.posteriorplot — ArviZ 0.1.0 documentation_example.pdf](https://github.com/arviz-devs/arviz/files/2238547/arviz.posteriorplot.ArviZ.0.1.0.documentation_example.pdf)
