### PR TITLE
Add 2d kde example

### DIFF
--- a/examples/plot_kde_2d.py
+++ b/examples/plot_kde_2d.py
@@ -1,0 +1,12 @@
+"""
+2d KDE
+======
+
+_thumb: .1, .8
+"""
+import arviz as az
+import numpy as np
+
+az.style.use('arviz-darkgrid')
+
+az.plot_kde(np.random.rand(100), np.random.rand(100))


### PR DESCRIPTION
Adding an example of a 2d kde plot. I'll add another that actually has correlated variables later, but this is visually pleasing. It will change on every commit.

![image](https://user-images.githubusercontent.com/2295568/45920972-6b487b80-be7a-11e8-8b50-c662b83fc672.png)
