### PR TITLE
support PyStan version < 2.18

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 git+https://github.com/pymc-devs/pymc3
-git+https://github.com/stan-dev/pystan
+pystan
 ipython
 nbsphinx
 numpydoc


### PR DESCRIPTION
This will first try to extract with parameters and  `permuted=False`. In older versions, it will return numpy.array and in later versions a dictionary. If a dictionary is not seen, it will extract again, but permuted=True and then goes to reorder permutation.

Also added `lp` back to sample_params, it went missing after the "rebase".