### PR TITLE
Add manifest to include data, autoclose netcdf

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include *.md
+include LICENSE
+
+recursive-include arviz *.gzip
+recursive-include arviz *.mplstyle
+recursive-include arviz *.nc

--- a/arviz/inference_data.py
+++ b/arviz/inference_data.py
@@ -51,7 +51,7 @@ class InferenceData():
         """
         groups = {}
         for group in nc.Dataset(filename, mode='r').groups:
-            groups[group] = xr.open_dataset(filename, group=group)
+            groups[group] = xr.open_dataset(filename, group=group, autoclose=True)
         return InferenceData(**groups)
 
     def to_netcdf(self, filename):


### PR DESCRIPTION
After about 30 tries, I think `autoclose=True` is what was needed to get everything to work on travis. I can not recreate the problem locally (I opened both datasets 100 times in 4 python processes), but this may get docs to build again.

Note that the build should succeed, but we still need to check the travis logs to make sure the docs actually built.