### PR TITLE
Fix dims and coords

### DIFF
--- a/arviz/tests/test_xarray_utils.py
+++ b/arviz/tests/test_xarray_utils.py
@@ -46,6 +46,73 @@ class TestNumpyToDataArray():
         assert inference_data.foo.draw.shape == shape[1:2]
         assert inference_data.foo[var_name].shape == shape
 
+class TestConvertToDataset():
+    def setup_method(self):
+        # pylint: disable=attribute-defined-outside-init
+        self.datadict = {
+            'a': np.random.randn(100),
+            'b': np.random.randn(1, 100, 10),
+            'c': np.random.randn(1, 100, 3, 4),
+        }
+        self.coords = {'c1' : np.arange(3), 'c2' : np.arange(4), 'b1' : np.arange(10)}
+        self.dims = {'b' : ['b1'], 'c' : ['c1', 'c2']}
+
+    def test_use_all(self):
+        dataset = convert_to_dataset(self.datadict,
+                                     coords=self.coords,
+                                     dims=self.dims)
+        assert set(dataset.data_vars) == {'a', 'b', 'c'}
+        assert set(dataset.coords) == {'chain', 'draw', 'c1', 'c2', 'b1'}
+
+        assert set(dataset.a.coords) == {'chain', 'draw'}
+        assert set(dataset.b.coords) == {'chain', 'draw', 'b1'}
+        assert set(dataset.c.coords) == {'chain', 'draw', 'c1', 'c2'}
+
+    def test_missing_coords(self):
+        dataset = convert_to_dataset(self.datadict,
+                                     coords=None,
+                                     dims=self.dims)
+        assert set(dataset.data_vars) == {'a', 'b', 'c'}
+        assert set(dataset.coords) == {'chain', 'draw', 'c1', 'c2', 'b1'}
+
+        assert set(dataset.a.coords) == {'chain', 'draw'}
+        assert set(dataset.b.coords) == {'chain', 'draw', 'b1'}
+        assert set(dataset.c.coords) == {'chain', 'draw', 'c1', 'c2'}
+
+    def test_missing_dims(self):
+        # missing dims
+        coords = {
+            'c_dim_0' : np.arange(3),
+            'c_dim_1' : np.arange(4),
+            'b_dim_0' : np.arange(10)
+        }
+        dataset = convert_to_dataset(self.datadict,
+                                     coords=coords,
+                                     dims=None)
+        assert set(dataset.data_vars) == {'a', 'b', 'c'}
+        assert set(dataset.coords) == {'chain', 'draw', 'c_dim_0', 'c_dim_1', 'b_dim_0'}
+
+        assert set(dataset.a.coords) == {'chain', 'draw'}
+        assert set(dataset.b.coords) == {'chain', 'draw', 'b_dim_0'}
+        assert set(dataset.c.coords) == {'chain', 'draw', 'c_dim_0', 'c_dim_1'}
+
+    def test_skip_dim_0(self):
+        dims = {'c' : [None, 'c2']}
+        coords = {
+            'c_dim_0' : np.arange(3),
+            'c2' : np.arange(4),
+            'b_dim_0' : np.arange(10)
+        }
+        dataset = convert_to_dataset(self.datadict,
+                                     coords=coords,
+                                     dims=dims)
+        assert set(dataset.data_vars) == {'a', 'b', 'c'}
+        assert set(dataset.coords) == {'chain', 'draw', 'c_dim_0', 'c2', 'b_dim_0'}
+
+        assert set(dataset.a.coords) == {'chain', 'draw'}
+        assert set(dataset.b.coords) == {'chain', 'draw', 'b_dim_0'}
+        assert set(dataset.c.coords) == {'chain', 'draw', 'c_dim_0', 'c2'}
+
 
 def test_dict_to_dataset():
     datadict = {
@@ -61,58 +128,6 @@ def test_dict_to_dataset():
     assert set(dataset.a.coords) == {'chain', 'draw'}
     assert set(dataset.b.coords) == {'chain', 'draw', 'c'}
 
-def test_missing_coords_or_dims():
-    datadict = {
-        'a': np.random.randn(100),
-        'b': np.random.randn(1, 100, 10),
-        'c': np.random.randn(1, 100, 3, 4),
-    }
-    # use all
-    coords = {'c1' : np.arange(3), 'c2' : np.arange(4), 'b1' : np.arange(10)}
-    dims = {'b' : ['b1'], 'c' : ['c1', 'c2']}
-    dataset = convert_to_dataset(datadict,
-                                 coords=coords,
-                                 dims=dims)
-    assert set(dataset.data_vars) == {'a', 'b', 'c'}
-    assert set(dataset.coords) == {'chain', 'draw', 'c1', 'c2', 'b1'}
-
-    assert set(dataset.a.coords) == {'chain', 'draw'}
-    assert set(dataset.b.coords) == {'chain', 'draw', 'b1'}
-    assert set(dataset.c.coords) == {'chain', 'draw', 'c1', 'c2'}
-    # missing coords
-    dims = {"b" : ["b1"], "c" : ["c1", "c2"]}
-    dataset = convert_to_dataset(datadict,
-                                 coords=None,
-                                 dims=dims)
-    assert set(dataset.data_vars) == {'a', 'b', 'c'}
-    assert set(dataset.coords) == {'chain', 'draw', 'c1', 'c2', 'b1'}
-
-    assert set(dataset.a.coords) == {'chain', 'draw'}
-    assert set(dataset.b.coords) == {'chain', 'draw', 'b1'}
-    assert set(dataset.c.coords) == {'chain', 'draw', 'c1', 'c2'}
-    # missing dims
-    coords = {'c_dim_0' : np.arange(3), 'c_dim_1' : np.arange(4), 'b_dim_0' : np.arange(10)}
-    dataset = convert_to_dataset(datadict,
-                                 coords=coords,
-                                 dims=None)
-    assert set(dataset.data_vars) == {'a', 'b', 'c'}
-    assert set(dataset.coords) == {'chain', 'draw', 'c_dim_0', 'c_dim_1', 'b_dim_0'}
-
-    assert set(dataset.a.coords) == {'chain', 'draw'}
-    assert set(dataset.b.coords) == {'chain', 'draw', 'b_dim_0'}
-    assert set(dataset.c.coords) == {'chain', 'draw', 'c_dim_0', 'c_dim_1'}
-    # dims skipping dimension 0
-    dims = {'c' : [None, 'c2']}
-    coords = {'c_dim_0' : np.arange(3), 'c2' : np.arange(4), 'b_dim_0' : np.arange(10)}
-    dataset = convert_to_dataset(datadict,
-                                 coords=coords,
-                                 dims=None)
-    assert set(dataset.data_vars) == {'a', 'b', 'c'}
-    assert set(dataset.coords) == {'chain', 'draw', 'c_dim_0', 'c2', 'b_dim_0'}
-
-    assert set(dataset.a.coords) == {'chain', 'draw'}
-    assert set(dataset.b.coords) == {'chain', 'draw', 'b_dim_0'}
-    assert set(dataset.c.coords) == {'chain', 'draw', 'c_dim_0', 'c2'}
 
 
 def test_convert_to_dataset_idempotent():

--- a/arviz/tests/test_xarray_utils.py
+++ b/arviz/tests/test_xarray_utils.py
@@ -61,6 +61,59 @@ def test_dict_to_dataset():
     assert set(dataset.a.coords) == {'chain', 'draw'}
     assert set(dataset.b.coords) == {'chain', 'draw', 'c'}
 
+def test_missing_coords_or_dims():
+    datadict = {
+        'a': np.random.randn(100),
+        'b': np.random.randn(1, 100, 10),
+        'c': np.random.randn(1, 100, 3, 4),
+    }
+    # use all
+    coords = {'c1' : np.arange(3), 'c2' : np.arange(4), 'b1' : np.arange(10)}
+    dims = {'b' : ['b1'], 'c' : ['c1', 'c2']}
+    dataset = convert_to_dataset(datadict,
+                                 coords=coords,
+                                 dims=dims)
+    assert set(dataset.data_vars) == {'a', 'b', 'c'}
+    assert set(dataset.coords) == {'chain', 'draw', 'c1', 'c2', 'b1'}
+
+    assert set(dataset.a.coords) == {'chain', 'draw'}
+    assert set(dataset.b.coords) == {'chain', 'draw', 'b1'}
+    assert set(dataset.c.coords) == {'chain', 'draw', 'c1', 'c2'}
+    # missing coords
+    dims = {"b" : ["b1"], "c" : ["c1", "c2"]}
+    dataset = convert_to_dataset(datadict,
+                                 coords=None,
+                                 dims=dims)
+    assert set(dataset.data_vars) == {'a', 'b', 'c'}
+    assert set(dataset.coords) == {'chain', 'draw', 'c1', 'c2', 'b1'}
+
+    assert set(dataset.a.coords) == {'chain', 'draw'}
+    assert set(dataset.b.coords) == {'chain', 'draw', 'b1'}
+    assert set(dataset.c.coords) == {'chain', 'draw', 'c1', 'c2'}
+    # missing dims
+    coords = {'c_dim_0' : np.arange(3), 'c_dim_1' : np.arange(4), 'b_dim_0' : np.arange(10)}
+    dataset = convert_to_dataset(datadict,
+                                 coords=coords,
+                                 dims=None)
+    assert set(dataset.data_vars) == {'a', 'b', 'c'}
+    assert set(dataset.coords) == {'chain', 'draw', 'c_dim_0', 'c_dim_1', 'b_dim_0'}
+
+    assert set(dataset.a.coords) == {'chain', 'draw'}
+    assert set(dataset.b.coords) == {'chain', 'draw', 'b_dim_0'}
+    assert set(dataset.c.coords) == {'chain', 'draw', 'c_dim_0', 'c_dim_1'}
+    # dims skipping dimension 0
+    dims = {'c' : [None, 'c2']}
+    coords = {'c_dim_0' : np.arange(3), 'c2' : np.arange(4), 'b_dim_0' : np.arange(10)}
+    dataset = convert_to_dataset(datadict,
+                                 coords=coords,
+                                 dims=None)
+    assert set(dataset.data_vars) == {'a', 'b', 'c'}
+    assert set(dataset.coords) == {'chain', 'draw', 'c_dim_0', 'c2', 'b_dim_0'}
+
+    assert set(dataset.a.coords) == {'chain', 'draw'}
+    assert set(dataset.b.coords) == {'chain', 'draw', 'b_dim_0'}
+    assert set(dataset.c.coords) == {'chain', 'draw', 'c_dim_0', 'c2'}
+
 
 def test_convert_to_dataset_idempotent():
     first = convert_to_dataset(np.random.randn(100))

--- a/arviz/utils/xarray_utils.py
+++ b/arviz/utils/xarray_utils.py
@@ -180,9 +180,12 @@ def numpy_to_data_array(ary, *, var_name='data', coords=None, dims=None):
     if coords is None:
         coords = {}
     for idx, dim_len in enumerate(shape):
-        if len(dims) < idx+1 or dims[idx] is None:
+        if (len(dims) < idx+1) or (dims[idx] is None):
             dim_name = '{var_name}_dim_{idx}'.format(var_name=var_name, idx=idx)
-            dims.append(dim_name)
+            if len(dims) < idx + 1:
+                dims.append(dim_name)
+            else:
+                dims[idx] = dim_name
         dim_name = dims[idx]
         if dim_name not in coords:
             coords[dim_name] = np.arange(dim_len)

--- a/arviz/utils/xarray_utils.py
+++ b/arviz/utils/xarray_utils.py
@@ -1,6 +1,7 @@
 """Utilities for converting and working with netcdf and xarray data."""
 import re
 import warnings
+from copy import deepcopy
 
 import numpy as np
 import xarray as xr
@@ -160,6 +161,9 @@ def numpy_to_data_array(ary, *, var_name='data', coords=None, dims=None):
     xr.DataArray
         Will have the same data as passed, but with coordinates and dimensions
     """
+    # manage and transform copies
+    coords = deepcopy(coords)
+    dims = deepcopy(dims)
     default_dims = ["chain", "draw"]
     ary = np.atleast_2d(ary)
     n_chains, n_samples, *shape = ary.shape


### PR DESCRIPTION
Enable more flexible usage for dims and coords.

This PR enables that user can input names only to specific dims or coords.
If dims is None or not defined, it will use the default name, and if coord is not defined, it creates the default coord.