### PR TITLE
change order mc_error and credible interval default value

### DIFF
--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -19,7 +19,7 @@ def pairwise(iterable):
 
 
 def forestplot(data, kind='forestplot', model_names=None, var_names=None, combined=False,
-               credible_interval=0.95, quartiles=True, r_hat=True, n_eff=True, colors='cycle',
+               credible_interval=0.94, quartiles=True, r_hat=True, n_eff=True, colors='cycle',
                textsize=None, linewidth=None, markersize=None, joyplot_alpha=None,
                joyplot_overlap=2, figsize=None):
     """
@@ -44,7 +44,7 @@ def forestplot(data, kind='forestplot', model_names=None, var_names=None, combin
         Flag for combining multiple chains into a single chain. If False (default),
         chains will be plotted separately.
     credible_interval : float, optional
-        Credible interval to plot. Defaults to 0.95.
+        Credible interval to plot. Defaults to 0.94.
     quartiles : bool, optional
         Flag for plotting the interquartile range, in addition to the credible_interval intervals.
         Defaults to True
@@ -366,7 +366,7 @@ class VarHandler():
     def treeplot(self, qlist, credible_interval):
         for y, _, values, color in self.iterator():
             ntiles = np.percentile(values.flatten(), qlist)
-            ntiles[0], ntiles[-1] = hpd(values.flatten(), alpha=1-credible_interval)
+            ntiles[0], ntiles[-1] = hpd(values.flatten(), credible_interval)
             yield y, ntiles, color
 
     def joyplot(self, mult):

--- a/arviz/plots/violintraceplot.py
+++ b/arviz/plots/violintraceplot.py
@@ -7,8 +7,8 @@ from ..stats import hpd
 from ..utils import get_varnames, trace_to_dataframe
 
 
-def violintraceplot(trace, varnames=None, quartiles=True, alpha=0.05, shade=0.35, bw=4.5,
-                    sharey=True, figsize=None, textsize=None, skip_first=0, ax=None,
+def violintraceplot(trace, varnames=None, quartiles=True, credible_interval=0.94, shade=0.35,
+                    bw=4.5, sharey=True, figsize=None, textsize=None, skip_first=0, ax=None,
                     kwargs_shade=None):
     """
     Violinplot
@@ -20,10 +20,10 @@ def violintraceplot(trace, varnames=None, quartiles=True, alpha=0.05, shade=0.35
     varnames: list, optional
         List of variables to plot (defaults to None, which results in all variables plotted)
     quartiles : bool, optional
-        Flag for plotting the interquartile range, in addition to the (1-alpha)*100% intervals.
-        Defaults to True
-    alpha : float, optional
-        Alpha value for (1-alpha)*100% credible intervals. Defaults to 0.05.
+        Flag for plotting the interquartile range, in addition to the credible_interval*100%
+        intervals. Defaults to True
+    credible_interval : float, optional
+        Credible intervals. Defaults to 0.94.
     shade : float
         Alpha blending value for the shaded area under the curve, between 0
         (no shade) and 1 (opaque). Defaults to 0
@@ -69,7 +69,7 @@ def violintraceplot(trace, varnames=None, quartiles=True, alpha=0.05, shade=0.35
             _violinplot(val, shade, bw, ax[axind], **kwargs_shade)
 
         per = np.percentile(val, [25, 75, 50])
-        hpd_intervals = hpd(val, alpha)
+        hpd_intervals = hpd(val, credible_interval)
 
         if quartiles:
             ax[axind].plot([0, 0], per[:2], lw=linewidth*3, color='k', solid_capstyle='round')

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -18,7 +18,7 @@ def test_bfmi():
 def test_hpd():
     normal_sample = np.random.randn(5000000)
     interval = hpd(normal_sample)
-    assert_array_almost_equal(interval, [-1.96, 1.96], 2)
+    assert_array_almost_equal(interval, [-1.88, 1.88], 2)
 
 
 def test_r2_score():

--- a/examples/densityplot.py
+++ b/examples/densityplot.py
@@ -11,4 +11,4 @@ az.style.use('arviz-darkgrid')
 centered_data = az.load_data('data/centered_eight.nc')
 non_centered_data = az.load_data('data/non_centered_eight.nc')
 az.densityplot([centered_data, non_centered_data], ['Centered', 'Non Centered'],
-                var_names=['theta'], shade=0.1, alpha=0.01)
+                var_names=['theta'], shade=0.1)


### PR DESCRIPTION
* the mean, standard deviation and hpd intervals are estimates of the _true_ variable while mc_error, n_eff and rhat are properties only of the samples used to approximate that variable. This change the order of mc_error accordingly.

* This also changes the name of the argument `alpha` to `credible_interval` to avoid confusion with matplotlib's alpha parameter.

* The value of the credible interval is set to 0.94, just to make the point that 0.95 is completely arbitrary  