### PR TITLE
Add nicer exception message for mistake in coords argument

### DIFF
--- a/arviz/plots/jointplot.py
+++ b/arviz/plots/jointplot.py
@@ -4,7 +4,7 @@ from matplotlib.ticker import NullFormatter
 
 from .kdeplot import kdeplot
 from ..utils import convert_to_dataset
-from .plot_utils import _scale_text, get_bins, xarray_var_iter, make_label
+from .plot_utils import _scale_text, get_bins, xarray_var_iter, make_label, get_coords
 
 
 def jointplot(data, var_names=None, coords=None, figsize=None, textsize=None, kind='scatter',
@@ -54,7 +54,7 @@ def jointplot(data, var_names=None, coords=None, figsize=None, textsize=None, ki
     if coords is None:
         coords = {}
 
-    plotters = list(xarray_var_iter(data.sel(**coords), var_names=var_names, combined=True))
+    plotters = list(xarray_var_iter(get_coords(data, coords), var_names=var_names, combined=True))
 
     if len(plotters) != 2:
         raise Exception(

--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -7,7 +7,7 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from .kdeplot import kdeplot
 from ..utils import convert_to_dataset
-from .plot_utils import _scale_text, xarray_to_nparray
+from .plot_utils import _scale_text, xarray_to_nparray, get_coords
 
 
 def pairplot(data, var_names=None, coords=None, figsize=None, textsize=None, kind='scatter',
@@ -72,7 +72,7 @@ def pairplot(data, var_names=None, coords=None, figsize=None, textsize=None, kin
 
     # Get posterior draws and combine chains
     posterior_data = convert_to_dataset(data, group='posterior')
-    _var_names, _posterior = xarray_to_nparray(posterior_data.sel(**coords),
+    _var_names, _posterior = xarray_to_nparray(get_coords(posterior_data, coords),
                                                var_names=var_names, combined=True)
 
     # Get diverging draws and combine chains

--- a/arviz/plots/parallelplot.py
+++ b/arviz/plots/parallelplot.py
@@ -2,7 +2,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 from ..utils import convert_to_dataset
-from .plot_utils import _scale_text, xarray_to_nparray
+from .plot_utils import _scale_text, xarray_to_nparray, get_coords
 
 
 def parallelplot(data, var_names=None, coords=None, figsize=None, textsize=None, legend=True,
@@ -44,15 +44,16 @@ def parallelplot(data, var_names=None, coords=None, figsize=None, textsize=None,
     if coords is None:
         coords = {}
 
-    # Get posterior draws and combine chains
-    posterior_data = convert_to_dataset(data, group='posterior')
-    _var_names, _posterior = xarray_to_nparray(posterior_data.sel(**coords), var_names=var_names,
-                                               combined=True)
-
     # Get diverging draws and combine chains
     divergent_data = convert_to_dataset(data, group='sample_stats')
     _, diverging_mask = xarray_to_nparray(divergent_data, var_names=('diverging',), combined=True)
     diverging_mask = np.squeeze(diverging_mask)
+
+    # Get posterior draws and combine chains
+    posterior_data = convert_to_dataset(data, group='posterior')
+    _var_names, _posterior = xarray_to_nparray(get_coords(posterior_data, coords),
+                                               var_names=var_names, combined=True)
+
 
     if len(_var_names) < 2:
         raise ValueError('This plot needs at least two variables')

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -247,3 +247,26 @@ def xarray_to_nparray(data, *, var_names=None, combined=True):
         unpacked_var_names.append(make_label(var_name, selection))
 
     return unpacked_var_names, np.array(unpacked_data)
+
+
+def get_coords(data, coords):
+    """Subselects xarray dataset object to provided coords. Raises exception if fails
+
+    Raises
+    ------
+    ValueError
+        If coords name or dims are not available in data
+
+    Returns
+    -------
+    data: xarray
+        xarray.Dataset object
+    """
+    try:
+        return data.sel(**coords)
+
+    except ValueError as err:
+        raise ValueError("Verify coords keys. {}".format(err))
+
+    except KeyError as err:
+        raise KeyError("Verify coords values. {}".format(err))

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -255,7 +255,10 @@ def get_coords(data, coords):
     Raises
     ------
     ValueError
-        If coords name or dims are not available in data
+        If coords name are not available in data
+
+    KeyError
+        If coords dims are not available in data
 
     Returns
     -------

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -250,7 +250,7 @@ def xarray_to_nparray(data, *, var_names=None, combined=True):
 
 
 def get_coords(data, coords):
-    """Subselects xarray dataset object to provided coords. Raises exception if fails
+    """Subselects xarray dataset object to provided coords. Raises exception if fails.
 
     Raises
     ------
@@ -268,8 +268,11 @@ def get_coords(data, coords):
     try:
         return data.sel(**coords)
 
-    except ValueError as err:
-        raise ValueError("Verify coords keys. {}".format(err))
+    except ValueError:
+        invalid_coords = set(coords.keys()) - set(data.coords.keys())
+        raise ValueError("Coords {} are invalid coordinate keys".format(invalid_coords))
 
     except KeyError as err:
-        raise KeyError("Verify coords values. {}".format(err))
+        raise KeyError(("Coords should follow mapping format {{coord_name:[dim1, dim2]}}. "
+                        "Check that coords structure is correct and"
+                        " dimensions are valid. {}").format(err))

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -5,7 +5,8 @@ from scipy.stats import mode
 from .kdeplot import kdeplot, _fast_kde
 from ..stats import hpd
 from ..utils import convert_to_dataset
-from .plot_utils import xarray_var_iter, _scale_text, make_label, default_grid, _create_axes_grid
+from .plot_utils import (xarray_var_iter, _scale_text, make_label, default_grid, _create_axes_grid,
+                         get_coords)
 
 
 def posteriorplot(data, var_names=None, coords=None, figsize=None, textsize=None,
@@ -132,7 +133,7 @@ def posteriorplot(data, var_names=None, coords=None, figsize=None, textsize=None
     if coords is None:
         coords = {}
 
-    plotters = list(xarray_var_iter(data.sel(**coords), var_names=var_names, combined=True))
+    plotters = list(xarray_var_iter(get_coords(data, coords), var_names=var_names, combined=True))
     length_plotters = len(plotters)
     rows, cols = default_grid(length_plotters)
 

--- a/arviz/plots/traceplot.py
+++ b/arviz/plots/traceplot.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from .kdeplot import kdeplot
 from ..utils import convert_to_dataset
-from .plot_utils import _scale_text, get_bins, xarray_var_iter, make_label
+from .plot_utils import _scale_text, get_bins, xarray_var_iter, make_label, get_coords
 
 
 def traceplot(data, var_names=None, coords=None, figsize=None, textsize=None, lines=None,
@@ -78,7 +78,7 @@ def traceplot(data, var_names=None, coords=None, figsize=None, textsize=None, li
     if lines is None:
         lines = ()
 
-    plotters = list(xarray_var_iter(data.sel(**coords), var_names=var_names, combined=True))
+    plotters = list(xarray_var_iter(get_coords(data, coords), var_names=var_names, combined=True))
 
     if figsize is None:
         figsize = (12, len(plotters) * 2)

--- a/arviz/tests/test_plotutils.py
+++ b/arviz/tests/test_plotutils.py
@@ -79,6 +79,5 @@ class TestCoordsExceptions:
         _, _, data = sample_dataset
         coords = {"draw"}
 
-        with pytest.raises(TypeError) as err:
+        with pytest.raises(TypeError):
             get_coords(data, coords)
-

--- a/arviz/tests/test_plotutils.py
+++ b/arviz/tests/test_plotutils.py
@@ -3,7 +3,7 @@ import numpy as np
 import xarray as xr
 import pytest
 
-from ..plots.plot_utils import xarray_to_nparray, xarray_var_iter
+from ..plots.plot_utils import xarray_to_nparray, xarray_var_iter, get_coords
 
 
 @pytest.fixture(scope='function')
@@ -51,3 +51,25 @@ def test_xarray_var_iter_ordering_uncombined(sample_dataset):  # pylint: disable
     var_names = [(var, selection) for (var, selection, _) in xarray_var_iter(data, var_names=None)]
     assert var_names == [("mu", {"chain": 0}), ("mu", {"chain": 1}),
                          ("tau", {"chain": 0}), ("tau", {"chain": 1})]
+
+
+class TestCoordsExceptions:
+    def test_invalid_coord_name(self, sample_dataset):  # pylint: disable=invalid-name
+        """Assert that nicer exception appears when user enters wrong coords name"""
+        _, _, data = sample_dataset
+        coords = {"NOT_A_COORD_NAME": [1]}
+
+        with pytest.raises(ValueError) as err:
+            get_coords(data, coords)
+
+        assert "Verify coords keys" in str(err)
+
+    def test_invalid_coord_value(self, sample_dataset):  # pylint: disable=invalid-name
+        """Assert that nicer exception appears when user enters wrong coords value"""
+        _, _, data = sample_dataset
+        coords = {"draw": [1234567]}
+
+        with pytest.raises(KeyError) as err:
+            get_coords(data, coords)
+
+        assert "Verify coords values" in str(err)

--- a/arviz/tests/test_plotutils.py
+++ b/arviz/tests/test_plotutils.py
@@ -62,7 +62,7 @@ class TestCoordsExceptions:
         with pytest.raises(ValueError) as err:
             get_coords(data, coords)
 
-        assert "Verify coords keys" in str(err)
+        assert "Coords {'NOT_A_COORD_NAME'} are invalid coordinate keys" in str(err)
 
     def test_invalid_coord_value(self, sample_dataset):  # pylint: disable=invalid-name
         """Assert that nicer exception appears when user enters wrong coords value"""
@@ -72,4 +72,13 @@ class TestCoordsExceptions:
         with pytest.raises(KeyError) as err:
             get_coords(data, coords)
 
-        assert "Verify coords values" in str(err)
+        assert "Coords should follow mapping format {coord_name:[dim1, dim2]}" in str(err)
+
+    def test_invalid_coord_structure(self, sample_dataset):  # pylint: disable=invalid-name
+        """Assert that nicer exception appears when user enters wrong coords datatype"""
+        _, _, data = sample_dataset
+        coords = {"draw"}
+
+        with pytest.raises(TypeError) as err:
+            get_coords(data, coords)
+


### PR DESCRIPTION
Fix for https://github.com/arviz-devs/arviz/issues/213

If you guys like how this looks I'll change all the other plots to this pattern. Did a couple as an example


```
# Sample code
import arviz as az
data = az.load_arviz_data('non_centered_eight')
az.traceplot(data, var_names=('theta_t'), coords={'theta_t_dim_0': [0, 1, 100]})
az.traceplot(data, var_names=('theta_t'), coords={'theta_t_dim_0_t': [0, 1]})
```