### PR TITLE
fix dict order with OrderedDict and streamline plot_utils functions

### DIFF
--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -7,7 +7,7 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from arviz import convert_to_dataset
 from .kdeplot import plot_kde
-from .plot_utils import _scale_text, xarray_to_nparray, get_coords
+from .plot_utils import _scale_text, xarray_to_ndarray, get_coords
 
 
 def plot_pair(data, var_names=None, coords=None, figsize=None, textsize=None, kind='scatter',
@@ -72,12 +72,12 @@ def plot_pair(data, var_names=None, coords=None, figsize=None, textsize=None, ki
 
     # Get posterior draws and combine chains
     posterior_data = convert_to_dataset(data, group='posterior')
-    _var_names, _posterior = xarray_to_nparray(get_coords(posterior_data, coords),
+    _var_names, _posterior = xarray_to_ndarray(get_coords(posterior_data, coords),
                                                var_names=var_names, combined=True)
 
     # Get diverging draws and combine chains
     divergent_data = convert_to_dataset(data, group='sample_stats')
-    _, diverging_mask = xarray_to_nparray(divergent_data, var_names=('diverging',), combined=True)
+    _, diverging_mask = xarray_to_ndarray(divergent_data, var_names=('diverging',), combined=True)
     diverging_mask = np.squeeze(diverging_mask)
 
     if divergences_kwargs is None:

--- a/arviz/plots/parallelplot.py
+++ b/arviz/plots/parallelplot.py
@@ -3,7 +3,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from arviz import convert_to_dataset
-from .plot_utils import _scale_text, xarray_to_nparray, get_coords
+from .plot_utils import _scale_text, xarray_to_ndarray, get_coords
 
 
 def plot_parallel(data, var_names=None, coords=None, figsize=None, textsize=None, legend=True,
@@ -47,12 +47,12 @@ def plot_parallel(data, var_names=None, coords=None, figsize=None, textsize=None
 
     # Get diverging draws and combine chains
     divergent_data = convert_to_dataset(data, group='sample_stats')
-    _, diverging_mask = xarray_to_nparray(divergent_data, var_names=('diverging',), combined=True)
+    _, diverging_mask = xarray_to_ndarray(divergent_data, var_names=('diverging',), combined=True)
     diverging_mask = np.squeeze(diverging_mask)
 
     # Get posterior draws and combine chains
     posterior_data = convert_to_dataset(data, group='posterior')
-    _var_names, _posterior = xarray_to_nparray(get_coords(posterior_data, coords),
+    _var_names, _posterior = xarray_to_ndarray(get_coords(posterior_data, coords),
                                                var_names=var_names, combined=True)
 
 

--- a/arviz/tests/test_plot_utils.py
+++ b/arviz/tests/test_plot_utils.py
@@ -3,7 +3,7 @@ import numpy as np
 import xarray as xr
 import pytest
 
-from ..plots.plot_utils import xarray_to_nparray, xarray_var_iter, get_coords
+from ..plots.plot_utils import xarray_to_ndarray, xarray_var_iter, get_coords
 
 
 @pytest.fixture(scope='function')
@@ -22,7 +22,7 @@ def sample_dataset():
 
 def test_dataset_to_numpy_not_combined(sample_dataset):  # pylint: disable=invalid-name
     mu, tau, data = sample_dataset
-    var_names, data = xarray_to_nparray(data, combined=False)
+    var_names, data = xarray_to_ndarray(data, combined=False)
 
     # 2 vars x 2 chains
     assert len(var_names) == 4
@@ -31,7 +31,7 @@ def test_dataset_to_numpy_not_combined(sample_dataset):  # pylint: disable=inval
 
 def test_dataset_to_numpy_combined(sample_dataset):
     mu, tau, data = sample_dataset
-    var_names, data = xarray_to_nparray(data, combined=True)
+    var_names, data = xarray_to_ndarray(data, combined=True)
 
     assert len(var_names) == 2
     assert (data[0] == mu.reshape(1, 6)).all()


### PR DESCRIPTION
Let's go with the odict. It is easiest solution.

At least I usually assume that the order of input equals output.

I streamlined a few functions, nothing big.