### PR TITLE
Update posterior plot to work with xarray

### DIFF
--- a/arviz/__init__.py
+++ b/arviz/__init__.py
@@ -4,4 +4,4 @@ from matplotlib.pyplot import style
 
 from .plots import *
 from .stats import *
-from .utils import trace_to_dataframe, save_data, load_data, convert_to_xarray
+from .utils import trace_to_dataframe, save_data, load_data, convert_to_xarray, load_arviz_data

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -36,7 +36,9 @@ class TestPlots(object):
 
     def test_posteriorplot(self):
         # posteriorplot(self.df_trace).shape == (1,)
-        assert posteriorplot(self.short_trace).shape == (18,)
+        for obj in (self.short_trace, self.fit):
+            axes = posteriorplot(obj, var_names=('mu', 'tau'), rope=(-2, 2), ref_val=0)
+            assert axes.shape == (1, 2)
 
     def test_autocorrplot(self):
         for obj in (self.short_trace, self.fit):

--- a/arviz/utils/__init__.py
+++ b/arviz/utils/__init__.py
@@ -1,5 +1,5 @@
 from .utils import (trace_to_dataframe, get_stats, expand_variable_names, get_varnames,
                     _create_flat_names, log_post_trace, save_data, load_data,
-                    save_trace, load_trace, untransform_varnames)
+                    save_trace, load_trace, untransform_varnames, load_arviz_data)
 
 from .xarray_utils import convert_to_xarray

--- a/arviz/utils/utils.py
+++ b/arviz/utils/utils.py
@@ -368,3 +368,45 @@ def load_data(filename):
         name or path of the file to load trace
     """
     return xr.open_dataset(filename)
+
+
+def load_arviz_data(dataset):
+    """Load built-in arviz dataset into memory
+
+    Will print out available datasets in case of error.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of dataset to load
+
+    Returns
+    -------
+    xr.Dataset
+    """
+    top = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    data_path = os.path.join(top, 'doc', 'data')
+    datasets_available = {
+        'centered_eight': {
+            'description': '''
+                Centered eight schools model.  Four chains, 500 draws each, fit with
+                NUTS in PyMC3.  Features named coordinates for each of the eight schools.
+            ''',
+            'path': os.path.join(data_path, 'centered_eight.nc')
+        },
+        'non_centered_eight': {
+            'description': '''
+                Non-centered eight schools model.  Four chains, 500 draws each, fit with
+                NUTS in PyMC3.  Features named coordinates for each of the eight schools.
+            ''',
+            'path': os.path.join(data_path, 'non_centered_eight.nc')
+        }
+    }
+    if dataset in datasets_available:
+        return xr.open_dataset(datasets_available[dataset]['path'])
+    else:
+        msg = ['\'dataset\' must be one of the following options:']
+        for key, value in sorted(datasets_available.items()):
+            msg.append('{key}: {description}'.format(key=key, description=value['description']))
+
+        raise ValueError('\n'.join(msg))

--- a/examples/posteriorplot.py
+++ b/examples/posteriorplot.py
@@ -8,5 +8,6 @@ import arviz as az
 
 az.style.use('arviz-darkgrid')
 
-trace = az.utils.load_trace('data/non_centered_eight_trace.gzip')
-az.posteriorplot(trace, varnames=['theta__0', 'theta__1', 'tau', 'mu'])
+non_centered = az.load_arviz_data('non_centered_eight')
+
+az.posteriorplot(non_centered, var_names=('theta_tilde',), ref_val=0, rope=(-1, 1), textsize=11)

--- a/examples/traceplot.py
+++ b/examples/traceplot.py
@@ -8,5 +8,5 @@ import arviz as az
 
 az.style.use('arviz-darkgrid')
 
-data = az.load_data('data/non_centered_eight.nc')
+data = az.load_arviz_data('non_centered_eight')
 az.traceplot(data, var_names=('tau', 'mu'))


### PR DESCRIPTION
A change I'm happy with is the addition of `load_arviz_data`, which allows you to load some pretrained datasets.  You can train some data, use `az.save_data(...)` on it, then move the file to the appropriate folder if you want to add more (I'd like to add models trained with pystan, edward, pymc4, tensorflow probability...) I made this so I could update @canyon289's documentation examples.

The actual plot definitely works but has some rough edges.  I think it is ok to merge given that there may be others who want to work on it.  As an example,
 
```python
az.posteriorplot(non_centered, var_names=('theta_tilde',), ref_val=0, rope=(-1, 1))
```
![image](https://user-images.githubusercontent.com/2295568/43417771-3723aefa-943c-11e8-9203-273a7d5587e1.png)

If we wanted followups, I think

1. The way of passing `rope` or `ref_val` arguments to individual plots is pretty nasty, but the best I could do.  Something like
```python
az.posteriorplot(non_centered, var_names=('mu', 'theta_tilde'), ref_val=1, textsize=10, 
                rope={'mu': [{'rope': (-2, 2)}], 
                      'theta_tilde': [{'school': 'Choate', 'rope': (2, 4)}]
                })
```
![image](https://user-images.githubusercontent.com/2295568/43417856-7c62eb34-943c-11e8-850f-4d3657c3c677.png)

2. The `_plot_posterior_op` function is a bit of a mess.  I'd much rather have a functional approach with a bunch of small functions adding on to the axes instead of everything sharing so much state.