### PR TITLE
fix empty pars if at least one par nonempty

### DIFF
--- a/arviz/utils/xarray_utils.py
+++ b/arviz/utils/xarray_utils.py
@@ -396,7 +396,6 @@ class PyStanToXarray(Converter):
 
         data = xr.Dataset(coords=self.coords)
         base_dims = ['chain', 'draw']
-        
         extract = fit.extract(pars=self.varnames,
                               dtypes=dtypes,
                               permuted=False)
@@ -448,8 +447,7 @@ class PyStanToXarray(Converter):
 
         if dims is None:
             dims = {}
-        
-        extract = fit.extract(varnames, permuted=False)
+        extract = obj.extract(varnames, permuted=False)
         for varname, vals in extract.items():
             if varname not in dims:
                 if len(vals.shape) == 1:

--- a/arviz/utils/xarray_utils.py
+++ b/arviz/utils/xarray_utils.py
@@ -396,10 +396,11 @@ class PyStanToXarray(Converter):
 
         data = xr.Dataset(coords=self.coords)
         base_dims = ['chain', 'draw']
-
-        for key in self.varnames:
-            var_dtype = {key : 'int'} if key in dtypes else {}
-            vals = fit.extract(key, dtypes=var_dtype, permuted=False)[key]
+        
+        extract = fit.extract(pars=self.varnames,
+                              dtypes=dtypes,
+                              permuted=False)
+        for key, vals in extract.items():
             if len(vals.shape) == 1:
                 vals = np.expand_dims(vals, axis=1)
             vals = np.swapaxes(vals, 0, 1)
@@ -447,10 +448,10 @@ class PyStanToXarray(Converter):
 
         if dims is None:
             dims = {}
-
-        for varname in varnames:
+        
+        extract = fit.extract(varnames, permuted=False)
+        for varname, vals in extract.items():
             if varname not in dims:
-                vals = obj.extract(varname, permuted=False)[varname]
                 if len(vals.shape) == 1:
                     vals = np.expand_dims(vals, axis=1)
                 vals = np.swapaxes(vals, 0, 1)


### PR DESCRIPTION
This way no need to check dims for all the variables to see if they are empty.