### PR TITLE
Update Pairplot example and spacing

### DIFF
--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -111,7 +111,7 @@ def pairplot(data, var_names=None, coords=None, figsize=None, textsize=None, kin
 
     if gs is None and ax is None:
         plt.figure(figsize=figsize)
-        gs = gridspec.GridSpec(numvars - 1, numvars - 1)
+        gs = gridspec.GridSpec(numvars - 1, numvars - 1, wspace=0.05, hspace=0.05)
 
         axs = []
         for i in range(0, numvars - 1):

--- a/examples/pairplot.py
+++ b/examples/pairplot.py
@@ -5,24 +5,12 @@ Pair Plot
 _thumb: .2, .5
 """
 import arviz as az
-import numpy as np
-import pymc3 as pm
 
 az.style.use('arviz-darkgrid')
 
-# Data of the Eight Schools Model
-J = 8
-y = np.array([28.,  8., -3.,  7., -1.,  1., 18., 12.])
-sigma = np.array([15., 10., 16., 11.,  9., 11., 10., 18.])
+centered = az.load_arviz_data('centered_eight')
+
+coords = {'school': ["Choate", "Deerfield"]}
+az.pairplot(centered, var_names=['theta', "mu"], coords=None, divergences=True)
 
 
-with pm.Model() as centered_eight:
-    mu = pm.Normal('mu', mu=0, sd=5)
-    tau = pm.HalfCauchy('tau', beta=5)
-    theta = pm.Normal('theta', mu=mu, sd=tau, shape=J)
-    obs = pm.Normal('obs', mu=theta, sd=sigma, observed=y)
-    centered_eight_trace = pm.sample()
-
-az.pairplot(centered_eight_trace,
-            var_names=['theta__0', 'theta__1', 'tau', 'mu'],
-            divergences=True)


### PR DESCRIPTION
Fixes https://github.com/arviz-devs/arviz/issues/212

Example Plots, It's easy enough to change the spacing if someone has a strong preference.

One thing to note is that there's some strange behavior with the y axis label positions. If this is problematic I create an issue.

![pairplot_1](https://user-images.githubusercontent.com/7213793/45250467-9c587600-b2e8-11e8-8059-ec9df3029911.png)
![pairplot_2](https://user-images.githubusercontent.com/7213793/45250468-9c587600-b2e8-11e8-8e28-5be897350fe2.png)
![pairplot_3](https://user-images.githubusercontent.com/7213793/45250469-9c587600-b2e8-11e8-9363-03ed6b548af5.png)
![pairplot_4](https://user-images.githubusercontent.com/7213793/45250470-9c587600-b2e8-11e8-99ed-7014a974dee6.png)
![pairplot_5](https://user-images.githubusercontent.com/7213793/45250471-9c587600-b2e8-11e8-94f8-8ef25dd6ef4d.png)
![pairplot_6](https://user-images.githubusercontent.com/7213793/45250472-9c587600-b2e8-11e8-9e2e-5bd530c99637.png)
![pairplot_7](https://user-images.githubusercontent.com/7213793/45250473-9cf10c80-b2e8-11e8-9f9e-39aa6aa91c36.png)
![pairplot_8](https://user-images.githubusercontent.com/7213793/45250474-9cf10c80-b2e8-11e8-9290-6874b19abc81.png)
