### PR TITLE
Use coordinates in pairplot

### DIFF
--- a/examples/pairplot.py
+++ b/examples/pairplot.py
@@ -10,7 +10,7 @@ az.style.use('arviz-darkgrid')
 
 centered = az.load_arviz_data('centered_eight')
 
-coords = {'school': ["Choate", "Deerfield"]}
-az.pairplot(centered, var_names=['theta', "mu"], coords=None, divergences=True)
+coords = {'school': ['Choate', 'Deerfield']}
+az.pairplot(centered, var_names=['theta', 'mu', 'tau'], coords=coords, divergences=True)
 
 


### PR DESCRIPTION
Coordinates were defined, but not used in the example!