### PR TITLE
a couple of small fixes

### DIFF
--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -48,17 +48,18 @@ def kdeplot(values, cumulative=False, rug=False, label=None, bw=4.5, rotated=Fal
         plot_kwargs = {}
     plot_kwargs.setdefault('color', 'C0')
 
+    default_color = plot_kwargs.get('color')
     if fill_kwargs is None:
         fill_kwargs = {}
 
-    fill_kwargs.setdefault('alpha', 0.2)
-    fill_kwargs.setdefault('color', 'C0')
+    fill_kwargs.setdefault('alpha', 0)
+    fill_kwargs.setdefault('color', default_color)
 
     if rug_kwargs is None:
         rug_kwargs = {}
     rug_kwargs.setdefault('marker', '_' if rotated else '|')
     rug_kwargs.setdefault('linestyle', 'None')
-    rug_kwargs.setdefault('color', 'C0')
+    rug_kwargs.setdefault('color', default_color)
 
     if figsize is None:
         if ax:

--- a/arviz/plots/traceplot.py
+++ b/arviz/plots/traceplot.py
@@ -7,7 +7,7 @@ from .plot_utils import _scale_text, get_bins, xarray_var_iter, make_label
 
 
 def traceplot(data, var_names=None, coords=None, figsize=None, textsize=None, lines=None,
-              combined=False, kde_kwargs=None, trace_kwargs=None):
+              combined=False, kde_kwargs=None, hist_kwargs=None, trace_kwargs=None):
     """Plot samples histograms and values.
 
     Parameters
@@ -29,7 +29,9 @@ def traceplot(data, var_names=None, coords=None, figsize=None, textsize=None, li
         Flag for combining multiple chains into a single line. If False (default), chains will be
         plotted separately.
     kde_kwargs : dict
-        Extra keyword arguments passed to `arviz.kdeplot`
+        Extra keyword arguments passed to `arviz.kdeplot`. Only affects continuous variables.
+    hist_kwargs : dict
+        Extra keyword arguments passed to `plt.hist`. Only affects discrete variables.
     trace_kwargs : dict
         Extra keyword arguments passed to `plt.plot`
     Returns
@@ -57,6 +59,11 @@ def traceplot(data, var_names=None, coords=None, figsize=None, textsize=None, li
     if kde_kwargs is None:
         kde_kwargs = {}
 
+    if hist_kwargs is None:
+        hist_kwargs = {}
+
+    hist_kwargs.setdefault('alpha', 0.35)
+
     textsize, linewidth, _ = _scale_text(figsize, textsize=textsize, scale_ratio=1)
     trace_kwargs.setdefault('linewidth', linewidth)
 
@@ -72,10 +79,8 @@ def traceplot(data, var_names=None, coords=None, figsize=None, textsize=None, li
             colors.append(axes[i, 1].get_lines()[-1].get_color())
             kde_kwargs.setdefault('plot_kwargs', {})
             kde_kwargs['plot_kwargs']['color'] = colors[-1]
-            kde_kwargs.setdefault('fill_kwargs', {})
-            kde_kwargs['fill_kwargs']['alpha'] = 0
             if row.dtype.kind == 'i':
-                _histplot_op(axes[i, 0], row, alpha=kde_kwargs['alpha'])
+                _histplot_op(axes[i, 0], row, **hist_kwargs)
             else:
                 kdeplot(row, textsize=textsize, ax=axes[i, 0], **kde_kwargs)
 
@@ -98,10 +103,10 @@ def traceplot(data, var_names=None, coords=None, figsize=None, textsize=None, li
     return axes
 
 
-def _histplot_op(ax, data, alpha=0.35):
+def _histplot_op(ax, data, **kwargs):
     """Add a histogram for the data to the axes."""
     bins = get_bins(data)
-    ax.hist(data, bins=bins, alpha=alpha, align='left', density=True)
+    ax.hist(data, bins=bins, align='left', density=True, **kwargs)
     xticks = get_bins(data, max_bins=10, fenceposts=1)
     ax.set_xticks(xticks)
     return ax

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -360,8 +360,8 @@ def loo(trace, model, pointwise=False, reff=None):
         return pd.DataFrame([[loo_lppd, loo_lppd_se, p_loo, warn_mg, loo_lppd_i]],
                             columns=['loo', 'loo_se', 'p_loo', 'warning', 'loo_i'])
     else:
-        return pd.DataFrame([[loo_lppd, loo_lppd_se, p_loo, warn_mg, loo_lppd_i]],
-                            columns=['loo', 'loo_se', 'p_loo', 'warning', 'loo_i'])
+        return pd.DataFrame([[loo_lppd, loo_lppd_se, p_loo, warn_mg]],
+                            columns=['loo', 'loo_se', 'p_loo', 'warning'])
 
 
 def psislw(log_weights, reff=1.):


### PR DESCRIPTION
* Loo was returning `loo_i` even when `pointwise=False`
* Colors for rug and fill in a kdeplot is set by default as the same color of the kde-line by default. 
* I think the fill under the line should be 0 (transparent) by default. KDEs are very useful to overlaid many distributions (contrary to filled-histtogram) having a shade by defaults reduce the usefulness of this feature. 