### PR TITLE
Xarray trouble

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,7 @@ before_script:
 script:
   - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then . ./scripts/lint.sh ; fi
   - pytest -v arviz/tests/ --cov=arviz/
-  - travis-sphinx build --nowarn --source=doc
+  - travis-sphinx build --source=doc
 
 after_success:
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then travis-sphinx deploy; fi
   - coveralls

--- a/arviz/inference_data.py
+++ b/arviz/inference_data.py
@@ -51,7 +51,7 @@ class InferenceData():
         """
         groups = {}
         for group in nc.Dataset(filename, mode='r').groups:
-            groups[group] = xr.open_dataset(filename, group=group, autoclose=True)
+            groups[group] = xr.open_dataset(filename, group=group)
         return InferenceData(**groups)
 
     def to_netcdf(self, filename):


### PR DESCRIPTION
This stops travis-sphinx from deploying docs until we can figure out what the error is. 

Maintainers can deploy manually using

```bash
git pull origin master
cd doc
make html
ghp-import -p -n -f -r git@github.com:arviz-devs/arviz.git _build/html/
```

This is equivalent to what `travis-sphinx` is doing.