### PR TITLE
Fix bug where argument was ignored

### DIFF
--- a/arviz/plots/autocorrplot.py
+++ b/arviz/plots/autocorrplot.py
@@ -32,7 +32,7 @@ def autocorrplot(data, var_names=None, max_lag=100, combined=False,
     -------
     axes : matplotlib axes
     """
-    data = convert_to_dataset(data, 'posterior')
+    data = convert_to_dataset(data, group='posterior')
 
     plotters = list(xarray_var_iter(data, var_names, combined))
     length_plotters = len(plotters)

--- a/arviz/plots/densityplot.py
+++ b/arviz/plots/densityplot.py
@@ -59,7 +59,7 @@ def densityplot(data, data_labels=None, var_names=None, credible_interval=0.94,
 
     """
     if not isinstance(data, (list, tuple)):
-        datasets = [convert_to_dataset(data, 'posterior')]
+        datasets = [convert_to_dataset(data, group='posterior')]
     else:
         datasets = [convert_to_dataset(d, 'posterior') for d in data]
 

--- a/arviz/plots/jointplot.py
+++ b/arviz/plots/jointplot.py
@@ -41,7 +41,7 @@ def jointplot(data, var_names=None, coords=None, figsize=None, textsize=None, ki
     ax_hist_y : matplotlib axes, y (right) distribution
     """
 
-    data = convert_to_dataset(data, 'posterior')
+    data = convert_to_dataset(data, group='posterior')
     if coords is None:
         coords = {}
 

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -128,7 +128,7 @@ def posteriorplot(data, var_names=None, coords=None, figsize=None, textsize=None
 
         >>> az.posteriorplot(non_centered, var_names=('mu', 'theta_tilde',), credible_interval=.94)
     """
-    data = convert_to_dataset(data, 'posterior')
+    data = convert_to_dataset(data, group='posterior')
 
     if coords is None:
         coords = {}

--- a/arviz/plots/traceplot.py
+++ b/arviz/plots/traceplot.py
@@ -38,7 +38,7 @@ def traceplot(data, var_names=None, coords=None, figsize=None, textsize=None, li
     -------
     axes : matplotlib axes
     """
-    data = convert_to_dataset(data, 'posterior')
+    data = convert_to_dataset(data, group='posterior')
 
     if coords is None:
         coords = {}

--- a/arviz/plots/violintraceplot.py
+++ b/arviz/plots/violintraceplot.py
@@ -50,7 +50,7 @@ def violintraceplot(data, var_names=None, quartiles=True, credible_interval=0.94
 
     """
 
-    data = convert_to_dataset(data, 'posterior')
+    data = convert_to_dataset(data, group='posterior')
     plotters = list(xarray_var_iter(data, var_names=var_names, combined=True))
 
     if kwargs_shade is None:

--- a/arviz/utils/utils.py
+++ b/arviz/utils/utils.py
@@ -8,7 +8,7 @@ import re
 import numpy as np
 import pandas as pd
 
-from arviz import InferenceData
+from ..inference_data import InferenceData
 
 
 def _has_type(object_, typename, module_path):
@@ -115,19 +115,19 @@ def expand_variable_names(trace, varnames):
 
 def get_stats(trace, stat=None, combined=True):
     """
-    get sampling statistics from trace
+    Get sampling statistics from trace
 
     Parameters
     ----------
     trace : Posterior sample
         Pandas DataFrame or PyMC3 trace
-    stats : string
+    stat : string
         Statistics
     combined : Bool
         If True multiple statistics from different chains will be combined together.
     Returns
     ----------
-    stat: array with the choosen statistic
+    stat: array with the chosen statistic
     """
     if _has_type(trace, typename="MultiTrace", module_path="pymc3.backends.base"):
         try:

--- a/arviz/utils/xarray_utils.py
+++ b/arviz/utils/xarray_utils.py
@@ -4,8 +4,8 @@ import warnings
 import numpy as np
 import xarray as xr
 
-from arviz import InferenceData
-from arviz.compat import pymc3 as pm
+from ..inference_data import InferenceData
+from ..compat import pymc3 as pm
 
 
 def convert_to_inference_data(obj, *_, group='posterior', coords=None, dims=None):


### PR DESCRIPTION
While the code works, the posterior argument is ignored and to a human it looks like a second non keyword argument is actually doing something when it isnt

@ColCarroll Out of curiosity why is an api where all non keyword arguments are ignored, except the first one preferred?

> (obj, *_, group='posterior', coords=None, dims=None)

*Before change*
![image](https://user-images.githubusercontent.com/7213793/44960299-e76e2580-aeb1-11e8-90d2-64b50131b619.png)
