### PR TITLE
Allow observed data to inherit dims

### DIFF
--- a/arviz/data/convert/from_pystan.py
+++ b/arviz/data/convert/from_pystan.py
@@ -183,6 +183,10 @@ class PyStanConverter:
     @requires('observed_data')
     def observed_data_to_xarray(self):
         """Convert observed data to xarray."""
+        if self.dims is None:
+            dims = {}
+        else:
+            dims = self.dims
         if isinstance(self.observed_data, str):
             observed_names = [self.observed_data]
         else:
@@ -190,8 +194,9 @@ class PyStanConverter:
         observed_data = {}
         for key in observed_names:
             vals = np.atleast_1d(self.fit.data[key])
+            val_dims = dims.get(key)
             val_dims, coords = generate_dims_coords(vals.shape, key,
-                                                    dims=None, coords=self.coords)
+                                                    dims=val_dims, coords=self.coords)
             observed_data[key] = xr.DataArray(vals, dims=val_dims, coords=coords)
         return xr.Dataset(data_vars=observed_data)
 

--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -53,26 +53,36 @@ def pystan_noncentered_schools(data, draws, chains):
             int<lower=0> J;
             real y[J];
             real<lower=0> sigma[J];
-            }
+        }
 
-            parameters {
+        parameters {
             real mu;
             real<lower=0> tau;
             real theta_tilde[J];
-            }
+        }
 
-            transformed parameters {
+        transformed parameters {
             real theta[J];
             for (j in 1:J)
                 theta[j] = mu + tau * theta_tilde[j];
-            }
+        }
 
-            model {
+        model {
             mu ~ normal(0, 5);
             tau ~ cauchy(0, 5);
             theta_tilde ~ normal(0, 1);
             y ~ normal(theta, sigma);
-        }'''
+        }
+
+        generated quantities {
+            vector[J] log_lik;
+            vector[J] y_hat;
+            for (j in 1:J) {
+                log_lik[j] = normal_lpdf(y[j] | theta[j], sigma[j]);
+                y_hat[j] = normal_rng(theta[j], sigma[j]);
+            }
+        }
+    '''
     stan_model = pystan.StanModel(model_code=schools_code)
     fit = stan_model.sampling(data=data,
                               iter=draws,

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -209,7 +209,8 @@ class TestDictNetCDFUtils(CheckNetCDFUtils):
         stan_dict = stan_fit.extract(stan_fit.model_pars, permuted=False)
         cls.obj = {}
         for name, vals in stan_dict.items():
-            cls.obj[name] = np.swapaxes(vals, 0, 1)
+            if name not in {'y_hat', 'log_lik'}:  # extra vars
+                cls.obj[name] = np.swapaxes(vals, 0, 1)
 
 
 class TestPyMC3NetCDFUtils(CheckNetCDFUtils):
@@ -256,21 +257,19 @@ class TestPyStanNetCDFUtils(CheckNetCDFUtils):
         cls.model, cls.obj = load_cached_models(cls.draws, cls.chains)['pystan']
 
     def get_inference_data(self):
-        return pystan_to_inference_data(
-            fit=self.obj,
-            coords={'school': np.arange(self.data['J'])},
-            dims={'theta': ['school'], 'theta_tilde': ['school']},
-        )
+        return pystan_to_inference_data(fit=self.obj,
+                                        posterior_predictive='y_hat',
+                                        observed_data=['y'],
+                                        log_likelihood='log_lik',
+                                        coords={'school': np.arange(self.data['J'])},
+                                        dims={'theta': ['school'],
+                                              'y': ['school'],
+                                              'log_lik': ['school'],
+                                              'y_hat': ['school'],
+                                              'theta_tilde': ['school']
+                                              }
+                                        )
+
     def test_sampler_stats(self):
         inference_data = self.get_inference_data()
         assert hasattr(inference_data, 'sample_stats')
-
-
-class TestNumpyNetCDFUtils(CheckNetCDFUtils):
-
-    @classmethod
-    def setup_class(cls):
-        # Data of the Eight Schools Model
-        cls.data = eight_schools_params()
-        cls.draws, cls.chains = 500, 2
-        cls.model, cls.obj = load_cached_models(cls.draws, cls.chains)['pystan']

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -31,7 +31,9 @@ class SetupPlots(BaseArvizTest):
 class TestPlots(SetupPlots):
     def test_density_plot(self):
         for obj in (self.short_trace, self.fit):
-            assert densityplot(obj).shape == (18, 1)
+            axes = densityplot(obj)
+            assert axes.shape[0] >= 18
+            assert axes.shape[1] == 1
 
     @pytest.mark.parametrize('combined', [True, False])
     def test_traceplot(self, combined):
@@ -42,7 +44,9 @@ class TestPlots(SetupPlots):
 
     def test_autocorrplot(self):
         for obj in (self.short_trace, self.fit):
-            assert autocorrplot(obj).shape == (1, 36)
+            axes = autocorrplot(obj)
+            assert axes.shape[0] == 1
+            assert axes.shape[1] >= 36
 
     def test_forestplot(self):
         for obj in (self.short_trace, self.fit, [self.short_trace, self.fit]):
@@ -89,7 +93,7 @@ class TestPlots(SetupPlots):
     def test_violintraceplot(self):
         for obj in (self.short_trace, self.fit):
             axes = violintraceplot(obj)
-            assert axes.shape == (18,)
+            assert axes.shape[0] >= 18
 
 
 class TestPosteriorPlot(SetupPlots):


### PR DESCRIPTION
Using a pattern like

```python
data = az.pystan_to_inference_data(fit=fit, 
                                observed_data=['y'], 
                                coords={'school': schools},
                                dims={'theta': ['school'], 'y': ['school']})
```
throws an exception without this change.