### PR TITLE
Add log_like to pymc3 sample_stats

### DIFF
--- a/arviz/utils/xarray_utils.py
+++ b/arviz/utils/xarray_utils.py
@@ -271,6 +271,41 @@ class PyMC3Converter:
         self.dims = dims
 
     @requires('trace')
+    def _extract_log_likelihood(self):
+        """Compute log likelihood of each observation.
+
+        Return None if there is not exactly 1 observed random variable.
+        """
+        # This next line is brittle and may not work forever, but is a secret
+        # way to access the model from the trace.
+        model = self.trace._straces[0].model # pylint: disable=protected-access
+        if len(model.observed_RVs) != 1:
+            return None, None
+        else:
+            if self.dims is not None:
+                coord_name = self.dims.get(model.observed_RVs[0].name)
+            else:
+                coord_name = None
+
+        cached = [(var, var.logp_elemwise) for var in model.observed_RVs]
+        def log_likelihood_vals_point(point):
+            """Compute log likelihood for each observed point."""
+            logp_vals = []
+            for var, logp in cached:
+                logp = logp(point)
+                if var.missing_values:
+                    logp = logp[~var.observations.mask]
+                logp_vals.append(logp.ravel())
+
+            return np.concatenate(logp_vals)
+
+        chain_likelihoods = []
+        for chain in self.trace.chains:
+            logp = (log_likelihood_vals_point(point) for point in self.trace.points([chain]))
+            chain_likelihoods.append(np.stack(logp))
+        return np.stack(chain_likelihoods), coord_name
+
+    @requires('trace')
     def posterior_to_xarray(self):
         """Convert the posterior to an xarray dataset."""
         var_names = pm.utils.get_default_varnames(self.trace.varnames, include_transformed=False)
@@ -289,7 +324,14 @@ class PyMC3Converter:
         for stat in self.trace.stat_names:
             name = rename_key.get(stat, stat)
             data[name] = np.array(self.trace.get_sampler_stats(stat, combine=False))
-        return dict_to_dataset(data)
+        log_likelihood, dims = self._extract_log_likelihood()
+        if log_likelihood is not None:
+            data['log_likelihood'] = log_likelihood
+            dims = {'log_likelihood': dims}
+        else:
+            dims = None
+
+        return dict_to_dataset(data, dims=dims, coords=self.coords)
 
     @requires('posterior_predictive')
     def posterior_predictive_to_xarray(self):

--- a/arviz/utils/xarray_utils.py
+++ b/arviz/utils/xarray_utils.py
@@ -290,19 +290,18 @@ class PyMC3Converter:
         cached = [(var, var.logp_elemwise) for var in model.observed_RVs]
         def log_likelihood_vals_point(point):
             """Compute log likelihood for each observed point."""
-            logp_vals = []
-            for var, logp in cached:
-                logp = logp(point)
+            log_like_vals = []
+            for var, log_like in cached:
+                log_like_val = log_like(point)
                 if var.missing_values:
-                    logp = logp[~var.observations.mask]
-                logp_vals.append(logp.ravel())
-
-            return np.concatenate(logp_vals)
+                    log_like_val = log_like_val[~var.observations.mask]
+                log_like_vals.append(log_like_val.ravel())
+            return np.concatenate(log_like_vals)
 
         chain_likelihoods = []
         for chain in self.trace.chains:
-            logp = (log_likelihood_vals_point(point) for point in self.trace.points([chain]))
-            chain_likelihoods.append(np.stack(logp))
+            log_like = (log_likelihood_vals_point(point) for point in self.trace.points([chain]))
+            chain_likelihoods.append(np.stack(log_like))
         return np.stack(chain_likelihoods), coord_name
 
     @requires('trace')

--- a/schema.md
+++ b/schema.md
@@ -19,21 +19,8 @@ For each dimension, we store a corresponding variable here, that contains the la
 Each backend can store a representation of the model in here. (I guess
 source code for stan, no clue for pymc3 at this point.)
 
-/stats
-
-/stats/rhat
-
-/stats/rhat/var1
-For each variable, the rhat.
-
-/stats/effective_n
-
-/stats/effective_n/var1
-For each variable, the effective_n
-
-/stats/treedepth?
-/stats/accept_stat?
-/stats/diverging?
+/sample_stats
+Statistics computed while sampling, like step size (step_size), depth, diverging, energy (for HMC), log probability (lp), and log likelihood (log_likelihood).
 
 /initial_point
     One point in parameter space for each chain, where that chain started.


### PR DESCRIPTION
I pulled this out of a larger PR I am working on to port diagnostics and stats to work with xarray. This takes `utils.log_post_trace`, and extracts it into the xarray object when reading a pymc3 object in.  @ahartikainen perhaps this could be added to `pystan` by having an argument giving the name of the generated quantity?

This implementation takes the coordinates for the observed variable, if the exist, and apply it to the likelihood.  For example, in the 8 schools model, the likelihood is 4 x 500 x 8 (chain x draw x school).

![image](https://user-images.githubusercontent.com/2295568/45463255-5ed55d80-b6d9-11e8-92e3-2dd89562bd96.png)
