### PR TITLE
minor tweaks to examples and plot_posterior docstring

### DIFF
--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -68,7 +68,7 @@ def _scale_fig_size(figsize, textsize, rows=1, cols=1):
         scale_factor = textsize / rc_xt_labelsize
     elif rows == cols == 1:
         scale_factor = ((width * height) / (rc_width * rc_height))**0.5
-    elif rows > 1 or cols > 1:
+    else:
         scale_factor = 1
 
     ax_labelsize = rc_ax_labelsize * scale_factor

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -68,29 +68,22 @@ def plot_posterior(data, var_names=None, coords=None, figsize=None, textsize=Non
         :context: close-figs
 
         >>> import arviz as az
-        >>> non_centered = az.load_arviz_data('non_centered_eight')
-        >>> az.plot_posterior(non_centered)
+        >>> data = az.load_arviz_data('centered_eight')
+        >>> az.plot_posterior(data)
 
     Plot subset variables by specifying variable name exactly
 
     .. plot::
         :context: close-figs
 
-        >>> az.plot_posterior(non_centered, var_names=("mu",), textsize=11)
-
-    Plot subset of variables by matching start of variable name
-
-    .. plot::
-        :context: close-figs
-
-        >>> az.plot_posterior(non_centered, var_names=("mu", "theta_tilde"))
+        >>> az.plot_posterior(data, var_names=['mu'])
 
     Plot Region of Practical Equivalence (rope) for all distributions
 
     .. plot::
         :context: close-figs
 
-        >>> az.plot_posterior(non_centered, var_names=("mu", 'theta_tilde',), rope=(-1, 1))
+        >>> az.plot_posterior(data, var_names=['mu', 'theta'], rope=(-1, 1))
 
     Plot Region of Practical Equivalence for selected distributions
 
@@ -98,7 +91,7 @@ def plot_posterior(data, var_names=None, coords=None, figsize=None, textsize=Non
         :context: close-figs
 
         >>> rope = {'mu': [{'rope': (-2, 2)}], 'theta': [{'school': 'Choate', 'rope': (2, 4)}]}
-        >>> az.plot_posterior(non_centered, var_names=('mu', 'theta_tilde',), rope=rope)
+        >>> az.plot_posterior(data, var_names=['mu', 'theta'], rope=rope)
 
 
     Add reference lines
@@ -106,28 +99,28 @@ def plot_posterior(data, var_names=None, coords=None, figsize=None, textsize=Non
     .. plot::
         :context: close-figs
 
-        >>> az.plot_posterior(non_centered, var_names=('mu', 'theta_tilde',), ref_val=0)
+        >>> az.plot_posterior(data, var_names=['mu', 'theta_tilde'], ref_val=0)
 
     Show point estimate of distribution
 
     .. plot::
         :context: close-figs
 
-        >>> az.plot_posterior(non_centered, var_names=('mu', 'theta_tilde',), point_estimate="mode")
+        >>> az.plot_posterior(data, var_names=['mu', 'theta_tilde'], point_estimate='mode')
 
     Plot posterior as a histogram
 
     .. plot::
         :context: close-figs
 
-        >>> az.plot_posterior(non_centered, var_names=('mu', 'theta_tilde',), kind="hist")
+        >>> az.plot_posterior(data, var_names=['mu'], kind='hist')
 
     Change size of credible interval
 
     .. plot::
         :context: close-figs
 
-        >>> az.plot_posterior(non_centered, var_names=('mu', 'theta_tilde',), credible_interval=.94)
+        >>> az.plot_posterior(data, var_names=['mu'], credible_interval=.75)
     """
     data = convert_to_dataset(data, group='posterior')
 

--- a/examples/plot_compare.py
+++ b/examples/plot_compare.py
@@ -9,9 +9,6 @@ import arviz as az
 az.style.use('arviz-darkgrid')
 
 
-model_compare = az.compare({
-    'Centered eight schools': az.load_arviz_data('centered_eight'),
-    'Non-centered eight schools': az.load_arviz_data('non_centered_eight'),
-})
-
+model_compare = az.compare({'Centered 8 schools': az.load_arviz_data('centered_eight'),
+                           'Non-centered 8 schools': az.load_arviz_data('non_centered_eight')})
 az.plot_compare(model_compare, figsize=(12, 4))

--- a/examples/plot_forest.py
+++ b/examples/plot_forest.py
@@ -10,7 +10,7 @@ az.style.use('arviz-darkgrid')
 
 centered_data = az.load_arviz_data('centered_eight')
 non_centered_data = az.load_arviz_data('non_centered_eight')
-fig, axes = az.plot_forest([centered_data, non_centered_data],
-                           model_names=['Centered', 'Non Centered'],
-                           var_names=['mu'])
+_, axes = az.plot_forest([centered_data, non_centered_data],
+                         model_names=['Centered', 'Non Centered'],
+                         var_names=['mu'])
 axes[0].set_title('Estimated theta for eight schools model')

--- a/examples/plot_forest_ridge.py
+++ b/examples/plot_forest_ridge.py
@@ -13,7 +13,7 @@ fig, axes = az.plot_forest(non_centered_data,
                            kind='ridgeplot',
                            var_names=['theta'],
                            combined=True,
-                           textsize=11,
                            ridgeplot_overlap=3,
-                           colors='white')
-axes[0].set_title('Estimated theta for eight schools model', fontsize=11)
+                           colors='white',
+                           figsize=(9, 7))
+axes[0].set_title('Estimated theta for 8 schools model')

--- a/examples/plot_kde.py
+++ b/examples/plot_kde.py
@@ -14,6 +14,6 @@ data = az.load_arviz_data('centered_eight')
 # Combine posterior draws for from xarray of (4,500) to ndarray (2000,)
 y_hat = np.concatenate(data.posterior_predictive["obs"].values)
 
-ax = az.plot_kde(y_hat, label='Estimated Effect of SAT Prep', rug=True,
-                 plot_kwargs={'linewidth': 5, 'color': 'black'},
+ax = az.plot_kde(y_hat, label='Estimated Effect\n of SAT Prep', rug=True,
+                 plot_kwargs={'linewidth': 2, 'color': 'black'},
                  rug_kwargs={'color': 'black'})

--- a/examples/plot_pair.py
+++ b/examples/plot_pair.py
@@ -11,4 +11,4 @@ az.style.use('arviz-darkgrid')
 centered = az.load_arviz_data('centered_eight')
 
 coords = {'school': ['Choate', 'Deerfield']}
-az.plot_pair(centered, var_names=['theta', 'mu', 'tau'], coords=coords, divergences=True)
+az.plot_pair(data, var_names=['theta', 'mu', 'tau'], coords=coords, divergences=True, textsize=22)

--- a/examples/plot_pair_kde.py
+++ b/examples/plot_pair_kde.py
@@ -11,4 +11,5 @@ az.style.use('arviz-darkgrid')
 centered = az.load_arviz_data('centered_eight')
 
 coords = {'school': ['Choate', 'Deerfield']}
-az.plot_pair(centered, var_names=['theta', 'mu', 'tau'], kind="kde", coords=coords, divergences=True)
+az.plot_pair(centered, var_names=['theta', 'mu', 'tau'], kind='kde', coords=coords,
+             divergences=True, textsize=22)

--- a/examples/plot_parallel.py
+++ b/examples/plot_parallel.py
@@ -9,4 +9,5 @@ import arviz as az
 az.style.use('arviz-darkgrid')
 
 data = az.load_arviz_data('centered_eight')
-az.plot_parallel(data, var_names=['theta', 'tau', 'mu'])
+ax = az.plot_parallel(data, var_names=['theta', 'tau', 'mu'])
+ax.set_xticklabels(ax.get_xticklabels(), rotation=70)

--- a/examples/plot_posterior.py
+++ b/examples/plot_posterior.py
@@ -8,6 +8,8 @@ import arviz as az
 
 az.style.use('arviz-darkgrid')
 
-non_centered = az.load_arviz_data('non_centered_eight')
+data = az.load_arviz_data('centered_eight')
 
-az.plot_posterior(non_centered, var_names=("mu", 'theta_tilde',), rope=(-1, 1))
+coords = {'school': ['Choate']}
+az.plot_posterior(data, var_names=['mu', 'theta'], coords=coords, rope=(-1, 1))
+

--- a/examples/plot_ppc_cumulative.py
+++ b/examples/plot_ppc_cumulative.py
@@ -9,4 +9,4 @@ import arviz as az
 az.style.use('arviz-darkgrid')
 
 data = az.load_arviz_data('non_centered_eight')
-az.plot_ppc(data, alpha=0.03, kind='cumulative', figsize=(12, 6), textsize=14)
+az.plot_ppc(data, alpha=0.3, kind='cumulative', figsize=(12, 6), textsize=14)

--- a/examples/plot_violin.py
+++ b/examples/plot_violin.py
@@ -8,5 +8,5 @@ import arviz as az
 
 az.style.use('arviz-darkgrid')
 
-non_centered = az.load_arviz_data('non_centered_eight')
-az.plot_violin(non_centered, var_names=["mu", "tau"], textsize=8)
+data = az.load_arviz_data('non_centered_eight')
+az.plot_violin(data, var_names=['mu', 'tau'])


### PR DESCRIPTION
I made several few changes, like trying to make some of the plots look nicer, being consistent with quotes marks, use list to pass `var_names` instead of tuples (I think this is less prone to errors and also the docs says that a list is expected). 