### PR TITLE
smooth hpd

### DIFF
--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -249,9 +249,9 @@ def hpd(
     circular : bool, optional
         Whether to compute the error taking into account `x` is a circular variable
         (in the range [-np.pi, np.pi]) or not. Defaults to False (i.e non-circular variables).
-    smooth_kwargs : dicts, optional
-        Additional keywords modifying the Savitzky-Golay filter. Only works if smooth is True.
-        Currently accepts window_length, polyorder and mode. See Scipy's documentation for details
+    smooth_kwargs : dict, optional
+        Additional keywords modifying the Savitzky-Golay filter. See Scipy's documentation for
+        details
 
     Returns
     -------
@@ -274,13 +274,11 @@ def hpd(
             order = min(3, window - 1)
             if window % 2 == 0:
                 window += 1
-            hpd_array = savgol_filter(
-                x=hpd_array,
-                window_length=smooth_kwargs.get("window_length", window),
-                polyorder=smooth_kwargs.get("polyorder", order),
-                mode=smooth_kwargs.get("mode", "mirror"),
-                axis=0,
-            )
+            smooth_kwargs.setdefault("window_length", window)
+            smooth_kwargs.setdefault("polyorder", order)
+            smooth_kwargs.setdefault("mode", "mirror")
+            smooth_kwargs.setdefault("axis", 0)
+            hpd_array = savgol_filter(x=hpd_array, **smooth_kwargs)
         return hpd_array
     # Make a copy of trace
     x = transform(x.copy())

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -222,7 +222,14 @@ def _ic_matrix(ics, ic_i):
     return rows, cols, ic_i_val
 
 
-def hpd(x, credible_interval=0.94, smooth=False, transform=lambda x: x, circular=False):
+def hpd(
+    x,
+    credible_interval=0.94,
+    smooth=False,
+    transform=lambda x: x,
+    circular=False,
+    smooth_kwargs=None,
+):
     """
     Calculate highest posterior density (HPD) of array for given credible_interval.
 
@@ -242,6 +249,9 @@ def hpd(x, credible_interval=0.94, smooth=False, transform=lambda x: x, circular
     circular : bool, optional
         Whether to compute the error taking into account `x` is a circular variable
         (in the range [-np.pi, np.pi]) or not. Defaults to False (i.e non-circular variables).
+    smooth_kwargs : dicts, optional
+        Additional keywords modifying the Savitzky-Golay filter. Only works if smooth is True.
+        Currently accepts window_length, polyorder and mode. See Scipy's documentation for details
 
     Returns
     -------
@@ -258,13 +268,18 @@ def hpd(x, credible_interval=0.94, smooth=False, transform=lambda x: x, circular
             ]
         )
         if smooth:
+            if smooth_kwargs is None:
+                smooth_kwargs = {}
             window = x.shape[1] // 3
             order = min(3, window - 1)
             if window % 2 == 0:
                 window += 1
-
             hpd_array = savgol_filter(
-                x=hpd_array, window_length=window, polyorder=order, mode="mirror", axis=0
+                x=hpd_array,
+                window_length=smooth_kwargs.get("window_length", window),
+                polyorder=smooth_kwargs.get("polyorder", order),
+                mode=smooth_kwargs.get("mode", "mirror"),
+                axis=0,
             )
         return hpd_array
     # Make a copy of trace

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -31,6 +31,11 @@ def test_hpd():
     interval = hpd(normal_sample)
     assert_array_almost_equal(interval, [-1.88, 1.88], 2)
 
+def test_hpd_smooth():
+    normal_sample = np.random.randn(500, 50)
+    hpd_s = hpd(normal_sample, smooth=True).var(0)
+    hpd_ns = hpd(normal_sample, smooth=False).var(0)
+    np.testing.assert_array_less(hpd_s, hpd_ns)
 
 def test_r2_score():
     x = np.linspace(0, 1, 100)

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -31,11 +31,13 @@ def test_hpd():
     interval = hpd(normal_sample)
     assert_array_almost_equal(interval, [-1.88, 1.88], 2)
 
+
 def test_hpd_smooth():
     normal_sample = np.random.randn(500, 50)
     hpd_s = hpd(normal_sample, smooth=True).var(0)
     hpd_ns = hpd(normal_sample, smooth=False).var(0)
     np.testing.assert_array_less(hpd_s, hpd_ns)
+
 
 def test_r2_score():
     x = np.linspace(0, 1, 100)


### PR DESCRIPTION
This add the option to smooth the output of a hpd, I hope this helps to get nicer plots and less confused students/audience. I did not do extensive testing but seems that the parameters I am using for `Savitzky-Golay` generally work, but I am open to suggestions. Should we let the user select those parameters? 

![smooth](https://user-images.githubusercontent.com/1338958/47524834-1382a300-d872-11e8-97d7-a69c0bfde871.png)
