### PR TITLE
Save plots on testing

### DIFF
--- a/arviz/tests/conftest.py
+++ b/arviz/tests/conftest.py
@@ -18,12 +18,9 @@ def save_figs(request):
     if fig_dir is not None:
         # Try creating directory if it doesn't exist
         print("Saving generated images in {}".format(fig_dir))
-        try:
-            os.mkdir(fig_dir)
-            print("Directory {} created".format(fig_dir))
 
-        except FileExistsError:
-            print("Directory {} exists".format(fig_dir))
+        os.makedirs(fig_dir, exist_ok=True)
+        print("Directory {} created".format(fig_dir))
 
         # Clear all files from the directory
         for file in os.listdir(fig_dir):

--- a/arviz/tests/conftest.py
+++ b/arviz/tests/conftest.py
@@ -18,22 +18,23 @@ def save_figs(request):
 
     if fig_dir is not None:
         # Try creating directory if it doesn't exist
+        print("Saving generated images in {}".format(fig_dir))
         try:
             os.mkdir(fig_dir)
             print("Directory {} created".format(fig_dir))
 
         except FileExistsError:
-            print("Directory {} already exists".format(fig_dir))
+            print("Directory {} exists".format(fig_dir))
 
         # Clear all files from the directory
         for file in os.listdir(fig_dir):
-            try:
-                os.remove(file)
-            except OSError:
-                print("Can't remove {}".format(file))
+            full_path = os.path.join(fig_dir, file)
 
-    else:
-        print("Not saving figures")
+            try:
+                os.remove(full_path)
+
+            except OSError:
+                print("Failed to remove {}".format(full_path))
 
     return fig_dir
 

--- a/arviz/tests/conftest.py
+++ b/arviz/tests/conftest.py
@@ -1,0 +1,40 @@
+"""
+Configuration for test suite
+"""
+import pytest
+import os
+
+
+def pytest_addoption(parser):
+    """Definition for command line option to save figures from tests"""
+    parser.addoption("--save", nargs="?", const="test_images",
+                     help="Save images rendered by plot")
+
+
+@pytest.fixture(scope="session")
+def save_figs(request):
+    """Enables command line switch for saving generation figures upon testing"""
+    fig_dir = request.config.getoption("--save")
+
+    if fig_dir is not None:
+        # Try creating directory if it doesn't exist
+        try:
+            os.mkdir(fig_dir)
+            print("Directory {} created".format(fig_dir))
+
+        except FileExistsError:
+            print("Directory {} already exists".format(fig_dir))
+
+        # Clear all files from the directory
+        for file in os.listdir(fig_dir):
+            try:
+                os.remove(file)
+            except OSError:
+                print("Can't remove {}".format(file))
+
+    else:
+        print("Not saving figures")
+
+    return fig_dir
+
+

--- a/arviz/tests/conftest.py
+++ b/arviz/tests/conftest.py
@@ -1,19 +1,18 @@
-"""
-Configuration for test suite
-"""
-import pytest
+"""Configuration for test suite."""
+# pylint: disable=redefined-outer-name
 import os
+import pytest
 
 
 def pytest_addoption(parser):
-    """Definition for command line option to save figures from tests"""
+    """Definition for command line option to save figures from tests."""
     parser.addoption("--save", nargs="?", const="test_images",
                      help="Save images rendered by plot")
 
 
 @pytest.fixture(scope="session")
 def save_figs(request):
-    """Enables command line switch for saving generation figures upon testing"""
+    """Enable command line switch for saving generation figures upon testing."""
     fig_dir = request.config.getoption("--save")
 
     if fig_dir is not None:
@@ -37,5 +36,3 @@ def save_figs(request):
                 print("Failed to remove {}".format(full_path))
 
     return fig_dir
-
-

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -37,7 +37,18 @@ def clean_plots(request, save_figs):
     """Close plots after each test, optionally save if --save is specified during test invocation"""
     def fin():
         if save_figs is not None:
-            plt.savefig("{0}.png".format(os.path.join(save_figs, request.node.name)))
+
+            # Retry save three times
+            for i in range(3):
+                try:
+                    plt.savefig("{0}.png".format(os.path.join(save_figs, request.node.name)))
+
+                except Exception as err:
+                    if i == 2:
+                        raise err
+                else:
+                    break
+
         plt.close('all')
 
     request.addfinalizer(fin)

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -1,4 +1,5 @@
 # pylint: disable=redefined-outer-name
+import os
 from unittest.mock import MagicMock
 import matplotlib.pyplot as plt
 from pandas import DataFrame
@@ -32,11 +33,16 @@ def models():
 
 
 @pytest.fixture(scope='function', autouse=True)
-def clean_plots(request):
+def clean_plots(request, save_figs):
+    """Close plots after each test, optionally save if --save is specified during test invocation"""
     def fin():
+        if save_figs is not None:
+            plt.savefig("{0}.png".format(os.path.join(save_figs, request.node.name)))
         plt.close('all')
 
     request.addfinalizer(fin)
+    return
+
 
 @pytest.fixture(scope='module')
 def pymc3_sample_ppc(models):

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -43,7 +43,7 @@ def clean_plots(request, save_figs):
                 try:
                     plt.savefig("{0}.png".format(os.path.join(save_figs, request.node.name)))
 
-                except Exception as err:
+                except Exception as err:  # pylint: disable=broad-except
                     if i == 2:
                         raise err
                 else:

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -1,5 +1,6 @@
 # pylint: disable=redefined-outer-name
 import os
+import time
 from unittest.mock import MagicMock
 import matplotlib.pyplot as plt
 from pandas import DataFrame
@@ -46,6 +47,7 @@ def clean_plots(request, save_figs):
                 except Exception as err:  # pylint: disable=broad-except
                     if i == 2:
                         raise err
+                    time.sleep(.250)
                 else:
                     break
 

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -41,7 +41,6 @@ def clean_plots(request, save_figs):
         plt.close('all')
 
     request.addfinalizer(fin)
-    return
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
The code here lets you save plots on testing. If this functionality and interface is acceptable I'll write up documentation and submit in another PR. 

Can you guys try this out and let me know what you think? I have not tested on Windows yet but I'm pretty sure I handled all the problems that would arise from the file system being locked from people leave images open, or leaving Windows Explorer open in the images directory

I want to make it possible to develop plots for ArviZ in the following way.
1. Think of idea for a plot addition, feature, change, or new plot entirely
2. Write code in arviz
3. Write some side code to verify your plot is working
4. Write a test to generate image your code is working as expected
5. Skip step 3 because by writing the test you can generate the image and get the test done in one step!!

**Usage**
Standard behavior of running test and closing plots
```
pytest arviz/tests
```

Saves generated images in a default directory called test_images
```
pytest arviz/tests --save
```

Saves generated images in a user specified directory
```
pytest arviz/tests --save user_choice
```

Test a specific plot and save just that image
```
pytest arviz/tests --save user_choice - k "test_plot_forest_single_value"
```
