### PR TITLE
[WIP] Add additional information to hdp exception

### DIFF
--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -270,7 +270,8 @@ def hpd(x, credible_interval=0.94, transform=lambda x: x, circular=False):
     interval_width = x[interval_idx_inc:] - x[:n_intervals]
 
     if len(interval_width) == 0:
-        raise ValueError('Too few elements for interval calculation')
+        raise ValueError('Too few elements for interval calculation.'
+                         ' Check that credible_interval meets condition 0 =< credible_interval < 1')
 
     min_idx = np.argmin(interval_width)
     hdi_min = x[min_idx]


### PR DESCRIPTION
When setting alpha (now credible_interval) out of the bounds of 0 to 1, the user gets a confusing error.
I propose adding an extra line of text to make it a little more clear what the user should do.

I would like to write a test for this but am traveling and away from my linux computer. Submitting for now just to get feedback.

<img width="842" alt="screen shot 2018-08-11 at 8 34 49 am" src="https://user-images.githubusercontent.com/7213793/43993415-b1631634-9d41-11e8-854d-19ed56761946.png">
