### PR TITLE
[WIP] Fix labels for plot

### DIFF
--- a/doc/sphinxext/gallery_generator.py
+++ b/doc/sphinxext/gallery_generator.py
@@ -308,7 +308,7 @@ class ExampleGenerator(object):
                 "\n\n"
                 "".format(self.htmlfilename,
                           self.thumbfilename,
-                          self.plotfunc))
+                          self.sphinxtag))
 
 
 def main(app):


### PR DESCRIPTION
The Example Generator was using the module name to label the thumbnails in the gallery so the ridgeplot was showing labeled as a forestplot

I propose changing this to the sphinxtag which allows for more flexibility in naming. The tradeoff though is it matches the "human" name now for the plot but not the method name, although I argue the user can just click into the example to see the code.

Before change

![forestplot](https://user-images.githubusercontent.com/7213793/44831218-66294100-abda-11e8-9dc4-714da14a5bac.png)

After change
![afterfix](https://user-images.githubusercontent.com/7213793/44831032-8efd0680-abd9-11e8-8553-6da4638e1b7a.png)
