### PR TITLE
Rename Class fixture attrs to be more descriptive

### DIFF
--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -18,10 +18,10 @@ class SetupPlots(BaseArvizTest):
         super().setup_class()
         cls.data = eight_schools_params()
         models = load_cached_models(draws=500, chains=2)
-        model, cls.short_trace = models['pymc3']
+        model, cls.pymc3_fit = models['pymc3']
         with model:
-            cls.sample_ppc = pm.sample_ppc(cls.short_trace, 100)
-        cls.stan_model, cls.fit = models['pystan']
+            cls.pymc3_sample_ppc = pm.sample_ppc(cls.pymc3_fit, 100)
+        cls.stan_model, cls.stan_fit = models['pystan']
         cls.df_trace = DataFrame({'a': np.random.poisson(2.3, 100)})
 
     def teardown_method(self):
@@ -31,26 +31,26 @@ class SetupPlots(BaseArvizTest):
 
 class TestPlots(SetupPlots):
     def test_plot_density(self):
-        for obj in (self.short_trace, self.fit):
+        for obj in (self.pymc3_fit, self.stan_fit):
             axes = plot_density(obj)
             assert axes.shape[0] >= 18
             assert axes.shape[1] == 1
 
     @pytest.mark.parametrize('combined', [True, False])
     def test_plot_trace(self, combined):
-        for obj in (self.short_trace, self.fit):
+        for obj in (self.pymc3_fit, self.stan_fit):
             axes = plot_trace(obj, var_names=('mu', 'tau'),
                               combined=combined, lines=[('mu', {}, [1, 2])])
             assert axes.shape == (2, 2)
 
     def test_plot_autocorr(self):
-        for obj in (self.short_trace, self.fit):
+        for obj in (self.pymc3_fit, self.stan_fit):
             axes = plot_autocorr(obj)
             assert axes.shape[0] == 1
             assert axes.shape[1] >= 36
 
     def test_plot_forest(self):
-        for obj in (self.short_trace, self.fit, [self.short_trace, self.fit]):
+        for obj in (self.pymc3_fit, self.stan_fit, [self.pymc3_fit, self.stan_fit]):
             _, axes = plot_forest(obj)
             assert axes.shape == (3,)
             _, axes = plot_forest(obj, r_hat=False, quartiles=False)
@@ -62,37 +62,37 @@ class TestPlots(SetupPlots):
 
     @pytest.mark.parametrize('kind', ['kde', 'hist'])
     def test_plot_energy(self, kind):
-        for obj in (self.short_trace, self.fit):
+        for obj in (self.pymc3_fit, self.stan_fit):
             assert plot_energy(obj, kind=kind)
 
     def test_plot_parallel(self):
         with pytest.raises(ValueError):
             plot_parallel(self.df_trace)
-        assert plot_parallel(self.short_trace)
+        assert plot_parallel(self.pymc3_fit)
 
     @pytest.mark.parametrize('kind', ['scatter', 'hexbin'])
     def test_plot_joint(self, kind):
-        for obj in (self.short_trace, self.fit):
+        for obj in (self.pymc3_fit, self.stan_fit):
             plot_joint(obj, var_names=('mu', 'tau'), kind=kind)
 
     def test_plot_pair(self):
 
-        plot_pair(self.short_trace, var_names=['theta'], divergences=True,
+        plot_pair(self.pymc3_fit, var_names=['theta'], divergences=True,
                   coords={'theta_dim_0': [0, 1]}, plot_kwargs={'marker': 'x'},
                   divergences_kwargs={'marker': '*', 'c': 'C'})
 
-        plot_pair(self.short_trace, divergences=True, plot_kwargs={'marker': 'x'},
+        plot_pair(self.pymc3_fit, divergences=True, plot_kwargs={'marker': 'x'},
                   divergences_kwargs={'marker': '*', 'c': 'C'})
-        plot_pair(self.short_trace, kind='hexbin', var_names=['theta'],
+        plot_pair(self.pymc3_fit, kind='hexbin', var_names=['theta'],
                   coords={'theta_dim_0': [0, 1]}, plot_kwargs={'cmap': 'viridis'}, textsize=20)
 
     @pytest.mark.parametrize('kind', ['density', 'cumulative'])
     def test_plot_ppc(self, kind):
-        data = from_pymc3(trace=self.short_trace, posterior_predictive=self.sample_ppc)
+        data = from_pymc3(trace=self.pymc3_fit, posterior_predictive=self.pymc3_sample_ppc)
         plot_ppc(data, kind=kind)
 
     def test_plot_violin(self):
-        for obj in (self.short_trace, self.fit):
+        for obj in (self.pymc3_fit, self.stan_fit):
             axes = plot_violin(obj)
             assert axes.shape[0] >= 18
 
@@ -100,12 +100,12 @@ class TestPlots(SetupPlots):
 class TestPosteriorPlot(SetupPlots):
 
     def test_plot_posterior(self):
-        for obj in (self.short_trace, self.fit):
+        for obj in (self.pymc3_fit, self.stan_fit):
             axes = plot_posterior(obj, var_names=('mu', 'tau'), rope=(-2, 2), ref_val=0)
             assert axes.shape == (2,)
 
     @pytest.mark.parametrize("point_estimate", ('mode', 'mean', 'median'))
     def test_point_estimates(self, point_estimate):
-        for obj in (self.short_trace, self.fit):
+        for obj in (self.pymc3_fit, self.stan_fit):
             axes = plot_posterior(obj, var_names=('mu', 'tau'), point_estimate=point_estimate)
             assert axes.shape == (2,)


### PR DESCRIPTION
Makes it possible to know what object the attr is without having to run a debugger or read across modules