### PR TITLE
DOC: add api examples for plot_ppc. #355

### DIFF
--- a/arviz/plots/ppcplot.py
+++ b/arviz/plots/ppcplot.py
@@ -37,6 +37,25 @@ def plot_ppc(
     Returns
     -------
     axes : matplotlib axes
+
+    Examples
+    --------
+    Plot the observed data KDE overlaid on posterior predictive KDEs.
+
+    .. plot::
+        :context: close-figs
+
+        >>> import arviz as az
+        >>> data = az.load_arviz_data('radon')
+        >>> az.plot_ppc(data)
+
+    Plot the overlay with empirical CDFs.
+
+    .. plot::
+        :context: close-figs
+
+        >>> az.plot_ppc(data, kind='cumulative')
+
     """
     for group in ("posterior_predictive", "observed_data"):
         if not hasattr(data, group):


### PR DESCRIPTION
Adds api examples for the plot_ppc function. Closes #355 

Let me know if there are edits/other examples you want added. 

In my html builds, the legends were defaulting quite large and covering up a lot of the plots. I also used the provided radon example data rather than the eight schools since the distributions are less wonky and make for a cleaner example in my opinion. Let me know if you would prefer the eight schools to fit with the other examples on the site.