### PR TITLE
A sphinx extension disappeared, but it does not matter

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -44,7 +44,6 @@ extensions = [
     'sphinx.ext.autosummary',
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
-    'matplotlib.sphinxext.only_directives',
     'matplotlib.sphinxext.plot_directive',
     'numpydoc',
     'nbsphinx',


### PR DESCRIPTION
This fixes the build, I think. Going to merge right in and see if it actually does, since this can only be checked on master, and won't hurt any functionality. 

I can not find any references to what this extension did, but can confirm it is not exposed on matplotlib 3.0 (which is what breaks the build).