### PR TITLE
Rename api for plots and io

### DIFF
--- a/arviz/data/convert/__init__.py
+++ b/arviz/data/convert/__init__.py
@@ -1,5 +1,5 @@
 """Code to convert data into xarray and netCDF format."""
 from .base import numpy_to_data_array, dict_to_dataset
 from .converters import convert_to_dataset, convert_to_inference_data
-from .from_pymc3 import pymc3_to_inference_data
-from .from_pystan import pystan_to_inference_data
+from .io_pymc3 import from_pymc3
+from .io_pystan import from_pystan

--- a/arviz/data/convert/converters.py
+++ b/arviz/data/convert/converters.py
@@ -4,12 +4,12 @@ import xarray as xr
 
 from ..inference_data import InferenceData
 from .base import dict_to_dataset
-from .from_pymc3 import pymc3_to_inference_data
-from .from_pystan import pystan_to_inference_data
+from .io_pymc3 import from_pymc3
+from .io_pystan import from_pystan
 
 
 
-def convert_to_inference_data(obj, *, group='posterior', coords=None, dims=None):
+def convert_to_inference_data(obj, *, group='posterior', coords=None, dims=None, **kwargs):
     """Convert a supported object to an InferenceData object.
 
     This function sends `obj` to the right conversion function. It is idempotent,
@@ -35,6 +35,8 @@ def convert_to_inference_data(obj, *, group='posterior', coords=None, dims=None)
         is the name of the dimension, the values are the index values.
     dims : dict[str, List(str)]
         A mapping from variables to a list of coordinate names for the variable
+    kwargs
+        Rest of the supported keyword arguments transferred to conversion function.
 
     Returns
     -------
@@ -46,9 +48,9 @@ def convert_to_inference_data(obj, *, group='posterior', coords=None, dims=None)
     elif isinstance(obj, str):
         return InferenceData.from_netcdf(obj)
     elif obj.__class__.__name__ == 'StanFit4Model':  # ugly, but doesn't make PyStan a requirement
-        return pystan_to_inference_data(fit=obj, coords=coords, dims=dims)
+        return from_pystan(fit=obj, coords=coords, dims=dims, **kwargs)
     elif obj.__class__.__name__ == 'MultiTrace':  # ugly, but doesn't make PyMC3 a requirement
-        return pymc3_to_inference_data(trace=obj, coords=coords, dims=dims)
+        return from_pymc3(trace=obj, coords=coords, dims=dims, **kwargs)
 
     # Cases that convert to xarray
     if isinstance(obj, xr.Dataset):

--- a/arviz/data/convert/io_pymc3.py
+++ b/arviz/data/convert/io_pymc3.py
@@ -133,8 +133,8 @@ class PyMC3Converter:
         })
 
 
-def pymc3_to_inference_data(*, trace=None, prior=None, posterior_predictive=None,
-                            coords=None, dims=None):
+def from_pymc3(*, trace=None, prior=None, posterior_predictive=None,
+               coords=None, dims=None):
     """Convert pymc3 data into an InferenceData object."""
     return PyMC3Converter(
         trace=trace,

--- a/arviz/data/convert/io_pystan.py
+++ b/arviz/data/convert/io_pystan.py
@@ -277,6 +277,8 @@ def from_pystan(*, fit=None, prior=None, posterior_predictive=None,
                 observed_data=None, log_likelihood=None, coords=None, dims=None):
     """Convert pystan data into an InferenceData object.
 
+    Parameters
+    ----------
     fit : StanFit4Model
         PyStan fit object.
     prior : dict
@@ -312,7 +314,11 @@ def from_pystan(*, fit=None, prior=None, posterior_predictive=None,
         A dictionary containing the values that are used as index. The key
         is the name of the dimension, the values are the index values.
     dims : dict[str, List(str)]
-        A mapping from variables to a list of coordinate names for the variable
+        A mapping from variables to a list of coordinate names for the variable.
+
+    Returns
+    -------
+    InferenceData object
     """
     return PyStanConverter(
         fit=fit,

--- a/arviz/data/convert/io_pystan.py
+++ b/arviz/data/convert/io_pystan.py
@@ -280,7 +280,7 @@ def from_pystan(*, fit=None, prior=None, posterior_predictive=None,
             `prior_dict = prior_fit.extract(pars=prior_vars, permuted=False)`
         For PyStan 2.17 and earlier:
             `prior_dict = prior_fit.extract(pars=prior_vars)`
-            `prior_dict = {var : az.from_pystan.unpermute(vals) for var, vals in prior_dict.items()}`
+            `prior_dict = {k : az.from_pystan.unpermute(v) for k, v in prior_dict.items()}`
     posterior_predictive : str, a list of str or dict
         Posterior predictive samples for the fit. If given string or a list of strings
         function extracts values from the fit object. Else a dictionary of posterior samples
@@ -289,14 +289,14 @@ def from_pystan(*, fit=None, prior=None, posterior_predictive=None,
             `pp_dict = posterior_predictive_fit.extract(pars=pp_vars, permuted=False)`
         For PyStan 2.17 and earlier:
             `pp_dict = posterior_predictive_fit.extract(pars=prior_vars)`
-            `pp_dict = {var : az.from_pystan.unpermute(vals) for var, vals in pp_dict.items()}`
+            `pp_dict = {k : az.from_pystan.unpermute(v) for k, v in pp_dict.items()}`
     observed_data : str or a list of str or a dictionary
         observed data used in the sampling. If a str or a list of str is given, observed data is
          extracted from the `fit.data`. Else a dictionary is assumed containing observed data.
     log_likelihood : str or np.ndarray
         log_likelihood for data calculated elementwise. If a string is given, log_likelihood is
-        extracted from the fit object. Else a ndarray containing elementwise log_likelihood is assumed
-        in PyStan extract format.
+        extracted from the fit object. Else a ndarray containing elementwise log_likelihood is
+        assumed in PyStan extract format.
         For PyStan 2.18+:
             `log_likelihood = log_likelihood_fit.extract(pars=log_likelihood_var, permuted=False)`
             `log_likelihood = log_likelihood[log_likelihood_var]`

--- a/arviz/data/convert/io_pystan.py
+++ b/arviz/data/convert/io_pystan.py
@@ -268,9 +268,47 @@ class PyStanConverter:
         })
 
 
-def pystan_to_inference_data(*, fit=None, prior=None, posterior_predictive=None,
-                             observed_data=None, log_likelihood=None, coords=None, dims=None):
-    """Convert pystan data into an InferenceData object."""
+def from_pystan(*, fit=None, prior=None, posterior_predictive=None,
+                observed_data=None, log_likelihood=None, coords=None, dims=None):
+    """Convert pystan data into an InferenceData object.
+
+    fit : StanFit4Model
+        PyStan fit object.
+    prior : dict
+        A dictionary containing prior samples extracted from pystan fit object.
+        For PyStan 2.18+:
+            `prior_dict = prior_fit.extract(pars=prior_vars, permuted=False)`
+        For PyStan 2.17 and earlier:
+            `prior_dict = prior_fit.extract(pars=prior_vars)`
+            `prior_dict = {var : az.from_pystan.unpermute(vals) for var, vals in prior_dict.items()}`
+    posterior_predictive : str, a list of str or dict
+        Posterior predictive samples for the fit. If given string or a list of strings
+        function extracts values from the fit object. Else a dictionary of posterior samples
+        is assumed in PyStan extract format.
+        For PyStan 2.18+:
+            `pp_dict = posterior_predictive_fit.extract(pars=pp_vars, permuted=False)`
+        For PyStan 2.17 and earlier:
+            `pp_dict = posterior_predictive_fit.extract(pars=prior_vars)`
+            `pp_dict = {var : az.from_pystan.unpermute(vals) for var, vals in pp_dict.items()}`
+    observed_data : str or a list of str or a dictionary
+        observed data used in the sampling. If a str or a list of str is given, observed data is
+         extracted from the `fit.data`. Else a dictionary is assumed containing observed data.
+    log_likelihood : str or np.ndarray
+        log_likelihood for data calculated elementwise. If a string is given, log_likelihood is
+        extracted from the fit object. Else a ndarray containing elementwise log_likelihood is assumed
+        in PyStan extract format.
+        For PyStan 2.18+:
+            `log_likelihood = log_likelihood_fit.extract(pars=log_likelihood_var, permuted=False)`
+            `log_likelihood = log_likelihood[log_likelihood_var]`
+        For PyStan 2.17 and earlier:
+            `log_likelihood = log_likelihood_fit.extract(pars=log_likelihood_var)`
+            `log_likelihood = az.from_pystan.unpermute(log_likelihood[log_likelihood_var])`
+    coords : dict[str, iterable]
+        A dictionary containing the values that are used as index. The key
+        is the name of the dimension, the values are the index values.
+    dims : dict[str, List(str)]
+        A mapping from variables to a list of coordinate names for the variable
+    """
     return PyStanConverter(
         fit=fit,
         prior=prior,

--- a/arviz/plots/__init__.py
+++ b/arviz/plots/__init__.py
@@ -1,15 +1,15 @@
 """Plotting functions."""
-from .autocorrplot import autocorrplot as plot_autocorr
-from .compareplot import compareplot as plot_compare
-from .densityplot import densityplot as plot_density
-from .energyplot import energyplot as plot_energy
-from .forestplot import forestplot as plot_forest
-from .kdeplot import kdeplot as plot_kde, _fast_kde, _fast_kde_2d
-from .parallelplot import parallelplot as plot_parallel
-from .posteriorplot import posteriorplot as plot_posterior
-from .traceplot import traceplot as plot_trace
-from .pairplot import pairplot as plot_pair
-from .jointplot import jointplot as plot_joint
-from .khatplot import khatplot as plot_khat
-from .ppcplot import ppcplot as plot_ppc
-from .violintraceplot import violintraceplot as plot_violintrace
+from .autocorrplot import plot_autocorr
+from .compareplot import plot_compare
+from .densityplot import plot_density
+from .energyplot import plot_energy
+from .forestplot import plot_forest
+from .kdeplot import plot_kde, _fast_kde, _fast_kde_2d
+from .parallelplot import plot_parallel
+from .posteriorplot import plot_posterior
+from .traceplot import plot_trace
+from .pairplot import plot_pair
+from .jointplot import plot_joint
+from .khatplot import plot_khat
+from .ppcplot import plot_ppc
+from .violinplot import plot_violin

--- a/arviz/plots/__init__.py
+++ b/arviz/plots/__init__.py
@@ -1,15 +1,15 @@
 """Plotting functions."""
-from .autocorrplot import autocorrplot
-from .compareplot import compareplot
-from .densityplot import densityplot
-from .energyplot import energyplot
-from .forestplot import forestplot
-from .kdeplot import kdeplot, _fast_kde, _fast_kde_2d
-from .parallelplot import parallelplot
-from .posteriorplot import posteriorplot
-from .traceplot import traceplot
-from .pairplot import pairplot
-from .jointplot import jointplot
-from .khatplot import khatplot
-from .ppcplot import ppcplot
-from .violintraceplot import violintraceplot
+from .autocorrplot import autocorrplot as plot_autocorr
+from .compareplot import compareplot as plot_compare
+from .densityplot import densityplot as plot_density
+from .energyplot import energyplot as plot_energy
+from .forestplot import forestplot as plot_forest
+from .kdeplot import kdeplot as plot_kde, _fast_kde, _fast_kde_2d
+from .parallelplot import parallelplot as plot_parallel
+from .posteriorplot import posteriorplot as plot_posterior
+from .traceplot import traceplot as plot_trace
+from .pairplot import pairplot as plot_pair
+from .jointplot import jointplot as plot_joint
+from .khatplot import khatplot as plot_khat
+from .ppcplot import ppcplot as plot_ppc
+from .violintraceplot import violintraceplot as plot_violintrace

--- a/arviz/plots/autocorrplot.py
+++ b/arviz/plots/autocorrplot.py
@@ -6,7 +6,7 @@ from arviz.stats.diagnostics import autocorr
 from .plot_utils import _scale_text, default_grid, make_label, xarray_var_iter, _create_axes_grid
 
 
-def autocorrplot(data, var_names=None, max_lag=100, combined=False, figsize=None, textsize=None):
+def plot_autocorr(data, var_names=None, max_lag=100, combined=False, figsize=None, textsize=None):
     """Bar plot of the autocorrelation function for a sequence of data.
 
     Useful in particular for posteriors from MCMC samples which may display correlation.

--- a/arviz/plots/compareplot.py
+++ b/arviz/plots/compareplot.py
@@ -4,8 +4,8 @@ import matplotlib.pyplot as plt
 from .plot_utils import _scale_text
 
 
-def compareplot(comp_df, insample_dev=True, plot_standard_error=True, plot_ic_diff=True,
-                figsize=None, textsize=None, plot_kwargs=None, ax=None):
+def plot_compare(comp_df, insample_dev=True, plot_standard_error=True, plot_ic_diff=True,
+                 figsize=None, textsize=None, plot_kwargs=None, ax=None):
     """Summary plot for model comparison.
 
     This plot is in the style of the one used in the book Statistical Rethinking

--- a/arviz/plots/densityplot.py
+++ b/arviz/plots/densityplot.py
@@ -9,9 +9,9 @@ from .plot_utils import _scale_text, make_label, xarray_var_iter
 
 
 # pylint:disable-msg=too-many-function-args
-def densityplot(data, data_labels=None, var_names=None, credible_interval=0.94,
-                point_estimate='mean', colors='cycle', outline=True, hpd_markers='', shade=0.,
-                bw=4.5, figsize=None, textsize=None):
+def plot_density(data, data_labels=None, var_names=None, credible_interval=0.94,
+                 point_estimate='mean', colors='cycle', outline=True, hpd_markers='', shade=0.,
+                 bw=4.5, figsize=None, textsize=None):
     """Generate KDE plots for continuous variables and histograms for discretes ones.
 
     Plots are truncated at their 100*(1-alpha)% credible intervals. Plots are grouped per variable

--- a/arviz/plots/energyplot.py
+++ b/arviz/plots/energyplot.py
@@ -4,13 +4,13 @@ import matplotlib.pyplot as plt
 
 from arviz import convert_to_dataset
 from arviz.stats import bfmi as e_bfmi
-from .kdeplot import kdeplot
+from .kdeplot import plot_kde
 from .plot_utils import _scale_text
 
 
-def energyplot(data, kind='kde', bfmi=True, figsize=None, legend=True, fill_alpha=(1, .75),
-               fill_color=('C0', 'C5'), bw=4.5, textsize=None, fill_kwargs=None, plot_kwargs=None,
-               ax=None):
+def plot_energy(data, kind='kde', bfmi=True, figsize=None, legend=True, fill_alpha=(1, .75),
+                fill_color=('C0', 'C5'), bw=4.5, textsize=None, fill_kwargs=None, plot_kwargs=None,
+                ax=None):
     """Plot energy transition distribution and marginal energy distribution in HMC algorithms.
 
     This may help to diagnose poor exploration by gradient-based algorithms like HMC or NUTS.
@@ -40,9 +40,9 @@ def energyplot(data, kind='kde', bfmi=True, figsize=None, legend=True, fill_alph
     textsize: int
         Text size for labels
     fill_kwargs : dicts, optional
-        Additional keywords passed to `arviz.kdeplot` (to control the shade)
+        Additional keywords passed to `arviz.plot_kde` (to control the shade)
     plot_kwargs : dicts, optional
-        Additional keywords passed to `arviz.kdeplot` or `plt.hist` (if type='hist')
+        Additional keywords passed to `arviz.plot_kde` or `plt.hist` (if type='hist')
     ax : axes
         Matplotlib axes.
 
@@ -79,7 +79,7 @@ def energyplot(data, kind='kde', bfmi=True, figsize=None, legend=True, fill_alph
             plot_kwargs.setdefault('color', color)
             plot_kwargs.setdefault('alpha', 0)
             plot_kwargs.setdefault('linewidth', linewidth)
-            kdeplot(value, bw=bw, label=label, textsize=textsize,
+            plot_kde(value, bw=bw, label=label, textsize=textsize,
                     plot_kwargs=plot_kwargs, fill_kwargs=fill_kwargs, ax=ax)
 
     elif kind == 'hist':

--- a/arviz/plots/energyplot.py
+++ b/arviz/plots/energyplot.py
@@ -80,7 +80,7 @@ def plot_energy(data, kind='kde', bfmi=True, figsize=None, legend=True, fill_alp
             plot_kwargs.setdefault('alpha', 0)
             plot_kwargs.setdefault('linewidth', linewidth)
             plot_kde(value, bw=bw, label=label, textsize=textsize,
-                    plot_kwargs=plot_kwargs, fill_kwargs=fill_kwargs, ax=ax)
+                     plot_kwargs=plot_kwargs, fill_kwargs=fill_kwargs, ax=ax)
 
     elif kind == 'hist':
         for alpha, color, label, value in series:

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -19,10 +19,10 @@ def pairwise(iterable):
     return zip(first, second)
 
 
-def forestplot(data, kind='forestplot', model_names=None, var_names=None, combined=False,
-               credible_interval=0.94, quartiles=True, r_hat=True, n_eff=True, colors='cycle',
-               textsize=None, linewidth=None, markersize=None, ridgeplot_alpha=None,
-               ridgeplot_overlap=2, figsize=None):
+def plot_forest(data, kind='forestplot', model_names=None, var_names=None, combined=False,
+                credible_interval=0.94, quartiles=True, r_hat=True, n_eff=True, colors='cycle',
+                textsize=None, linewidth=None, markersize=None, ridgeplot_alpha=None,
+                ridgeplot_overlap=2, figsize=None):
     """Forest plot to compare credible intervals from a number of distributions.
 
     Generates a forest plot of 100*(credible_interval)% credible intervals from

--- a/arviz/plots/jointplot.py
+++ b/arviz/plots/jointplot.py
@@ -3,13 +3,13 @@ import matplotlib.pyplot as plt
 from matplotlib.ticker import NullFormatter
 
 from arviz import convert_to_dataset
-from .kdeplot import kdeplot
+from .kdeplot import plot_kde
 from .plot_utils import _scale_text, get_bins, xarray_var_iter, make_label, get_coords
 
 
-def jointplot(data, var_names=None, coords=None, figsize=None, textsize=None, kind='scatter',
-              gridsize='auto', contour=True, fill_last=True, joint_kwargs=None,
-              marginal_kwargs=None):
+def plot_joint(data, var_names=None, coords=None, figsize=None, textsize=None, kind='scatter',
+               gridsize='auto', contour=True, fill_last=True, joint_kwargs=None,
+               marginal_kwargs=None):
     """
     Plot a scatter or hexbin of two variables with their respective marginals distributions.
 
@@ -91,7 +91,7 @@ def jointplot(data, var_names=None, coords=None, figsize=None, textsize=None, ki
     if kind == 'scatter':
         axjoin.scatter(x, y, **joint_kwargs)
     elif kind == 'kde':
-        kdeplot(x, y, contour=contour, fill_last=fill_last, ax=axjoin, **joint_kwargs)
+        plot_kde(x, y, contour=contour, fill_last=fill_last, ax=axjoin, **joint_kwargs)
     else:
         if gridsize == 'auto':
             gridsize = int(len(x)**0.35)
@@ -107,7 +107,7 @@ def jointplot(data, var_names=None, coords=None, figsize=None, textsize=None, ki
         else:
             marginal_kwargs.setdefault('plot_kwargs', {})
             marginal_kwargs['plot_kwargs']['linewidth'] = linewidth
-            kdeplot(val, rotated=rotate, ax=ax, **marginal_kwargs)
+            plot_kde(val, rotated=rotate, ax=ax, **marginal_kwargs)
 
     ax_hist_x.set_xlim(axjoin.get_xlim())
     ax_hist_y.set_ylim(axjoin.get_ylim())

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -8,9 +8,9 @@ from scipy.stats import entropy
 from .plot_utils import _scale_text
 
 
-def kdeplot(values, values2=None, cumulative=False, rug=False, label=None, bw=4.5, rotated=False,
-            contour=True, fill_last=True, figsize=None, textsize=None, plot_kwargs=None,
-            fill_kwargs=None, rug_kwargs=None, contour_kwargs=None, ax=None):
+def plot_kde(values, values2=None, cumulative=False, rug=False, label=None, bw=4.5, rotated=False,
+             contour=True, fill_last=True, figsize=None, textsize=None, plot_kwargs=None,
+             fill_kwargs=None, rug_kwargs=None, contour_kwargs=None, ax=None):
     """1D or 2D KDE plot taking into account boundary conditions.
 
     Parameters

--- a/arviz/plots/khatplot.py
+++ b/arviz/plots/khatplot.py
@@ -5,7 +5,7 @@ import numpy as np
 from .plot_utils import _scale_text
 
 
-def khatplot(khats, figsize=None, textsize=None, ax=None, hlines_kwargs=None, **kwargs):
+def plot_khat(khats, figsize=None, textsize=None, ax=None, hlines_kwargs=None, **kwargs):
     R"""
     Plot Pareto tail indices.
 

--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -6,13 +6,13 @@ from matplotlib.ticker import NullFormatter
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from arviz import convert_to_dataset
-from .kdeplot import kdeplot
+from .kdeplot import plot_kde
 from .plot_utils import _scale_text, xarray_to_nparray, get_coords
 
 
-def pairplot(data, var_names=None, coords=None, figsize=None, textsize=None, kind='scatter',
-             gridsize='auto', contour=True, fill_last=True, divergences=False, colorbar=False,
-             gs=None, ax=None, divergences_kwargs=None, plot_kwargs=None):
+def plot_pair(data, var_names=None, coords=None, figsize=None, textsize=None, kind='scatter',
+              gridsize='auto', contour=True, fill_last=True, divergences=False, colorbar=False,
+              gs=None, ax=None, divergences_kwargs=None, plot_kwargs=None):
     """
     Plot a scatter or hexbin matrix of the sampled parameters.
 
@@ -52,7 +52,7 @@ def pairplot(data, var_names=None, coords=None, figsize=None, textsize=None, kin
     divergences_kwargs : dicts, optional
         Additional keywords passed to ax.scatter for divergences
     plot_kwargs : dicts, optional
-        Additional keywords passed to ax.scatter, az.kdeplot or ax.hexbin
+        Additional keywords passed to ax.scatter, az.plot_kde or ax.hexbin
     Returns
     -------
     ax : matplotlib axes
@@ -102,8 +102,8 @@ def pairplot(data, var_names=None, coords=None, figsize=None, textsize=None, kin
         if kind == 'scatter':
             ax.scatter(_posterior[0], _posterior[1], s=markersize, **plot_kwargs)
         elif kind == 'kde':
-            kdeplot(_posterior[0], _posterior[1], contour=contour, fill_last=fill_last, ax=ax,
-                    **plot_kwargs)
+            plot_kde(_posterior[0], _posterior[1], contour=contour, fill_last=fill_last, ax=ax,
+                     **plot_kwargs)
         else:
             hexbin = ax.hexbin(posterior_data[0], posterior_data[1], mincnt=1, gridsize=gridsize,
                                **plot_kwargs)
@@ -136,7 +136,7 @@ def pairplot(data, var_names=None, coords=None, figsize=None, textsize=None, kin
                 if kind == 'scatter':
                     ax.scatter(var1, var2, s=markersize, **plot_kwargs)
                 elif kind == 'kde':
-                    kdeplot(var1, var2, contour=contour, fill_last=fill_last, ax=ax, **plot_kwargs)
+                    plot_kde(var1, var2, contour=contour, fill_last=fill_last, ax=ax, **plot_kwargs)
                 else:
                     ax.grid(False)
                     hexbin = ax.hexbin(var1, var2, mincnt=1, gridsize=gridsize, **plot_kwargs)

--- a/arviz/plots/parallelplot.py
+++ b/arviz/plots/parallelplot.py
@@ -6,8 +6,8 @@ from arviz import convert_to_dataset
 from .plot_utils import _scale_text, xarray_to_nparray, get_coords
 
 
-def parallelplot(data, var_names=None, coords=None, figsize=None, textsize=None, legend=True,
-                 colornd='k', colord='C1', shadend=.025, ax=None):
+def plot_parallel(data, var_names=None, coords=None, figsize=None, textsize=None, legend=True,
+                  colornd='k', colord='C1', shadend=.025, ax=None):
     """
     Plot parallel coordinates plot showing posterior points with and without divergences.
 

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -5,14 +5,14 @@ from scipy.stats import mode
 
 from arviz import convert_to_dataset
 from arviz.stats import hpd
-from .kdeplot import kdeplot, _fast_kde
+from .kdeplot import plot_kde, _fast_kde
 from .plot_utils import (xarray_var_iter, _scale_text, make_label, default_grid, _create_axes_grid,
                          get_coords)
 
 
-def posteriorplot(data, var_names=None, coords=None, figsize=None, textsize=None,
-                  credible_interval=0.94, round_to=1, point_estimate='mean', rope=None,
-                  ref_val=None, kind='kde', bw=4.5, bins=None, ax=None, **kwargs):
+def plot_posterior(data, var_names=None, coords=None, figsize=None, textsize=None,
+                   credible_interval=0.94, round_to=1, point_estimate='mean', rope=None,
+                   ref_val=None, kind='kde', bw=4.5, bins=None, ax=None, **kwargs):
     """Plot Posterior densities in the style of John K. Kruschke's book.
 
     Parameters
@@ -69,28 +69,28 @@ def posteriorplot(data, var_names=None, coords=None, figsize=None, textsize=None
 
         >>> import arviz as az
         >>> non_centered = az.load_arviz_data('non_centered_eight')
-        >>> az.posteriorplot(non_centered)
+        >>> az.plot_posterior(non_centered)
 
     Plot subset variables by specifying variable name exactly
 
     .. plot::
         :context: close-figs
 
-        >>> az.posteriorplot(non_centered, var_names=("mu",), textsize=11)
+        >>> az.plot_posterior(non_centered, var_names=("mu",), textsize=11)
 
     Plot subset of variables by matching start of variable name
 
     .. plot::
         :context: close-figs
 
-        >>> az.posteriorplot(non_centered, var_names=("mu", "theta_tilde"))
+        >>> az.plot_posterior(non_centered, var_names=("mu", "theta_tilde"))
 
     Plot Region of Practical Equivalence (rope) for all distributions
 
     .. plot::
         :context: close-figs
 
-        >>> az.posteriorplot(non_centered, var_names=("mu", 'theta_tilde',), rope=(-1, 1))
+        >>> az.plot_posterior(non_centered, var_names=("mu", 'theta_tilde',), rope=(-1, 1))
 
     Plot Region of Practical Equivalence for selected distributions
 
@@ -98,7 +98,7 @@ def posteriorplot(data, var_names=None, coords=None, figsize=None, textsize=None
         :context: close-figs
 
         >>> rope = {'mu': [{'rope': (-2, 2)}], 'theta': [{'school': 'Choate', 'rope': (2, 4)}]}
-        >>> az.posteriorplot(non_centered, var_names=('mu', 'theta_tilde',), rope=rope)
+        >>> az.plot_posterior(non_centered, var_names=('mu', 'theta_tilde',), rope=rope)
 
 
     Add reference lines
@@ -106,28 +106,28 @@ def posteriorplot(data, var_names=None, coords=None, figsize=None, textsize=None
     .. plot::
         :context: close-figs
 
-        >>> az.posteriorplot(non_centered, var_names=('mu', 'theta_tilde',), ref_val=0)
+        >>> az.plot_posterior(non_centered, var_names=('mu', 'theta_tilde',), ref_val=0)
 
     Show point estimate of distribution
 
     .. plot::
         :context: close-figs
 
-        >>> az.posteriorplot(non_centered, var_names=('mu', 'theta_tilde',), point_estimate="mode")
+        >>> az.plot_posterior(non_centered, var_names=('mu', 'theta_tilde',), point_estimate="mode")
 
     Plot posterior as a histogram
 
     .. plot::
         :context: close-figs
 
-        >>> az.posteriorplot(non_centered, var_names=('mu', 'theta_tilde',), kind="hist")
+        >>> az.plot_posterior(non_centered, var_names=('mu', 'theta_tilde',), kind="hist")
 
     Change size of credible interval
 
     .. plot::
         :context: close-figs
 
-        >>> az.posteriorplot(non_centered, var_names=('mu', 'theta_tilde',), credible_interval=.94)
+        >>> az.plot_posterior(non_centered, var_names=('mu', 'theta_tilde',), credible_interval=.94)
     """
     data = convert_to_dataset(data, group='posterior')
 
@@ -259,12 +259,11 @@ def _plot_posterior_op(values, var_name, selection, ax, bw, linewidth, bins, kin
         ax.spines['bottom'].set_color('0.5')
 
     if kind == 'kde' and values.dtype.kind == 'f':
-        kdeplot(values,
-                bw=bw,
-                fill_kwargs={'alpha': kwargs.pop('fill_alpha', 0)},
-                plot_kwargs={'linewidth': linewidth},
-                ax=ax)
-
+        plot_kde(values,
+                 bw=bw,
+                 fill_kwargs={'alpha': kwargs.pop('fill_alpha', 0)},
+                 plot_kwargs={'linewidth': linewidth},
+                 ax=ax)
     else:
         if bins is None:
             if values.dtype.kind == 'i':

--- a/arviz/plots/ppcplot.py
+++ b/arviz/plots/ppcplot.py
@@ -1,10 +1,10 @@
 """Posterior predictive plot."""
 import numpy as np
-from .kdeplot import kdeplot
+from .kdeplot import plot_kde
 from .plot_utils import _scale_text, _create_axes_grid, default_grid
 
 
-def ppcplot(data, kind='kde', alpha=0.2, mean=True, figsize=None, textsize=None):
+def plot_ppc(data, kind='kde', alpha=0.2, mean=True, figsize=None, textsize=None):
     """
     Plot for Posterior Predictive checks.
 
@@ -45,27 +45,27 @@ def ppcplot(data, kind='kde', alpha=0.2, mean=True, figsize=None, textsize=None)
     textsize, linewidth, _ = _scale_text(figsize, textsize)
     for ax, var_name in zip(np.atleast_1d(axes), observed.data_vars):
         if kind == 'kde':
-            kdeplot(observed[var_name].values.flatten(), label='Observed {}'.format(var_name),
-                    plot_kwargs={'color': 'k', 'linewidth': linewidth, 'zorder': 3},
-                    fill_kwargs={'alpha': 0},
-                    ax=ax)
+            plot_kde(observed[var_name].values.flatten(), label='Observed {}'.format(var_name),
+                     plot_kwargs={'color': 'k', 'linewidth': linewidth, 'zorder': 3},
+                     fill_kwargs={'alpha': 0},
+                     ax=ax)
             for _, chain_vals in posterior_predictive[var_name].groupby('chain'):
                 for _, vals in chain_vals.groupby('draw'):
-                    kdeplot(vals,
-                            plot_kwargs={'color': 'C4',
-                                         'alpha': alpha,
-                                         'linewidth': 0.5 * linewidth},
-                            fill_kwargs={'alpha': 0},
-                            ax=ax)
+                    plot_kde(vals,
+                             plot_kwargs={'color': 'C4',
+                                          'alpha': alpha,
+                                          'linewidth': 0.5 * linewidth},
+                             fill_kwargs={'alpha': 0},
+                             ax=ax)
             ax.plot([], color='C4', label='Posterior predictive {}'.format(var_name))
             if mean:
-                kdeplot(posterior_predictive[var_name].values.flatten(),
-                        plot_kwargs={'color': 'C0',
-                                     'linestyle': '--',
-                                     'linewidth': linewidth,
-                                     'zorder': 2},
-                        label='Posterior predictive mean {}'.format(var_name),
-                        ax=ax)
+                plot_kde(posterior_predictive[var_name].values.flatten(),
+                         plot_kwargs={'color': 'C0',
+                                      'linestyle': '--',
+                                      'linewidth': linewidth,
+                                      'zorder': 2},
+                         label='Posterior predictive mean {}'.format(var_name),
+                         ax=ax)
             ax.set_xlabel(var_name, fontsize=textsize)
             ax.set_yticks([])
 

--- a/arviz/plots/traceplot.py
+++ b/arviz/plots/traceplot.py
@@ -3,12 +3,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from arviz import convert_to_dataset
-from .kdeplot import kdeplot
+from .kdeplot import plot_kde
 from .plot_utils import _scale_text, get_bins, xarray_var_iter, make_label, get_coords
 
 
-def traceplot(data, var_names=None, coords=None, figsize=None, textsize=None, lines=None,
-              combined=False, kde_kwargs=None, hist_kwargs=None, trace_kwargs=None):
+def plot_trace(data, var_names=None, coords=None, figsize=None, textsize=None, lines=None,
+               combined=False, kde_kwargs=None, hist_kwargs=None, trace_kwargs=None):
     """Plot samples histograms and values.
 
     Parameters
@@ -30,7 +30,7 @@ def traceplot(data, var_names=None, coords=None, figsize=None, textsize=None, li
         Flag for combining multiple chains into a single line. If False (default), chains will be
         plotted separately.
     kde_kwargs : dict
-        Extra keyword arguments passed to `arviz.kdeplot`. Only affects continuous variables.
+        Extra keyword arguments passed to `arviz.plot_kde`. Only affects continuous variables.
     hist_kwargs : dict
         Extra keyword arguments passed to `plt.hist`. Only affects discrete variables.
     trace_kwargs : dict
@@ -50,7 +50,7 @@ def traceplot(data, var_names=None, coords=None, figsize=None, textsize=None, li
         >>> import arviz as az
         >>> data = az.load_arviz_data('non_centered_eight')
         >>> coords = {'theta_t_dim_0': [0, 1], 'school':['Lawrenceville']}
-        >>> az.traceplot(data, var_names=('theta_t', 'theta'), coords=coords)
+        >>> az.plot_trace(data, var_names=('theta_t', 'theta'), coords=coords)
 
     Combine all chains into one distribution and trace
 
@@ -58,7 +58,7 @@ def traceplot(data, var_names=None, coords=None, figsize=None, textsize=None, li
         :context: close-figs
 
         >>> coords = {'theta_t_dim_0': [0, 1], 'school':['Lawrenceville']}
-        >>> az.traceplot(data, var_names=('theta_t', 'theta'), coords=coords, combined=True)
+        >>> az.plot_trace(data, var_names=('theta_t', 'theta'), coords=coords, combined=True)
 
 
     Plot reference lines against distribution and trace
@@ -68,7 +68,7 @@ def traceplot(data, var_names=None, coords=None, figsize=None, textsize=None, li
 
         >>> lines = (('theta_t',{'theta_t_dim_0':0}, [-1]),)
         >>> coords = {'theta_t_dim_0': [0, 1], 'school':['Lawrenceville']}
-        >>> az.traceplot(data, var_names=('theta_t', 'theta'), coords=coords, lines=lines)
+        >>> az.plot_trace(data, var_names=('theta_t', 'theta'), coords=coords, lines=lines)
     """
     data = convert_to_dataset(data, group='posterior')
 
@@ -114,7 +114,7 @@ def traceplot(data, var_names=None, coords=None, figsize=None, textsize=None, li
             if row.dtype.kind == 'i':
                 _histplot_op(axes[i, 0], row, **hist_kwargs)
             else:
-                kdeplot(row, textsize=textsize, ax=axes[i, 0], **kde_kwargs)
+                plot_kde(row, textsize=textsize, ax=axes[i, 0], **kde_kwargs)
 
         axes[i, 0].set_yticks([])
         for idx in (0, 1):

--- a/arviz/plots/violinplot.py
+++ b/arviz/plots/violinplot.py
@@ -8,8 +8,8 @@ from .kdeplot import _fast_kde
 from .plot_utils import get_bins, _scale_text, xarray_var_iter, make_label
 
 
-def violintraceplot(data, var_names=None, quartiles=True, credible_interval=0.94, shade=0.35,
-                    bw=4.5, sharey=True, figsize=None, textsize=None, ax=None, kwargs_shade=None):
+def plot_violin(data, var_names=None, quartiles=True, credible_interval=0.94, shade=0.35,
+                bw=4.5, sharey=True, figsize=None, textsize=None, ax=None, kwargs_shade=None):
     """Plot posterior of traces as violin plot.
 
     Notes

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -6,8 +6,8 @@ import pytest
 from arviz import (
     convert_to_inference_data,
     convert_to_dataset,
-    pymc3_to_inference_data,
-    pystan_to_inference_data,
+    from_pymc3,
+    from_pystan,
 )
 from .helpers import eight_schools_params, load_cached_models, BaseArvizTest
 
@@ -226,7 +226,7 @@ class TestPyMC3NetCDFUtils(CheckNetCDFUtils):
             prior = pm.sample_prior_predictive()
             posterior_predictive = pm.sample_posterior_predictive(self.obj)
 
-        return pymc3_to_inference_data(
+        return from_pymc3(
             trace=self.obj,
             prior=prior,
             posterior_predictive=posterior_predictive,
@@ -256,7 +256,7 @@ class TestPyStanNetCDFUtils(CheckNetCDFUtils):
         cls.model, cls.obj = load_cached_models(cls.draws, cls.chains)['pystan']
 
     def get_inference_data(self):
-        return pystan_to_inference_data(
+        return from_pystan(
             fit=self.obj,
             coords={'school': np.arange(self.data['J'])},
             dims={'theta': ['school'], 'theta_tilde': ['school']},

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -6,8 +6,9 @@ import pytest
 
 from arviz import from_pymc3
 from .helpers import eight_schools_params, load_cached_models, BaseArvizTest
-from ..plots import (plot_density, plot_trace, plot_energy, plot_posterior, plot_autocorr, plot_forest,
-                     plot_parallel, plot_pair, plot_joint, plot_ppc, plot_violintrace)
+from ..plots import (plot_density, plot_trace, plot_energy, plot_posterior,
+                     plot_autocorr, plot_forest, plot_parallel, plot_pair,
+                     plot_joint, plot_ppc, plot_violintrace)
 
 
 class SetupPlots(BaseArvizTest):
@@ -37,7 +38,7 @@ class TestPlots(SetupPlots):
     def test_traceplot(self, combined):
         for obj in (self.short_trace, self.fit):
             axes = plot_trace(obj, var_names=('mu', 'tau'),
-                             combined=combined, lines=[('mu', {}, [1, 2])])
+                              combined=combined, lines=[('mu', {}, [1, 2])])
             assert axes.shape == (2, 2)
 
     def test_autocorrplot(self):
@@ -73,13 +74,13 @@ class TestPlots(SetupPlots):
     def test_pairplot(self):
 
         plot_pair(self.short_trace, var_names=['theta'], divergences=True,
-                 coords={'theta_dim_0': [0, 1]}, plot_kwargs={'marker': 'x'},
-                 divergences_kwargs={'marker': '*', 'c': 'C'})
+                  coords={'theta_dim_0': [0, 1]}, plot_kwargs={'marker': 'x'},
+                  divergences_kwargs={'marker': '*', 'c': 'C'})
 
         plot_pair(self.short_trace, divergences=True, plot_kwargs={'marker': 'x'},
-                 divergences_kwargs={'marker': '*', 'c': 'C'})
+                  divergences_kwargs={'marker': '*', 'c': 'C'})
         plot_pair(self.short_trace, kind='hexbin', var_names=['theta'],
-                 coords={'theta_dim_0': [0, 1]}, plot_kwargs={'cmap': 'viridis'}, textsize=20)
+                  coords={'theta_dim_0': [0, 1]}, plot_kwargs={'cmap': 'viridis'}, textsize=20)
 
     @pytest.mark.parametrize('kind', ['kde', 'cumulative'])
     def test_ppcplot(self, kind):

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -6,8 +6,8 @@ import pytest
 
 from arviz import from_pymc3
 from .helpers import eight_schools_params, load_cached_models, BaseArvizTest
-from ..plots import (densityplot, traceplot, energyplot, posteriorplot, autocorrplot, forestplot,
-                     parallelplot, pairplot, jointplot, ppcplot, violintraceplot)
+from ..plots import (plot_density, plot_trace, plot_energy, plot_posterior, plot_autocorr, plot_forest,
+                     plot_parallel, plot_pair, plot_joint, plot_ppc, plot_violintrace)
 
 
 class SetupPlots(BaseArvizTest):
@@ -31,64 +31,64 @@ class SetupPlots(BaseArvizTest):
 class TestPlots(SetupPlots):
     def test_density_plot(self):
         for obj in (self.short_trace, self.fit):
-            assert densityplot(obj).shape == (18, 1)
+            assert plot_density(obj).shape == (18, 1)
 
     @pytest.mark.parametrize('combined', [True, False])
     def test_traceplot(self, combined):
         for obj in (self.short_trace, self.fit):
-            axes = traceplot(obj, var_names=('mu', 'tau'),
+            axes = plot_trace(obj, var_names=('mu', 'tau'),
                              combined=combined, lines=[('mu', {}, [1, 2])])
             assert axes.shape == (2, 2)
 
     def test_autocorrplot(self):
         for obj in (self.short_trace, self.fit):
-            assert autocorrplot(obj).shape == (1, 36)
+            assert plot_autocorr(obj).shape == (1, 36)
 
     def test_forestplot(self):
         for obj in (self.short_trace, self.fit, [self.short_trace, self.fit]):
-            _, axes = forestplot(obj)
+            _, axes = plot_forest(obj)
             assert axes.shape == (3,)
-            _, axes = forestplot(obj, r_hat=False, quartiles=False)
+            _, axes = plot_forest(obj, r_hat=False, quartiles=False)
             assert axes.shape == (2,)
-            _, axes = forestplot(obj, var_names=['mu'], colors='C0', n_eff=False, combined=True)
+            _, axes = plot_forest(obj, var_names=['mu'], colors='C0', n_eff=False, combined=True)
             assert axes.shape == (2,)
-            _, axes = forestplot(obj, kind='ridgeplot', r_hat=False, n_eff=False)
+            _, axes = plot_forest(obj, kind='ridgeplot', r_hat=False, n_eff=False)
             assert axes.shape == (1,)
 
     @pytest.mark.parametrize('kind', ['kde', 'hist'])
     def test_energyplot(self, kind):
         for obj in (self.short_trace, self.fit):
-            assert energyplot(obj, kind=kind)
+            assert plot_energy(obj, kind=kind)
 
     def test_parallelplot(self):
         with pytest.raises(ValueError):
-            parallelplot(self.df_trace)
-        assert parallelplot(self.short_trace)
+            plot_parallel(self.df_trace)
+        assert plot_parallel(self.short_trace)
 
     @pytest.mark.parametrize('kind', ['scatter', 'hexbin'])
     def test_jointplot(self, kind):
         for obj in (self.short_trace, self.fit):
-            jointplot(obj, var_names=('mu', 'tau'), kind=kind)
+            plot_joint(obj, var_names=('mu', 'tau'), kind=kind)
 
     def test_pairplot(self):
 
-        pairplot(self.short_trace, var_names=['theta'], divergences=True,
+        plot_pair(self.short_trace, var_names=['theta'], divergences=True,
                  coords={'theta_dim_0': [0, 1]}, plot_kwargs={'marker': 'x'},
                  divergences_kwargs={'marker': '*', 'c': 'C'})
 
-        pairplot(self.short_trace, divergences=True, plot_kwargs={'marker': 'x'},
+        plot_pair(self.short_trace, divergences=True, plot_kwargs={'marker': 'x'},
                  divergences_kwargs={'marker': '*', 'c': 'C'})
-        pairplot(self.short_trace, kind='hexbin', var_names=['theta'],
+        plot_pair(self.short_trace, kind='hexbin', var_names=['theta'],
                  coords={'theta_dim_0': [0, 1]}, plot_kwargs={'cmap': 'viridis'}, textsize=20)
 
     @pytest.mark.parametrize('kind', ['kde', 'cumulative'])
     def test_ppcplot(self, kind):
         data = from_pymc3(trace=self.short_trace, posterior_predictive=self.sample_ppc)
-        ppcplot(data, kind=kind)
+        plot_ppc(data, kind=kind)
 
     def test_violintraceplot(self):
         for obj in (self.short_trace, self.fit):
-            axes = violintraceplot(obj)
+            axes = plot_violintrace(obj)
             assert axes.shape == (18,)
 
 
@@ -96,11 +96,11 @@ class TestPosteriorPlot(SetupPlots):
 
     def test_posteriorplot(self):
         for obj in (self.short_trace, self.fit):
-            axes = posteriorplot(obj, var_names=('mu', 'tau'), rope=(-2, 2), ref_val=0)
+            axes = plot_posterior(obj, var_names=('mu', 'tau'), rope=(-2, 2), ref_val=0)
             assert axes.shape == (2,)
 
     @pytest.mark.parametrize("point_estimate", ('mode', 'mean', 'median'))
     def test_point_estimates(self, point_estimate):
         for obj in (self.short_trace, self.fit):
-            axes = posteriorplot(obj, var_names=('mu', 'tau'), point_estimate=point_estimate)
+            axes = plot_posterior(obj, var_names=('mu', 'tau'), point_estimate=point_estimate)
             assert axes.shape == (2,)

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -8,7 +8,7 @@ from arviz import from_pymc3
 from .helpers import eight_schools_params, load_cached_models, BaseArvizTest
 from ..plots import (plot_density, plot_trace, plot_energy, plot_posterior,
                      plot_autocorr, plot_forest, plot_parallel, plot_pair,
-                     plot_joint, plot_ppc, plot_violintrace)
+                     plot_joint, plot_ppc, plot_violin)
 
 
 class SetupPlots(BaseArvizTest):
@@ -30,26 +30,26 @@ class SetupPlots(BaseArvizTest):
 
 
 class TestPlots(SetupPlots):
-    def test_density_plot(self):
+    def test_plot_density(self):
         for obj in (self.short_trace, self.fit):
             axes = plot_density(obj)
             assert axes.shape[0] >= 18
             assert axes.shape[1] == 1
 
     @pytest.mark.parametrize('combined', [True, False])
-    def test_traceplot(self, combined):
+    def test_plot_trace(self, combined):
         for obj in (self.short_trace, self.fit):
             axes = plot_trace(obj, var_names=('mu', 'tau'),
                               combined=combined, lines=[('mu', {}, [1, 2])])
             assert axes.shape == (2, 2)
 
-    def test_autocorrplot(self):
+    def test_plot_autocorr(self):
         for obj in (self.short_trace, self.fit):
             axes = plot_autocorr(obj)
             assert axes.shape[0] == 1
             assert axes.shape[1] >= 36
 
-    def test_forestplot(self):
+    def test_plot_forest(self):
         for obj in (self.short_trace, self.fit, [self.short_trace, self.fit]):
             _, axes = plot_forest(obj)
             assert axes.shape == (3,)
@@ -61,21 +61,21 @@ class TestPlots(SetupPlots):
             assert axes.shape == (1,)
 
     @pytest.mark.parametrize('kind', ['kde', 'hist'])
-    def test_energyplot(self, kind):
+    def test_plot_energy(self, kind):
         for obj in (self.short_trace, self.fit):
             assert plot_energy(obj, kind=kind)
 
-    def test_parallelplot(self):
+    def test_plot_parallel(self):
         with pytest.raises(ValueError):
             plot_parallel(self.df_trace)
         assert plot_parallel(self.short_trace)
 
     @pytest.mark.parametrize('kind', ['scatter', 'hexbin'])
-    def test_jointplot(self, kind):
+    def test_plot_joint(self, kind):
         for obj in (self.short_trace, self.fit):
             plot_joint(obj, var_names=('mu', 'tau'), kind=kind)
 
-    def test_pairplot(self):
+    def test_plot_pair(self):
 
         plot_pair(self.short_trace, var_names=['theta'], divergences=True,
                   coords={'theta_dim_0': [0, 1]}, plot_kwargs={'marker': 'x'},
@@ -87,19 +87,19 @@ class TestPlots(SetupPlots):
                   coords={'theta_dim_0': [0, 1]}, plot_kwargs={'cmap': 'viridis'}, textsize=20)
 
     @pytest.mark.parametrize('kind', ['kde', 'cumulative'])
-    def test_ppcplot(self, kind):
+    def test_plot_ppc(self, kind):
         data = from_pymc3(trace=self.short_trace, posterior_predictive=self.sample_ppc)
         plot_ppc(data, kind=kind)
 
-    def test_violintraceplot(self):
+    def test_plot_violin(self):
         for obj in (self.short_trace, self.fit):
-            axes = plot_violintrace(obj)
+            axes = plot_violin(obj)
             assert axes.shape[0] >= 18
 
 
 class TestPosteriorPlot(SetupPlots):
 
-    def test_posteriorplot(self):
+    def test_plot_posterior(self):
         for obj in (self.short_trace, self.fit):
             axes = plot_posterior(obj, var_names=('mu', 'tau'), rope=(-2, 2), ref_val=0)
             assert axes.shape == (2,)

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -4,7 +4,7 @@ import numpy as np
 import pymc3 as pm
 import pytest
 
-from arviz import pymc3_to_inference_data
+from arviz import from_pymc3
 from .helpers import eight_schools_params, load_cached_models, BaseArvizTest
 from ..plots import (densityplot, traceplot, energyplot, posteriorplot, autocorrplot, forestplot,
                      parallelplot, pairplot, jointplot, ppcplot, violintraceplot)
@@ -83,7 +83,7 @@ class TestPlots(SetupPlots):
 
     @pytest.mark.parametrize('kind', ['kde', 'cumulative'])
     def test_ppcplot(self, kind):
-        data = pymc3_to_inference_data(trace=self.short_trace, posterior_predictive=self.sample_ppc)
+        data = from_pymc3(trace=self.short_trace, posterior_predictive=self.sample_ppc)
         ppcplot(data, kind=kind)
 
     def test_violintraceplot(self):

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -29,7 +29,8 @@ Contributions and issue reports are very welcome at
 .. toctree::
    :maxdepth: 1
 
-   installation
+   Quickstart<notebooks/Introduction>
+   Example Gallery<examples/index>
    Current Roadmap<roadmap>
    Example Gallery<examples/index>
    Quickstart<notebooks/Introduction>

--- a/examples/autocorrplot.py
+++ b/examples/autocorrplot.py
@@ -9,4 +9,4 @@ import arviz as az
 az.style.use('arviz-darkgrid')
 
 data = az.load_arviz_data('centered_eight')
-az.autocorrplot(data, var_names=('tau', 'mu'))
+az.plot_autocorr(data, var_names=('tau', 'mu'))

--- a/examples/compareplot.py
+++ b/examples/compareplot.py
@@ -38,4 +38,4 @@ model_compare = az.compare({
     non_centered: non_centered_eight_trace
 })
 
-az.compareplot(model_compare, figsize=(12, 4))
+az.plot_compare(model_compare, figsize=(12, 4))

--- a/examples/densityplot.py
+++ b/examples/densityplot.py
@@ -10,7 +10,7 @@ az.style.use('arviz-darkgrid')
 
 centered_data = az.load_arviz_data('centered_eight')
 non_centered_data = az.load_arviz_data('non_centered_eight')
-az.densityplot([centered_data, non_centered_data],
-               data_labels=['Centered', 'Non Centered'],
-               var_names=['theta'],
-               shade=0.1)
+az.plot_density([centered_data, non_centered_data],
+                data_labels=['Centered', 'Non Centered'],
+                var_names=['theta'],
+                shade=0.1)

--- a/examples/energyplot.py
+++ b/examples/energyplot.py
@@ -23,4 +23,4 @@ with pm.Model('Centered Eight Schools') as centered_eight:
     obs = pm.Normal('obs', mu=theta, sd=sigma, observed=y)
     centered_eight_trace = pm.sample()
 
-az.energyplot(centered_eight_trace, figsize=(12, 8))
+az.plot_energy(centered_eight_trace, figsize=(12, 8))

--- a/examples/forestplot.py
+++ b/examples/forestplot.py
@@ -10,7 +10,7 @@ az.style.use('arviz-darkgrid')
 
 centered_data = az.load_arviz_data('centered_eight')
 non_centered_data = az.load_arviz_data('non_centered_eight')
-fig, axes = az.forestplot([centered_data, non_centered_data],
-                          model_names=['Centered', 'Non Centered'],
-                          var_names=['mu'])
+fig, axes = az.plot_forest([centered_data, non_centered_data],
+                           model_names=['Centered', 'Non Centered'],
+                           var_names=['mu'])
 axes[0].set_title('Estimated theta for eight schools model')

--- a/examples/hexpairplot.py
+++ b/examples/hexpairplot.py
@@ -11,5 +11,5 @@ az.style.use('arviz-darkgrid')
 centered = az.load_arviz_data('centered_eight')
 
 coords = {'school': ['Choate', 'Deerfield']}
-az.pairplot(centered, var_names=['theta', "mu", "tau"], kind='hexbin', coords=coords,
-            colorbar=True, divergences=True)
+az.plot_pair(centered, var_names=['theta', "mu", "tau"], kind='hexbin', coords=coords,
+             colorbar=True, divergences=True)

--- a/examples/jointplot.py
+++ b/examples/jointplot.py
@@ -11,8 +11,8 @@ az.style.use('arviz-darkgrid')
 
 data = az.load_arviz_data('non_centered_eight')
 
-az.jointplot(data,
-             var_names=['theta'],
-             coords={'school': ['Choate', 'Phillips Andover']},
-             kind='hexbin',
-             figsize=(10, 10))
+az.plot_joint(data,
+              var_names=['theta'],
+              coords={'school': ['Choate', 'Phillips Andover']},
+              kind='hexbin',
+              figsize=(10, 10))

--- a/examples/kdepairplot.py
+++ b/examples/kdepairplot.py
@@ -11,4 +11,4 @@ az.style.use('arviz-darkgrid')
 centered = az.load_arviz_data('centered_eight')
 
 coords = {'school': ['Choate', 'Deerfield']}
-az.pairplot(centered, var_names=['theta', 'mu', 'tau'], kind="kde", coords=coords, divergences=True)
+az.plot_pair(centered, var_names=['theta', 'mu', 'tau'], kind="kde", coords=coords, divergences=True)

--- a/examples/kdeplot.py
+++ b/examples/kdeplot.py
@@ -10,6 +10,6 @@ import numpy as np
 
 az.style.use('arviz-darkgrid')
 
-ax = az.kdeplot(np.random.gumbel(size=100), label='100 gumbel samples', rug=True,
-                plot_kwargs={'linewidth': 5, 'color': 'black'},
-                rug_kwargs={'color': 'black'})
+ax = az.plot_kde(np.random.gumbel(size=100), label='100 gumbel samples', rug=True,
+                 plot_kwargs={'linewidth': 5, 'color': 'black'},
+                 rug_kwargs={'color': 'black'})

--- a/examples/pairplot.py
+++ b/examples/pairplot.py
@@ -11,4 +11,4 @@ az.style.use('arviz-darkgrid')
 centered = az.load_arviz_data('centered_eight')
 
 coords = {'school': ['Choate', 'Deerfield']}
-az.pairplot(centered, var_names=['theta', 'mu', 'tau'], coords=coords, divergences=True)
+az.plot_pair(centered, var_names=['theta', 'mu', 'tau'], coords=coords, divergences=True)

--- a/examples/parallelplot.py
+++ b/examples/parallelplot.py
@@ -23,4 +23,4 @@ with pm.Model() as centered_eight:
     obs = pm.Normal('obs', mu=theta, sd=sigma, observed=y)
     centered_eight_trace = pm.sample()
 
-az.parallelplot(centered_eight_trace, var_names=['theta', 'tau', 'mu'])
+az.plot_parallel(centered_eight_trace, var_names=['theta', 'tau', 'mu'])

--- a/examples/posteriorplot.py
+++ b/examples/posteriorplot.py
@@ -10,4 +10,4 @@ az.style.use('arviz-darkgrid')
 
 non_centered = az.load_arviz_data('non_centered_eight')
 
-az.posteriorplot(non_centered, var_names=("mu", 'theta_tilde',), rope=(-1, 1))
+az.plot_posterior(non_centered, var_names=("mu", 'theta_tilde',), rope=(-1, 1))

--- a/examples/ppcplot.py
+++ b/examples/ppcplot.py
@@ -9,4 +9,4 @@ import arviz as az
 az.style.use('arviz-darkgrid')
 
 data = az.load_arviz_data('non_centered_eight')
-az.ppcplot(data, alpha=0.03, figsize=(12, 6), textsize=14)
+az.plot_ppc(data, alpha=0.03, figsize=(12, 6), textsize=14)

--- a/examples/ppcplot_cumulative.py
+++ b/examples/ppcplot_cumulative.py
@@ -9,4 +9,4 @@ import arviz as az
 az.style.use('arviz-darkgrid')
 
 data = az.load_arviz_data('non_centered_eight')
-az.ppcplot(data, alpha=0.03, kind='cumulative', figsize=(12, 6), textsize=14)
+az.plot_ppc(data, alpha=0.03, kind='cumulative', figsize=(12, 6), textsize=14)

--- a/examples/ridgeplot.py
+++ b/examples/ridgeplot.py
@@ -9,13 +9,13 @@ import arviz as az
 az.style.use('arviz-darkgrid')
 
 non_centered_data = az.load_arviz_data('non_centered_eight')
-fig, axes = az.forestplot(non_centered_data,
-                          kind='ridgeplot',
-                          var_names=['theta'],
-                          combined=True,
-                          textsize=11,
-                          ridgeplot_overlap=3,
-                          colors='white',
-                          r_hat=False,
-                          n_eff=False)
+fig, axes = az.plot_forest(non_centered_data,
+                           kind='ridgeplot',
+                           var_names=['theta'],
+                           combined=True,
+                           textsize=11,
+                           ridgeplot_overlap=3,
+                           colors='white',
+                           r_hat=False,
+                           n_eff=False)
 axes[0].set_title('Estimated theta for eight schools model', fontsize=11)

--- a/examples/traceplot.py
+++ b/examples/traceplot.py
@@ -9,4 +9,4 @@ import arviz as az
 az.style.use('arviz-darkgrid')
 
 data = az.load_arviz_data('non_centered_eight')
-az.traceplot(data, var_names=('tau', 'mu'))
+az.plot_trace(data, var_names=('tau', 'mu'))

--- a/examples/violinplot.py
+++ b/examples/violinplot.py
@@ -9,4 +9,4 @@ import arviz as az
 az.style.use('arviz-darkgrid')
 
 non_centered = az.load_arviz_data('non_centered_eight')
-az.violintraceplot(non_centered, var_names=["mu", "tau"], textsize=8)
+az.plot_violintrace(non_centered, var_names=["mu", "tau"], textsize=8)

--- a/examples/violinplot.py
+++ b/examples/violinplot.py
@@ -9,4 +9,4 @@ import arviz as az
 az.style.use('arviz-darkgrid')
 
 non_centered = az.load_arviz_data('non_centered_eight')
-az.plot_violintrace(non_centered, var_names=["mu", "tau"], textsize=8)
+az.plot_violin(non_centered, var_names=["mu", "tau"], textsize=8)


### PR DESCRIPTION
io contains now

    io_pymc3.py
        from_pymc3 --> InferenceData
    io_pystan.py
        from_pystan --> InferenceData

`convert_to_inference_data` now contains `**kwargs` and they are passed for `from_pymc3` and `from_pystan` functions.

All the plots are imported to `plots.__init__` as 

    from xyzplot import xyzplot as plot_xyz

This will keep the names of the files and everything normal.