### PR TITLE
Fix warnings on doc build

### DIFF
--- a/arviz/plots/ppcplot.py
+++ b/arviz/plots/ppcplot.py
@@ -25,11 +25,10 @@ def plot_ppc(data, kind='density', alpha=0.2, mean=True, figsize=None, textsize=
         If None, size is (6, 5)
     textsize: int
         Text size for labels. If None it will be auto-scaled based on figsize.
-    data_pairs : dict
-        Dictionary containing relations between observed data and posterior predictive data.
-        Dictionary structure:
-            Key = data var_name
-            Value = posterior predictive var_name
+    data_pairs : dict[str] -> str
+        Dictionary containing relations between observed data and posterior
+        predictive data. Dictionary keys are data var_name and posterior
+        predictive var_name.
         Example: `data_pairs = {'y' : 'y_hat'}`
 
     Returns

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -44,7 +44,6 @@ extensions = [
     'sphinx.ext.autosummary',
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
-    'matplotlib.sphinxext.only_directives',
     'matplotlib.sphinxext.plot_directive',
     'numpydoc',
     'nbsphinx',


### PR DESCRIPTION
Docs aren't building which is breaking the build. This tackles a few of those warnings - I think the main problem is the `matplotlib.sphinxext.only_directives` not being found with matplotlib 3.0. I removed that locally and everything worked, but I think sphinx caches aggressively, so going to try on travis.