### PR TITLE
[Demo] Why not use plt.subplots(numvars-1, numvars-1)  

### DIFF
--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -118,8 +118,8 @@ def plot_pair(data, var_names=None, coords=None, figsize=None, textsize=None, ki
         ax.tick_params(labelsize=textsize)
 
     if gs is None and ax is None:
-        plt.figure(figsize=figsize)
-        gs = gridspec.GridSpec(numvars - 1, numvars - 1, wspace=0.05, hspace=0.05)
+        fig, axes = plt.subplots(numvars - 1, numvars - 1, figsize=figsize)
+        # gs = gridspec.GridSpec(numvars - 1, numvars - 1, wspace=0.05, hspace=0.05)
 
         axs = []
         for i in range(0, numvars - 1):
@@ -128,7 +128,7 @@ def plot_pair(data, var_names=None, coords=None, figsize=None, textsize=None, ki
             for j in range(i, numvars - 1):
                 var2 = _posterior[j + 1]
 
-                ax = plt.subplot(gs[j, i])
+                ax = axes[j, i]
 
                 if kind == 'scatter':
                     ax.scatter(var1, var2, s=markersize, **plot_kwargs)
@@ -161,7 +161,7 @@ def plot_pair(data, var_names=None, coords=None, figsize=None, textsize=None, ki
                     ax.set_ylabel('{}'.format(_var_names[j + 1]), fontsize=textsize)
 
                 ax.tick_params(labelsize=textsize)
-                axs.append(ax)
+                # axs.append(ax)
 
-    plt.tight_layout()
+    fig.tight_layout()
     return ax, gs


### PR DESCRIPTION
@junpenglao Demonstration per your PR comment. 

> Since the shape of the subplot is known (numvars-1, numvars-1), why not just create fig, ax = plt.subplots(numvars-1, numvars-1, figsize=figsize) above and index to the right one here?


Is this implementation what you were referring to?

![image](https://user-images.githubusercontent.com/7213793/45938966-bb5f3500-bf83-11e8-9461-eda0054c3539.png)
