### PR TITLE
expose fast_kde

### DIFF
--- a/arviz/plots/__init__.py
+++ b/arviz/plots/__init__.py
@@ -4,7 +4,7 @@ from .compareplot import compareplot
 from .densityplot import densityplot
 from .energyplot import energyplot
 from .forestplot import forestplot
-from .kdeplot import kdeplot
+from .kdeplot import kdeplot, _fast_kde, _fast_kde_2d
 from .parallelplot import parallelplot
 from .posteriorplot import posteriorplot
 from .traceplot import traceplot

--- a/arviz/plots/densityplot.py
+++ b/arviz/plots/densityplot.py
@@ -2,7 +2,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
 
-from .kdeplot import fast_kde
+from .kdeplot import _fast_kde
 from ..stats import hpd
 from ..utils import convert_to_dataset
 from .plot_utils import _scale_text, make_label, xarray_var_iter
@@ -154,7 +154,7 @@ def _d_helper(vec, vname, color, bw, textsize, linewidth, markersize, credible_i
     ax : matplotlib axes
     """
     if vec.dtype.kind == 'f':
-        density, lower, upper = fast_kde(vec, bw=bw)
+        density, lower, upper = _fast_kde(vec, bw=bw)
         x = np.linspace(lower, upper, len(density))
         hpd_ = hpd(vec, credible_interval)
         cut = (x >= hpd_[0]) & (x <= hpd_[1])

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -9,7 +9,7 @@ from ..stats.diagnostics import _get_neff, _get_rhat
 from ..stats import hpd
 from .plot_utils import _scale_text, xarray_var_iter, make_label
 from ..utils import convert_to_dataset
-from .kdeplot import fast_kde
+from .kdeplot import _fast_kde
 
 
 def pairwise(iterable):
@@ -425,7 +425,7 @@ class VarHandler():
             yvals.append(y)
             colors.append(color)
             values = values.flatten()
-            density, lower, upper = fast_kde(values)
+            density, lower, upper = _fast_kde(values)
             xvals.append(np.linspace(lower, upper, len(density)))
             pdfs.append(density)
 

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -87,7 +87,7 @@ def kdeplot(values, values2=None, cumulative=False, rug=False, label=None, bw=4.
         plot_kwargs.setdefault('linewidth', linewidth)
         rug_kwargs.setdefault('markersize', 2 * markersize)
 
-        density, lower, upper = fast_kde(values, cumulative, bw)
+        density, lower, upper = _fast_kde(values, cumulative, bw)
         x = np.linspace(lower, upper, len(density))
         fill_func = ax.fill_between
         fill_x, fill_y = x, density
@@ -115,7 +115,7 @@ def kdeplot(values, values2=None, cumulative=False, rug=False, label=None, bw=4.
 
         gridsize = (128, 128) if contour else (256, 256)
 
-        density, xmin, xmax, ymin, ymax = fast_kde_2d(values, values2, gridsize=gridsize)
+        density, xmin, xmax, ymin, ymax = _fast_kde_2d(values, values2, gridsize=gridsize)
         g_s = complex(gridsize[0])
         x_x, y_y = np.mgrid[xmin:xmax:g_s, ymin:ymax:g_s]
 
@@ -133,7 +133,7 @@ def kdeplot(values, values2=None, cumulative=False, rug=False, label=None, bw=4.
     return ax
 
 
-def fast_kde(x, cumulative=False, bw=4.5):
+def _fast_kde(x, cumulative=False, bw=4.5):
     """Fast Fourier transform-based Gaussian kernel density estimate (KDE).
 
     The code was adapted from https://github.com/mfouesneau/faststats
@@ -184,7 +184,7 @@ def fast_kde(x, cumulative=False, bw=4.5):
     return density, xmin, xmax
 
 
-def fast_kde_2d(x, y, gridsize=(128, 128), circular=False):
+def _fast_kde_2d(x, y, gridsize=(128, 128), circular=False):
     """
     2D fft-based Gaussian kernel density estimate (KDE).
 

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -2,7 +2,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy.stats import mode
-from .kdeplot import kdeplot, fast_kde
+from .kdeplot import kdeplot, _fast_kde
 from ..stats import hpd
 from ..utils import convert_to_dataset
 from .plot_utils import xarray_var_iter, _scale_text, make_label, default_grid, _create_axes_grid
@@ -219,7 +219,7 @@ def _plot_posterior_op(values, var_name, selection, ax, bw, linewidth, bins, kin
             point_value = values.mean()
         elif point_estimate == 'mode':
             if isinstance(values[0], float):
-                density, lower, upper = fast_kde(values, bw=bw)
+                density, lower, upper = _fast_kde(values, bw=bw)
                 x = np.linspace(lower, upper, len(density))
                 point_value = x[np.argmax(density)]
             else:

--- a/arviz/plots/violintraceplot.py
+++ b/arviz/plots/violintraceplot.py
@@ -2,7 +2,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
 
-from .kdeplot import fast_kde
+from .kdeplot import _fast_kde
 from .plot_utils import get_bins, _scale_text, xarray_var_iter, make_label
 from ..stats import hpd
 from ..utils import convert_to_dataset
@@ -93,7 +93,7 @@ def violintraceplot(data, var_names=None, quartiles=True, credible_interval=0.94
 
 def _violinplot(val, shade, bw, ax, **kwargs_shade):
     """Auxiliary function to plot violinplots."""
-    density, low_b, up_b = fast_kde(val, bw=bw)
+    density, low_b, up_b = _fast_kde(val, bw=bw)
     x = np.linspace(low_b, up_b, len(density))
 
     x = np.concatenate([x, x[::-1]])


### PR DESCRIPTION
Sometimes I find useful to have access to `fast_kde`, at the sometime it should not be of interested to most users hence the underscore.