### PR TITLE
Implement InferenceData with ParallelPlot

### DIFF
--- a/arviz/plots/parallelplot.py
+++ b/arviz/plots/parallelplot.py
@@ -8,7 +8,7 @@ from .plot_utils import _scale_text, xarray_to_nparray
 def parallelplot(data, var_names=None, figsize=None, textsize=None, legend=True, colornd='k',
                  colord='C1', shadend=.025, ax=None):
     """
-    A parallel coordinates plot showing posterior points with and without divergences
+    Plot parallel coordinates plot showing posterior points with and without divergences.
 
     Described by https://arxiv.org/abs/1709.01449, suggested by Ari Hartikainen
 

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -213,3 +213,37 @@ def xarray_var_iter(data, var_names=None, combined=False, skip_dims=None, revers
 
             for selection in dims:
                 yield var_name, selection, data[var_name].sel(**selection).values
+
+
+def xarray_to_nparray(data, *, var_names=None, combined=True):
+    """Takes xarray data and unpacks into variables and data into list and numpy array respectively
+
+    Assumes that chain and draw are in coordinates
+
+    Parameters
+    ----------
+    data: xarray.DataSet
+        Data in an xarray from an InferenceData object. Examples include posterior or sample_stats
+
+    var_names: iter
+        Should be a subset of data.data_vars not including chain and draws. Defaults to all of them
+
+    combined: bool
+        Whether to combine chain into one array
+
+    Returns
+    -------
+    var_names: list
+        List of variable names
+    data: np.array
+        Data values
+    """
+    unpacked_data, unpacked_var_names, = [], []
+
+    # Merge chains and variables
+    for var_name, selection, data_array in xarray_var_iter(data, var_names=var_names,
+                                                           combined=combined):
+        unpacked_data.append(data_array.flatten())
+        unpacked_var_names.append(make_label(var_name, selection))
+
+    return unpacked_var_names, np.array(unpacked_data)

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -216,7 +216,7 @@ def xarray_var_iter(data, var_names=None, combined=False, skip_dims=None, revers
 
 
 def xarray_to_nparray(data, *, var_names=None, combined=True):
-    """Takes xarray data and unpacks into variables and data into list and numpy array respectively
+    """Take xarray data and unpacks into variables and data into list and numpy array respectively.
 
     Assumes that chain and draw are in coordinates
 

--- a/arviz/tests/test_plotutils.py
+++ b/arviz/tests/test_plotutils.py
@@ -1,0 +1,38 @@
+# pylint: disable=redefined-outer-name
+import numpy as np
+import xarray as xr
+import pytest
+
+from ..plots.plot_utils import xarray_to_nparray
+
+
+@pytest.fixture(scope='function')
+def sample_dataset():
+    mu = np.arange(1, 7).reshape(2, 3)
+    tau = np.arange(7, 13).reshape(2, 3)
+
+    chain = [0, 1]
+    draws = [0, 1, 2]
+
+    data = xr.Dataset({"mu": (["chain", "draw"], mu), "tau": (["chain", "draw"], tau)},
+                      coords={"draw": draws, "chain": chain})
+
+    return mu, tau, data
+
+
+def test_dataset_to_numpy_not_combined(sample_dataset):  # pylint: disable=invalid-name
+    mu, tau, data = sample_dataset
+    var_names, data = xarray_to_nparray(data, combined=False)
+
+    # 2 vars x 2 chains
+    assert len(var_names) == 4
+    assert (data == np.concatenate((mu, tau), axis=0)).all()
+
+
+def test_dataset_to_numpy_combined(sample_dataset):
+    mu, tau, data = sample_dataset
+    var_names, data = xarray_to_nparray(data, combined=True)
+
+    assert len(var_names) == 2
+    assert (data[0] == mu.reshape(1, 6)).all()
+    assert (data[1] == tau.reshape(1, 6)).all()

--- a/examples/parallelplot.py
+++ b/examples/parallelplot.py
@@ -23,4 +23,5 @@ with pm.Model() as centered_eight:
     obs = pm.Normal('obs', mu=theta, sd=sigma, observed=y)
     centered_eight_trace = pm.sample()
 
-az.parallelplot(centered_eight_trace, varnames=['theta', 'tau', 'mu'])
+az.parallelplot(centered_eight_trace, var_names=['theta', 'tau', 'mu'])
+


### PR DESCRIPTION
Looking for two pieces of feedback.
1. Is the approach palatable? 
2. This approach won't work with numpy array inputs at time of writing.numpy_to_data array doesn't have a mechanism for the user to specific sample_stats. Is that an immediate problem?

If this is headed in the right direction though I can clean this up e.g. make functions to add to plot_utils  etc