### PR TITLE
Add emcee support

### DIFF
--- a/arviz/data/__init__.py
+++ b/arviz/data/__init__.py
@@ -5,8 +5,9 @@ from .base import numpy_to_data_array, dict_to_dataset
 from .converters import convert_to_dataset, convert_to_inference_data
 from .io_pymc3 import from_pymc3
 from .io_pystan import from_pystan
+from .io_emcee import from_emcee
 
 
 __all__ = ['InferenceData', 'load_data', 'save_data', 'load_arviz_data', 'numpy_to_data_array',
            'dict_to_dataset', 'convert_to_dataset', 'convert_to_inference_data', 'from_pymc3',
-           'from_pystan']
+           'from_pystan', 'from_emcee']

--- a/arviz/data/converters.py
+++ b/arviz/data/converters.py
@@ -4,6 +4,7 @@ import xarray as xr
 
 from .inference_data import InferenceData
 from .base import dict_to_dataset
+from .io_emcee import from_emcee
 from .io_pymc3 import from_pymc3
 from .io_pystan import from_pystan
 
@@ -50,6 +51,8 @@ def convert_to_inference_data(obj, *, group='posterior', coords=None, dims=None,
         return from_pystan(fit=obj, coords=coords, dims=dims, **kwargs)
     elif obj.__class__.__name__ == 'MultiTrace':  # ugly, but doesn't make PyMC3 a requirement
         return from_pymc3(trace=obj, coords=coords, dims=dims, **kwargs)
+    elif obj.__class__.__name__ == 'EnsembleSampler':  # ugly, but doesn't make emcee a requirement
+        return from_emcee(obj, coords=coords, dims=dims, **kwargs)
 
     # Cases that convert to xarray
     if isinstance(obj, xr.Dataset):

--- a/arviz/data/io_emcee.py
+++ b/arviz/data/io_emcee.py
@@ -1,0 +1,101 @@
+"""emcee-specific conversion code."""
+from .inference_data import InferenceData
+from .base import dict_to_dataset
+
+def _verify_names(sampler, var_names, arg_names):
+    """Make sure var_names and arg_names are assigned reasonably.
+
+    This is meant to run before loading emcee objects into InferenceData.
+    In case var_names or arg_names is None, will provide defaults. If they are
+    not None, it verifies there are the right number of them.
+
+    Throws a ValueError in case validation fails.
+
+    Parameters
+    ----------
+    sampler : emcee.EnsembleSampler
+        Fitted emcee sampler
+    var_names : list[str] or None
+        Names for the emcee parameters
+    arg_names : list[str] or None
+        Names for the args/observations provided to emcee
+
+    Returns
+    -------
+    list[str], list[str]
+        Defaults for var_names and arg_names
+    """
+    num_vars = sampler.chain.shape[-1]
+    num_args = len(sampler.args)
+
+    if var_names is None:
+        var_names = ['var_{}'.format(idx) for idx in range(num_vars)]
+    if arg_names is None:
+        arg_names = ['arg_{}'.format(idx) for idx in range(num_args)]
+
+    if len(var_names) != num_vars:
+        raise ValueError(
+            'The sampler has {} variables, but only {} var_names were provided!'.format(
+                num_vars, len(var_names)))
+
+    if len(arg_names) != num_args:
+        raise ValueError('The sampler has {} args, but only {} arg_names were provided!'.format(
+            num_args, len(arg_names)))
+    return var_names, arg_names
+
+
+class EmceeConverter:
+    """Encapsulate emcee specific logic."""
+
+    def __init__(self, sampler, *_, var_names=None, arg_names=None, coords=None, dims=None):
+        var_names, arg_names = _verify_names(sampler, var_names, arg_names)
+        self.sampler = sampler
+        self.var_names = var_names
+        self.arg_names = arg_names
+        self.coords = coords
+        self.dims = dims
+
+    def posterior_to_xarray(self):
+        """Convert the posterior to an xarray dataset."""
+        data = {}
+        for idx, var_name in enumerate(self.var_names):
+            data[var_name] = self.sampler.chain[(..., idx)]
+        return dict_to_dataset(data, coords=self.coords, dims=self.dims)
+
+    def observed_data_to_xarray(self):
+        """Convert observed data to xarray."""
+        data = {}
+        for idx, var_name in enumerate(self.arg_names):
+            data[var_name] = self.sampler.args[idx]
+        return dict_to_dataset(data, coords=self.coords, dims=self.dims)
+
+    def to_inference_data(self):
+        """Convert all available data to an InferenceData object."""
+        return InferenceData(**{
+            'posterior': self.posterior_to_xarray(),
+            'observed_data': self.observed_data_to_xarray(),
+        })
+
+
+def from_emcee(sampler, *, var_names=None, arg_names=None, coords=None, dims=None):
+    """Convert emcee data into an InferenceData object.
+
+    Parameters
+    ----------
+    sampler : emcee.EnsembleSampler
+        Fitted sampler from emcee.
+    var_names : list[str] (Optional)
+        A list of names for variables in the sampler
+    arg_names : list[str] (Optional)
+        A list of names for args in the sampler
+    coords : dict[str] -> list[str]
+        Map of dimensions to coordinates
+    dims : dict[str] -> list[str]
+        Map variable names to their coordinates
+    """
+    return EmceeConverter(
+        sampler,
+        var_names=var_names,
+        arg_names=arg_names,
+        coords=coords,
+        dims=dims).to_inference_data()

--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -77,12 +77,15 @@ def plot_pair(data, var_names=None, coords=None, figsize=None, textsize=None, ki
                                                var_names=var_names, combined=True)
 
     # Get diverging draws and combine chains
-    divergent_data = convert_to_dataset(data, group='sample_stats')
-    _, diverging_mask = xarray_to_ndarray(divergent_data, var_names=('diverging',), combined=True)
-    diverging_mask = np.squeeze(diverging_mask)
+    if divergences:
+        divergent_data = convert_to_dataset(data, group='sample_stats')
+        _, diverging_mask = xarray_to_ndarray(divergent_data,
+                                              var_names=('diverging',),
+                                              combined=True)
+        diverging_mask = np.squeeze(diverging_mask)
 
-    if divergences_kwargs is None:
-        divergences_kwargs = {}
+        if divergences_kwargs is None:
+            divergences_kwargs = {}
 
     if gridsize == 'auto':
         gridsize = int(len(_posterior[0])**0.35)

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -8,6 +8,7 @@ from arviz import (
     convert_to_dataset,
     from_pymc3,
     from_pystan,
+    from_emcee,
 )
 from .helpers import eight_schools_params, load_cached_models, BaseArvizTest
 
@@ -208,6 +209,30 @@ class TestDictNetCDFUtils(BaseArvizTest):
             coords={'school': np.arange(self.data['J'])},
             dims={'theta': ['school'], 'theta_tilde': ['school']},
         )
+
+class TestEmceeNetCDFUtils(BaseArvizTest):
+
+    @classmethod
+    def setup_class(cls):
+        cls.draws, cls.chains = 500, 20
+        fake_chains = cls.chains // 10  # emcee uses lots of walkers
+        cls.obj = load_cached_models(cls.draws, fake_chains)['emcee']
+
+    def get_inference_data(self):
+
+        return from_emcee(
+            self.obj,
+            var_names=['ln(f)', 'b', 'm']
+        )
+
+    def test__verify_var_names(self):
+        with pytest.raises(ValueError):
+            from_emcee(self.obj, var_names=['not', 'enough'])
+
+    def test__verify_arg_names(self):
+        with pytest.raises(ValueError):
+            from_emcee(self.obj, arg_names=['not', 'enough'])
+
 
 
 class TestPyMC3NetCDFUtils(BaseArvizTest):

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -21,6 +21,7 @@ def models(request):
         models = load_cached_models(draws=500, chains=2)
         pymc3_model, pymc3_fit = models['pymc3']
         stan_model, stan_fit = models['pystan']
+        emcee_fit = models['emcee']
 
     def fin():
         plt.close('all')
@@ -72,12 +73,21 @@ def test_plot_density_int():
     assert axes.shape[1] == 1
 
 
-@pytest.mark.parametrize("model_fit", ["pymc3_fit", "stan_fit"])
+@pytest.mark.parametrize("model_fit", ["pymc3_fit", "stan_fit", "emcee_fit"])
 @pytest.mark.parametrize('combined', [True, False])
 def test_plot_trace(models, combined, model_fit):
+    has_labels = bool(model_fit in {'pymc3_fit', 'stan_fit'})
     obj = getattr(models, model_fit)
-    axes = plot_trace(obj, var_names=('mu', 'tau'), combined=combined, lines=[('mu', {}, [1, 2])])
-    assert axes.shape == (2, 2)
+    if has_labels:
+        kwargs = {'var_names': ('mu', 'tau'), 'lines': [('mu', {}, [1, 2])]}
+    else:
+        kwargs = {}
+    axes = plot_trace(obj, combined=combined, **kwargs)
+
+    assert axes.ndim == 2
+    assert axes.shape[1] == 2
+    if has_labels:
+        assert axes.shape == (2, 2)
 
 
 @pytest.mark.parametrize("model_fits", [["pymc3_fit"], ["stan_fit"], ["pymc3_fit", "stan_fit"]])

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+emcee
 git+https://github.com/pymc-devs/pymc3
 pystan
 ipython


### PR DESCRIPTION
This adds support for [emcee](http://dfm.io/emcee/current/), and adds a model to the test suite.

I ended up not adding test support to too many plots: `emcee` does not "know" the names of its variables, so it is hard in `test_plots` to reuse the machinery too much. The test coverage for `io_emcee.py` is still 94% - I will add a small test to throw the two `ValueErrors` that are missing.

Note that now arviz can mostly recreate the plots from http://dfm.io/emcee/current/user/line/ :

```python
import arviz as az
from arviz.tests import helpers

az.style.use('arviz-darkgrid')

sampler = models['emcee']
data = az.from_emcee(sampler, var_names=['ln(f)', 'b', 'm'])


az.plot_trace(data, trace_kwargs={'color': 'k'})
```
![image](https://user-images.githubusercontent.com/2295568/46248960-1911d800-c3ef-11e8-88cc-e6c6c82f659f.png)

```python
az.plot_pair(data, plot_kwargs={'c': 'k', 'alpha': 0.05})
```
![image](https://user-images.githubusercontent.com/2295568/46248979-537b7500-c3ef-11e8-85c8-d188c84694aa.png)
