### PR TITLE
clean namespace

### DIFF
--- a/arviz/data/__init__.py
+++ b/arviz/data/__init__.py
@@ -1,4 +1,4 @@
-#pylint: disable=wildcard-import
+# pylint: disable=wildcard-import
 """Code for loading and manipulating data structures."""
 from .inference_data import InferenceData
 from .io_netcdf import load_data, save_data, load_arviz_data
@@ -6,3 +6,8 @@ from .base import numpy_to_data_array, dict_to_dataset
 from .converters import convert_to_dataset, convert_to_inference_data
 from .io_pymc3 import from_pymc3
 from .io_pystan import from_pystan
+
+
+__all__ = ['InferenceData', 'load_data', 'save_data', 'load_arviz_data', 'numpy_to_data_array',
+           'dict_to_dataset', 'convert_to_dataset', 'convert_to_inference_data', 'from_pymc3',
+           'from_pystan']

--- a/arviz/plots/__init__.py
+++ b/arviz/plots/__init__.py
@@ -13,3 +13,8 @@ from .jointplot import plot_joint
 from .khatplot import plot_khat
 from .ppcplot import plot_ppc
 from .violinplot import plot_violin
+
+
+__all__ = ['plot_autocorr', 'plot_compare', 'plot_density', 'plot_energy', 'plot_forest',
+           'plot_kde', '_fast_kde', '_fast_kde_2d', 'plot_parallel', 'plot_posterior',
+           'plot_trace', 'plot_pair', 'plot_joint', 'plot_khat', 'plot_ppc', 'plot_violin']

--- a/arviz/stats/__init__.py
+++ b/arviz/stats/__init__.py
@@ -2,3 +2,7 @@
 """Statistical tests and diagnostics for ArviZ."""
 from .stats import *
 from .diagnostics import *
+
+
+__all__ = ['bfmi', 'compare', 'hpd', 'loo', 'psislw', 'r2_score', 'summary', 'waic', 'effective_n',
+           'gelman_rubin', 'geweke', 'autocorr']


### PR DESCRIPTION
I noticed that it was possible to have access to numpy and pandas from ArviZ or that we have, for example  `jointplot` and `plot_joint` at the same level. This fix it. Not sure if this is the best way, but it's one way :-) 