### PR TITLE
Add pyro converter

### DIFF
--- a/arviz/data/__init__.py
+++ b/arviz/data/__init__.py
@@ -3,12 +3,13 @@ from .inference_data import InferenceData
 from .io_netcdf import load_data, save_data, load_arviz_data
 from .base import numpy_to_data_array, dict_to_dataset
 from .converters import convert_to_dataset, convert_to_inference_data
+from .io_cmdstan import from_cmdstan
 from .io_pymc3 import from_pymc3
 from .io_pystan import from_pystan
 from .io_emcee import from_emcee
-from .io_cmdstan import from_cmdstan
+from .io_pyro import from_pyro
 
 
 __all__ = ['InferenceData', 'load_data', 'save_data', 'load_arviz_data', 'numpy_to_data_array',
            'dict_to_dataset', 'convert_to_dataset', 'convert_to_inference_data', 'from_pymc3',
-           'from_pystan', 'from_emcee', 'from_cmdstan']
+           'from_pystan', 'from_emcee', 'from_cmdstan', 'from_pyro']

--- a/arviz/data/converters.py
+++ b/arviz/data/converters.py
@@ -10,6 +10,7 @@ from .io_pyro import from_pyro
 from .io_pystan import from_pystan
 
 
+# pylint: disable=too-many-return-statements
 def convert_to_inference_data(obj, *, group='posterior', coords=None, dims=None, **kwargs):
     r"""Convert a supported object to an InferenceData object.
 

--- a/arviz/data/converters.py
+++ b/arviz/data/converters.py
@@ -6,6 +6,7 @@ from .inference_data import InferenceData
 from .base import dict_to_dataset
 from .io_emcee import from_emcee
 from .io_pymc3 import from_pymc3
+from .io_pyro import from_pyro
 from .io_pystan import from_pystan
 
 
@@ -23,6 +24,8 @@ def convert_to_inference_data(obj, *, group='posterior', coords=None, dims=None,
             | str: Attempts to load the netcdf dataset from disk
             | pystan fit: Automatically extracts data
             | pymc3 trace: Automatically extracts data
+            | emcee sampler: Automatically extracts data
+            | pyro MCMC: Automatically extracts data
             | xarray.Dataset: adds to InferenceData as only group
             | dict: creates an xarray dataset as the only group
             | numpy array: creates an xarray dataset as the only group, gives the
@@ -53,6 +56,8 @@ def convert_to_inference_data(obj, *, group='posterior', coords=None, dims=None,
         return from_pymc3(trace=obj, coords=coords, dims=dims, **kwargs)
     elif obj.__class__.__name__ == 'EnsembleSampler':  # ugly, but doesn't make emcee a requirement
         return from_emcee(obj, coords=coords, dims=dims, **kwargs)
+    elif obj.__class__.__name__ == 'MCMC' and obj.__class__.__module__.startswith('pyro'):
+        return from_pyro(obj, coords=coords, dims=dims, **kwargs)
 
     # Cases that convert to xarray
     if isinstance(obj, xr.Dataset):

--- a/arviz/data/io_pyro.py
+++ b/arviz/data/io_pyro.py
@@ -1,0 +1,89 @@
+"""pyro-specific conversion code."""
+import numpy as np
+
+from .inference_data import InferenceData
+from .base import dict_to_dataset
+
+
+def _get_var_names(posterior):
+    """Extract latent and observed variable names from pyro.MCMC.
+
+    Parameters
+    ----------
+    posterior : pyro.MCMC
+        Fitted MCMC object from Pyro
+
+    Returns
+    -------
+    list[str], list[str]
+    observed and latent variable names from the MCMC trace.
+    """
+    sample_point = posterior.exec_traces[0]
+    nodes = [node for node in sample_point.nodes.values() if node['type'] == 'sample']
+    observed = [node['name'] for node in nodes if node['is_observed']]
+    latent = [node['name'] for node in nodes if not node['is_observed']]
+    return observed, latent
+
+
+class PyroConverter:
+    """Encapsulate Pyro specific logic."""
+
+    def __init__(self, posterior, *_, coords=None, dims=None):
+        """Convert emcee data into an InferenceData object.
+
+        Parameters
+        ----------
+        posterior : pyro.MCMC
+            Fitted MCMC object from Pyro
+        coords : dict[str] -> list[str]
+            Map of dimensions to coordinates
+        dims : dict[str] -> list[str]
+            Map variable names to their coordinates
+        """
+        self.posterior = posterior
+        self.observed_vars, self.latent_vars = _get_var_names(posterior)
+        self.coords = coords
+        self.dims = dims
+
+    def posterior_to_xarray(self):
+        """Convert the posterior to an xarray dataset."""
+        from pyro.infer import EmpiricalMarginal
+        data = {}
+        for var_name in self.latent_vars:
+            samples = EmpiricalMarginal(self.posterior, sites=var_name).get_samples_and_weights()[0]
+            data[var_name] = np.expand_dims(samples.numpy().squeeze(), 0)
+        return dict_to_dataset(data, coords=self.coords, dims=self.dims)
+
+    def observed_data_to_xarray(self):
+        """Convert observed data to xarray."""
+        from pyro.infer import EmpiricalMarginal
+        data = {}
+        for var_name in self.observed_vars:
+            samples = EmpiricalMarginal(self.posterior, sites=var_name).get_samples_and_weights()[0]
+            data[var_name] = np.expand_dims(samples.numpy().squeeze(), 0)
+        return dict_to_dataset(data, coords=self.coords, dims=self.dims)
+
+    def to_inference_data(self):
+        """Convert all available data to an InferenceData object."""
+        return InferenceData(**{
+            'posterior': self.posterior_to_xarray(),
+            'observed_data': self.observed_data_to_xarray(),
+        })
+
+
+def from_pyro(posterior, *, coords=None, dims=None):
+    """Convert pyro data into an InferenceData object.
+
+    Parameters
+    ----------
+    posterior : pyro.MCMC
+        Fitted MCMC object from Pyro
+    coords : dict[str] -> list[str]
+        Map of dimensions to coordinates
+    dims : dict[str] -> list[str]
+        Map variable names to their coordinates
+    """
+    return PyroConverter(
+        posterior=posterior,
+        coords=coords,
+        dims=dims).to_inference_data()

--- a/arviz/data/io_pyro.py
+++ b/arviz/data/io_pyro.py
@@ -29,7 +29,7 @@ class PyroConverter:
     """Encapsulate Pyro specific logic."""
 
     def __init__(self, posterior, *_, coords=None, dims=None):
-        """Convert emcee data into an InferenceData object.
+        """Convert pyro data into an InferenceData object.
 
         Parameters
         ----------
@@ -47,6 +47,7 @@ class PyroConverter:
 
     def posterior_to_xarray(self):
         """Convert the posterior to an xarray dataset."""
+        # Do not make pyro a requirement
         from pyro.infer import EmpiricalMarginal
         data = {}
         for var_name in self.latent_vars:

--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -226,6 +226,7 @@ def load_cached_models(draws, chains):
         (pystan, pystan_noncentered_schools),
         (pm, pymc3_noncentered_schools),
         (emcee, emcee_linear_model),
+        (pyro, pyro_centered_schools),
     )
     data_directory = os.path.join(here, 'saved_models')
     models = {}

--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -145,7 +145,7 @@ def pyro_centered_schools(data, draws, chains):
     sigma = torch.Tensor(data['sigma']).type(torch.Tensor)
 
     nuts_kernel = NUTS(_pyro_conditioned_model, adapt_step_size=True)
-    posterior = MCMC(
+    posterior = MCMC(  # pylint:disable=not-callable
         nuts_kernel,
         num_samples=draws,
         warmup_steps=500,

--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -150,6 +150,14 @@ def pyro_centered_schools(data, draws, chains):
         num_samples=draws,
         warmup_steps=500,
     ).run(_pyro_centered_model, sigma, y)
+
+    # This block lets the posterior be pickled
+    for trace in posterior.exec_traces:
+        for node in trace.nodes.values():
+            node.pop('fn', None)
+    posterior.kernel = None
+    posterior.run = None
+    posterior.logger = None
     return posterior
 
 

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -11,6 +11,7 @@ from arviz import (
     from_pymc3,
     from_pystan,
     from_emcee,
+    from_pyro,
 )
 from .helpers import eight_schools_params, load_cached_models, BaseArvizTest
 

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -11,7 +11,6 @@ from arviz import (
     from_pymc3,
     from_pystan,
     from_emcee,
-    from_pyro,
 )
 from .helpers import eight_schools_params, load_cached_models, BaseArvizTest
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ nbsphinx
 numpydoc
 pydocstyle
 pylint
+pyro-ppl
 pytest
 pytest-cov
 Sphinx

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -23,6 +23,12 @@ if [[ $* != *--global* ]]; then
     source activate ${ENVNAME}
 fi
 
+if [ "$PYTHON_VERSION" -eq "3.5" ]; then
+    pip install http://download.pytorch.org/whl/cpu/torch-0.4.1-cp35-cp35m-linux_x86_64.whl
+else
+    pip install http://download.pytorch.org/whl/cpu/torch-0.4.1-cp36-cp36m-linux_x86_64.whl
+fi
+
 conda install --yes numpy cython scipy pandas matplotlib pytest pylint sphinx numpydoc ipython xarray netcdf4 mkl-service
 
 pip install --upgrade pip

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -23,6 +23,8 @@ if [[ $* != *--global* ]]; then
     source activate ${ENVNAME}
 fi
 
+# Pyro install with pip is ~511MB. These binaries are ~91MB, somehow, and do not
+# break the build. The first is the Python 3.5 wheel, the second is 3.6.
 if [ "$PYTHON_VERSION" = "3.5" ]; then
     pip install http://download.pytorch.org/whl/cpu/torch-0.4.1-cp35-cp35m-linux_x86_64.whl
 else

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -23,7 +23,7 @@ if [[ $* != *--global* ]]; then
     source activate ${ENVNAME}
 fi
 
-if [ "$PYTHON_VERSION" -eq "3.5" ]; then
+if [ "$PYTHON_VERSION" = "3.5" ]; then
     pip install http://download.pytorch.org/whl/cpu/torch-0.4.1-cp35-cp35m-linux_x86_64.whl
 else
     pip install http://download.pytorch.org/whl/cpu/torch-0.4.1-cp36-cp36m-linux_x86_64.whl


### PR DESCRIPTION
This adds pyro support. It is missing tests, but it is ready to be tested as soon as https://github.com/uber/pyro/issues/1426 is settled.

I have run this all manually, and it does ok. The below code gets you a centered eight schools model on this branch.

```python
import arviz as az
from arviz.tests import helpers

posterior = helpers.pyro_centered_schools(helpers.eight_schools_params(), 500, 500)

schools = np.array(['Choate', 'Deerfield', 'Phillips Andover', 'Phillips Exeter', 'Hotchkiss', 'Lawrenceville', "St. Paul's", 'Mt. Hermon'])
data = az.convert_to_inference_data(posterior,
                                    coords={'school': schools},
                                    dims={'theta': ['school'], 'obs': ['school']})

data
```
```
Inference data with groups:
	> posterior
	> observed_data
```