### PR TITLE
fix forestplot: order dimensions in ascending order

### DIFF
--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -329,7 +329,8 @@ class VarHandler():
             for _, sub_data in grouped_datum:
                 datum_iter = xarray_var_iter(sub_data,
                                              var_names=[self.var_name],
-                                             skip_dims=skip_dims)
+                                             skip_dims=skip_dims,
+                                             reverse_selections=True)
                 for _, selection, values in datum_iter:
                     label = make_label(self.var_name, selection)
                     if label not in label_dict:

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -159,7 +159,7 @@ def make_label(var_name, selection):
     return '{}'.format(var_name)
 
 
-def xarray_var_iter(data, var_names=None, combined=False, skip_dims=None):
+def xarray_var_iter(data, var_names=None, combined=False, skip_dims=None, reverse_selections=False):
     """Converts xarray data to an iterator over vectors
 
     Iterates over each var_name and all of its coordinates, returning the 1d
@@ -178,6 +178,9 @@ def xarray_var_iter(data, var_names=None, combined=False, skip_dims=None):
 
     skip_dims : set
         dimensions to not iterate over
+
+    reverse_selections : bool
+        Whether to reverse selections before iterating.
 
     Returns
     -------
@@ -205,5 +208,8 @@ def xarray_var_iter(data, var_names=None, combined=False, skip_dims=None):
             new_dims = set(data[var_name].dims) - skip_dims
             vals = [data[var_name][dim].values for dim in new_dims]
             dims = [{k: v for k, v in zip(new_dims, prod)} for prod in itertools.product(*vals)]
+            if reverse_selections:
+                dims = reversed(dims)
+
             for selection in dims:
                 yield var_name, selection, data[var_name].sel(**selection).values


### PR DESCRIPTION
Adresses #166. Dimensions of multidimensional variables are now ordered ascending instead of descending as they were previously. I decided to go the route @ColCarroll suggested in #166. I introduced 
a flag `reverse_selections` for `xarray_var_iter` in `arviz.plots.plot_utils.py` and set it to `True` inside `arviz.plots.forestplot`. 

They say pictures say more than a thousand words, so:

Old:

![old_behavior](https://user-images.githubusercontent.com/6368040/44312696-68321980-a3fc-11e8-8005-fe5c2046c661.png)


New:
![new_behavior](https://user-images.githubusercontent.com/6368040/44312699-6c5e3700-a3fc-11e8-8a62-d4310acbafee.png)
