### PR TITLE
[WIP] Break axes labels at selection

### DIFF
--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -155,7 +155,7 @@ def make_label(var_name, selection):
         A text representation of the label
     """
     if selection:
-        return '{} ({})'.format(var_name, selection_to_string(selection))
+        return '{} \n ({})'.format(var_name, selection_to_string(selection))
     return '{}'.format(var_name)
 
 

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -135,7 +135,7 @@ def selection_to_string(selection):
     str
         key1: value1, key2: value2, ...
     """
-    return ', '.join(['{}: {}'.format(k, v) for k, v in selection.items()])
+    return ', '.join(['{}'.format(v) for _, v in selection.items()])
 
 
 def make_label(var_name, selection):


### PR DESCRIPTION
Per at @ahartikainen comments make the labels a little nicer.

Still not great, but for a two character change I think this is moving the labels in the right direction.

I haven't checked all the plots yet but below are examples from pairplot.  They're getting cut off a little but If they generally look good I can fix this and check more plots.

![hexpairplot_1_](https://user-images.githubusercontent.com/7213793/45277248-b9717e00-b47b-11e8-8667-91ca028bcb1f.png)
![hexpairplot_2_](https://user-images.githubusercontent.com/7213793/45277249-b9717e00-b47b-11e8-8806-d222126e6b5b.png)
![hexpairplot_3_](https://user-images.githubusercontent.com/7213793/45277250-ba0a1480-b47b-11e8-9beb-3d9f3123216d.png)
![hexpairplot_4_](https://user-images.githubusercontent.com/7213793/45277251-ba0a1480-b47b-11e8-8826-f57cc5ec15ba.png)
![hexpairplot_5_](https://user-images.githubusercontent.com/7213793/45277252-ba0a1480-b47b-11e8-8673-8299f59886f0.png)
![hexpairplot_6_](https://user-images.githubusercontent.com/7213793/45277253-ba0a1480-b47b-11e8-84ad-f3019bd82ed4.png)
![hexpairplot_7_](https://user-images.githubusercontent.com/7213793/45277254-ba0a1480-b47b-11e8-88a3-dd090a205fd1.png)
![hexpairplot_8_](https://user-images.githubusercontent.com/7213793/45277255-ba0a1480-b47b-11e8-8f3d-b7820e76d382.png)
