### PR TITLE
Use constrained_layout in plot_pair

### DIFF
--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -118,8 +118,8 @@ def plot_pair(data, var_names=None, coords=None, figsize=None, textsize=None, ki
         ax.tick_params(labelsize=textsize)
 
     if gs is None and ax is None:
-        fig, _ = plt.subplots(0, 0, figsize=figsize)
-        gs = gridspec.GridSpec(numvars - 1, numvars - 1, wspace=0.05, hspace=0.05)
+        fig = plt.figure(figsize=figsize, constrained_layout=True)
+        gs = gridspec.GridSpec(numvars - 1, numvars - 1, figure=fig)
 
         axs = []
         for i in range(0, numvars - 1):
@@ -165,5 +165,4 @@ def plot_pair(data, var_names=None, coords=None, figsize=None, textsize=None, ki
                 ax.tick_params(labelsize=textsize)
                 axs.append(ax)
 
-    fig.tight_layout()
     return ax, gs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-matplotlib
+matplotlib>=2.1
 numpy
 scipy
 pandas


### PR DESCRIPTION
This gets rid of a warning, and trying a few different sizes it looked reasonable.

Here's the new version of the example:

![image](https://user-images.githubusercontent.com/2295568/46031472-ed2ce480-c0c6-11e8-8b8b-6e55341a92a1.png)

Here's the version on master:

![image](https://user-images.githubusercontent.com/2295568/46031505-fddd5a80-c0c6-11e8-985b-b7eb8cc4ef97.png)
