### PR TITLE
README gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,17 @@ Arviz is tested on Python 3.5 and 3.6, and depends on NumPy, SciPy, xarray, and 
 
 ## Developing
 
-There is a Dockerfile which helps for isolating build problems and local development.
+A typical development workflow is:
+
+1. Install project requirements: `pip install requirements.txt`
+2. Install additional testing requirements: `pip install requirements-dev.txt`
+3. Write helpful code and tests.
+4. Verify code style: `./scripts/lint.sh`
+5. Run test suite: `pytest arviz/tests`
+6. Make a pull request.
+
+There is also a Dockerfile which helps for isolating build problems and local development.
+
 1. Install Docker for your operating system
 2. Clone this repo,
 3. Run `./scripts/start_container.sh`

--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@
 [![Build Status](https://travis-ci.org/arviz-devs/arviz.svg?branch=master)](https://travis-ci.org/arviz-devs/arviz) [![Coverage Status](https://coveralls.io/repos/github/arviz-devs/arviz/badge.svg?branch=master)](https://coveralls.io/github/arviz-devs/arviz?branch=master)
 
 # ArviZ
+
 ArviZ (pronounced "AR-_vees_") is a Python package for exploratory analysis of Bayesian models.
 Includes functions for posterior analysis, model checking, comparison and diagnostics.
 
 ## Documentation
-The official Arviz documentation can be found here  
+
+The official Arviz documentation can be found here
 http://arviz-devs.github.io/arviz/index.html
 
 ## Installation
@@ -20,9 +22,64 @@ pip install git+git://github.com/arviz-devs/arviz.git
 
 Another option is to clone the repository and install using `python setup.py install`.
 
+-------------------------------------------------------------------------------
+## Gallery
+
+<p>
+<table cellspacing="20">
+<tr>
+
+  <td>
+  <a href="https://arviz-devs.github.io/arviz/examples/ridgeplot.html">
+  <img alt="Ridge plot"
+  src="doc/example_thumbs/ridgeplot_thumb.png" />
+  </a>
+  </td>
+
+  <td>
+  <a href="https://arviz-devs.github.io/arviz/examples/parallelplot.html">
+  <img alt="Parallel plot"
+  src="doc/example_thumbs/parallelplot_thumb.png" />
+  </a>
+  </td>
+
+  <td>
+  <a href="https://arviz-devs.github.io/arviz/examples/traceplot.html">
+  <img alt="Trace plot"
+  src="doc/example_thumbs/traceplot_thumb.png" />
+  </a>
+  </td>
+
+  <td>
+  <a href="https://arviz-devs.github.io/arviz/examples/jointplot.html">
+  <img alt="Joint plot"
+  src="doc/example_thumbs/jointplot_thumb.png" />
+  </a>
+  </td>
+
+  </tr>
+  <tr>
+
+  <td>
+  <a href="https://arviz-devs.github.io/arviz/examples/ppcplot.html">
+  <img alt="Posterior predictive plot"
+  src="doc/example_thumbs/ppcplot_thumb.png" />
+  </a>
+  </td>
+
+  <td>
+  <a href="https://bokeh.pydata.org/en/latest/docs/gallery/image.html">
+  <img alt="Autocorrelation plot"
+  src="doc/example_thumbs/autocorrplot_thumb.png" />
+  </a>
+  </td>
+
+</tr>
+</table>
+
 ## Dependencies
 
-Arviz is tested on Python 3.6 and depends on NumPy, SciPy, Pandas and Matplotlib.
+Arviz is tested on Python 3.5 and 3.6, and depends on NumPy, SciPy, Xarray, and Matplotlib.
 
 ## Developing
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="doc/_static/logo.png" height=100></img>
+<img src="https://arviz-devs.github.io/arviz/_static/logo.png" height=100></img>
 
 [![Build Status](https://travis-ci.org/arviz-devs/arviz.svg?branch=master)](https://travis-ci.org/arviz-devs/arviz) [![Coverage Status](https://coveralls.io/repos/github/arviz-devs/arviz/badge.svg?branch=master)](https://coveralls.io/github/arviz-devs/arviz?branch=master)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Includes functions for posterior analysis, model checking, comparison and diagno
 ## Documentation
 
 The official Arviz documentation can be found here
-http://arviz-devs.github.io/arviz/index.html
+https://arviz-devs.github.io/arviz/index.html
 
 ## Installation
 
@@ -23,37 +23,37 @@ pip install git+git://github.com/arviz-devs/arviz.git
 Another option is to clone the repository and install using `python setup.py install`.
 
 -------------------------------------------------------------------------------
-## Gallery
+## [Gallery](https://arviz-devs.github.io/arviz/examples/index.html)
 
 <p>
-<table cellspacing="20">
+<table>
 <tr>
 
   <td>
   <a href="https://arviz-devs.github.io/arviz/examples/ridgeplot.html">
   <img alt="Ridge plot"
-  src="doc/example_thumbs/ridgeplot_thumb.png" />
+  src="https://arviz-devs.github.io/arviz/_static/ridgeplot_thumb.png" />
   </a>
   </td>
 
   <td>
   <a href="https://arviz-devs.github.io/arviz/examples/parallelplot.html">
   <img alt="Parallel plot"
-  src="doc/example_thumbs/parallelplot_thumb.png" />
+  src="https://arviz-devs.github.io/arviz/_static/parallelplot_thumb.png" />
   </a>
   </td>
 
   <td>
   <a href="https://arviz-devs.github.io/arviz/examples/traceplot.html">
   <img alt="Trace plot"
-  src="doc/example_thumbs/traceplot_thumb.png" />
+  src="https://arviz-devs.github.io/arviz/_static/traceplot_thumb.png" />
   </a>
   </td>
 
   <td>
-  <a href="https://arviz-devs.github.io/arviz/examples/jointplot.html">
-  <img alt="Joint plot"
-  src="doc/example_thumbs/jointplot_thumb.png" />
+  <a href="https://arviz-devs.github.io/arviz/examples/densityplot.html">
+  <img alt="Density plot"
+  src="https://arviz-devs.github.io/arviz/_static/densityplot_thumb.png" />
   </a>
   </td>
 
@@ -61,16 +61,61 @@ Another option is to clone the repository and install using `python setup.py ins
   <tr>
 
   <td>
-  <a href="https://arviz-devs.github.io/arviz/examples/ppcplot.html">
-  <img alt="Posterior predictive plot"
-  src="doc/example_thumbs/ppcplot_thumb.png" />
+  <a href="https://arviz-devs.github.io/arviz/examples/posteriorplot.html">
+  <img alt="Posterior plot"
+  src="https://arviz-devs.github.io/arviz/_static/posteriorplot_thumb.png" />
   </a>
   </td>
 
   <td>
-  <a href="https://bokeh.pydata.org/en/latest/docs/gallery/image.html">
-  <img alt="Autocorrelation plot"
-  src="doc/example_thumbs/autocorrplot_thumb.png" />
+  <a href="https://arviz-devs.github.io/arviz/examples/jointplot.html">
+  <img alt="Joint plot"
+  src="https://arviz-devs.github.io/arviz/_static/jointplot_thumb.png" />
+  </a>
+  </td>
+
+  <td>
+  <a href="https://arviz-devs.github.io/arviz/examples/ppcplot.html">
+  <img alt="Posterior predictive plot"
+  src="https://arviz-devs.github.io/arviz/_static/ppcplot_thumb.png" />
+  </a>
+  </td>
+
+  <td>
+  <a href="https://arviz-devs.github.io/arviz/examples/pairplot.html">
+  <img alt="Pairplot"
+  src="https://arviz-devs.github.io/arviz/_static/pairplot_thumb.png" />
+  </a>
+  </td>
+
+  </tr>
+  <tr>
+
+  <td>
+  <a href="https://arviz-devs.github.io/arviz/examples/energyplot.html">
+  <img alt="Energy Plot"
+  src="https://arviz-devs.github.io/arviz/_static/energyplot_thumb.png" />
+  </a>
+  </td>
+
+  <td>
+  <a href="https://arviz-devs.github.io/arviz/examples/violinplot.html">
+  <img alt="Violin Plot"
+  src="https://arviz-devs.github.io/arviz/_static/violinplot_thumb.png" />
+  </a>
+  </td>
+
+  <td>
+  <a href="https://arviz-devs.github.io/arviz/examples/forestplot.html">
+  <img alt="Forest Plot"
+  src="https://arviz-devs.github.io/arviz/_static/forestplot_thumb.png" />
+  </a>
+  </td>
+
+  <td>
+  <a href="https://arviz-devs.github.io/arviz/examples/autocorrplot.html">
+  <img alt="Autocorrelation Plot"
+  src="https://arviz-devs.github.io/arviz/_static/autocorrplot_thumb.png" />
   </a>
   </td>
 
@@ -83,4 +128,9 @@ Arviz is tested on Python 3.5 and 3.6, and depends on NumPy, SciPy, Xarray, and 
 
 ## Developing
 
-There is a Dockerfile which helps for isolating build problems and local development. Install Docker for your operating system, clone this repo, then run ./scripts/start_container.sh. This should start a local docker container called arviz, as well as a Jupyter notebook server running on port 8888. The notebook should be opened in your browser automatically (you can disable this by passing --no-browser). The container will be running the code from your local copy of arviz, so you can test your changes.
+There is a Dockerfile which helps for isolating build problems and local development.
+1. Install Docker for your operating system
+2. Clone this repo,
+3. Run `./scripts/start_container.sh`
+
+ This should start a local docker container called arviz, as well as a Jupyter notebook server running on port 8888. The notebook should be opened in your browser automatically (you can disable this by passing --no-browser). The container will be running the code from your local copy of arviz, so you can test your changes.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Another option is to clone the repository and install using `python setup.py ins
 
 ## Dependencies
 
-Arviz is tested on Python 3.5 and 3.6, and depends on NumPy, SciPy, Xarray, and Matplotlib.
+Arviz is tested on Python 3.5 and 3.6, and depends on NumPy, SciPy, xarray, and Matplotlib.
 
 ## Developing
 


### PR DESCRIPTION
Some minor edits, but mostly adding a gallery to the readme. 

Note that I am linking the images directly to the documentation, instead of internally into the github repo. This is a little risky (if the documentation goes down, the README looks bad), but makes the README portable: the images will still display on pypi, for example.

You can see it at https://github.com/ColCarroll/arviz/tree/pretty-docs