### PR TITLE
Update AutoCorrPlot test

### DIFF
--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -43,12 +43,6 @@ class TestPlots(SetupPlots):
                               combined=combined, lines=[('mu', {}, [1, 2])])
             assert axes.shape == (2, 2)
 
-    def test_plot_autocorr(self):
-        for obj in (self.pymc3_fit, self.stan_fit):
-            axes = plot_autocorr(obj)
-            assert axes.shape[0] == 1
-            assert axes.shape[1] >= 36
-
     def test_plot_forest(self):
         for obj in (self.pymc3_fit, self.stan_fit, [self.pymc3_fit, self.stan_fit]):
             _, axes = plot_forest(obj)
@@ -95,6 +89,23 @@ class TestPlots(SetupPlots):
         for obj in (self.pymc3_fit, self.stan_fit):
             axes = plot_violin(obj)
             assert axes.shape[0] >= 18
+
+
+class TestAutoCorrPlot(SetupPlots):
+
+    @pytest.mark.parametrize("obj_attr", ["pymc3_fit", "stan_fit"])
+    def test_plot_autocorr_uncombined(self, obj_attr):
+        obj = getattr(self, obj_attr)
+        axes = plot_autocorr(obj, combined=False)
+        assert axes.shape[0] == 1
+        assert axes.shape[1] in (36, 68)
+
+    @pytest.mark.parametrize("obj_attr", ["pymc3_fit", "stan_fit"])
+    def test_plot_autocorr_combined(self, obj_attr):
+        obj = getattr(self, obj_attr)
+        axes = plot_autocorr(obj, combined=True)
+        assert axes.shape[0] == 1
+        assert axes.shape[1] == 18
 
 
 class TestPosteriorPlot(SetupPlots):

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -98,14 +98,16 @@ class TestAutoCorrPlot(SetupPlots):
         obj = getattr(self, obj_attr)
         axes = plot_autocorr(obj, combined=False)
         assert axes.shape[0] == 1
-        assert axes.shape[1] in (36, 68)
+        assert (axes.shape[1] == 36 and obj_attr == "pymc3_fit" or
+                axes.shape[1] == 68 and obj_attr == "stan_fit")
 
     @pytest.mark.parametrize("obj_attr", ["pymc3_fit", "stan_fit"])
     def test_plot_autocorr_combined(self, obj_attr):
         obj = getattr(self, obj_attr)
         axes = plot_autocorr(obj, combined=True)
         assert axes.shape[0] == 1
-        assert axes.shape[1] == 18
+        assert (axes.shape[1] == 18 and obj_attr == "pymc3_fit" or
+                axes.shape[1] == 34 and obj_attr == "stan_fit")
 
 
 class TestPosteriorPlot(SetupPlots):


### PR DESCRIPTION
One question I have,
Does it make sense to have all the plot tests take a pymc3.MultiTrace and a StanFit4Anon model as an input, and instead have az.InferenceData as an input?

I ask because these objects get converted to InferenceData right at the top of most plots, and I vaguely feel like we should have `(pymc3.MultiTrace, StanFit4Anon) -> Inference Data` be its own test and decouple the object conversion from "does it plot" test?

I could make arguments about repeated computation, and more atomic tests, but if someone has strong(er) feelings let me know.
