### PR TITLE
Update install order

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-matplotlib>=2.1
+matplotlib>=3.0
 numpy
 scipy
 pandas

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ import shutil
 import os
 import re
 
+import setuptools
 from setuptools import setup, find_packages
 from setuptools.command.install import install
 from setuptools.command.develop import develop
@@ -13,6 +14,10 @@ REQUIREMENTS_FILE = os.path.join(PROJECT_ROOT, 'requirements.txt')
 README_FILE = os.path.join(PROJECT_ROOT, 'README.md')
 VERSION_FILE = os.path.join(PROJECT_ROOT, 'arviz', '__init__.py')
 
+
+# Ensure matplotlib dependencies are available to copy
+# styles over
+setuptools.dist.Distribution().fetch_build_eggs(['matplotlib>=3.0'])
 
 def get_requirements():
     with codecs.open(REQUIREMENTS_FILE) as buff:


### PR DESCRIPTION
This uses https://github.com/pypa/pip/issues/5761 to install matplotlib first. Also pins to at least matplotlib 3.0, since there are some `constrained_layout`s in there.