### PR TITLE
Fix examples

### DIFF
--- a/examples/plot_pair.py
+++ b/examples/plot_pair.py
@@ -11,4 +11,4 @@ az.style.use('arviz-darkgrid')
 centered = az.load_arviz_data('centered_eight')
 
 coords = {'school': ['Choate', 'Deerfield']}
-az.plot_pair(data, var_names=['theta', 'mu', 'tau'], coords=coords, divergences=True, textsize=22)
+az.plot_pair(centered, var_names=['theta', 'mu', 'tau'], coords=coords, divergences=True, textsize=22)


### PR DESCRIPTION
Typo got into the examples, and broke docs.