### PR TITLE
Trace divergence

### DIFF
--- a/arviz/plots/traceplot.py
+++ b/arviz/plots/traceplot.py
@@ -89,7 +89,6 @@ def plot_trace(
         >>> coords = {'theta_t_dim_0': [0, 1], 'school':['Lawrenceville']}
         >>> az.plot_trace(data, var_names=('theta_t', 'theta'), coords=coords, lines=lines)
     """
-
     if divergences:
         try:
             divergence_data = convert_to_dataset(data, group="sample_stats").diverging
@@ -175,22 +174,28 @@ def plot_trace(
                 div_idxs = np.arange(len(chain_divs))[chain_divs]
                 if div_idxs.size > 0:
                     values = value[chain, div_idxs]
-                    axes[idx, 1].vlines(
+                    axes[idx, 1].plot(
                         div_idxs,
-                        *ylims[1],
-                        colors=colors[idx][chain],
-                        linestyles="dashed",
+                        np.zeros_like(div_idxs) + ylims[1][0],
+                        marker="|",
+                        color="black",
+                        markeredgewidth=1.5,
+                        markersize=30,
+                        linestyle="None",
                         alpha=hist_kwargs["alpha"],
-                        zorder=-5
+                        zorder=-5,
                     )
                     axes[idx, 1].set_ylim(*ylims[1])
-                    axes[idx, 0].vlines(
+                    axes[idx, 0].plot(
                         values,
-                        *ylims[1],
-                        colors=colors[idx][chain],
-                        linestyles="dashed",
+                        np.zeros_like(values),
+                        marker="|",
+                        color="black",
+                        markeredgewidth=1.5,
+                        markersize=30,
+                        linestyle="None",
                         alpha=trace_kwargs["alpha"],
-                        zorder=-5
+                        zorder=-5,
                     )
                     axes[idx, 0].set_ylim(*ylims[0])
 

--- a/arviz/plots/traceplot.py
+++ b/arviz/plots/traceplot.py
@@ -12,7 +12,7 @@ def plot_trace(
     data,
     var_names=None,
     coords=None,
-    divergences=True,
+    divergences="bottom",
     figsize=None,
     textsize=None,
     lines=None,
@@ -35,8 +35,8 @@ def plot_trace(
         Variables to be plotted, two variables are required.
     coords : mapping, optional
         Coordinates of var_names to be plotted. Passed to `Dataset.sel`
-    divergences : bool
-        Plot location of divergences on the traceplots
+    divergences : {"bottom", "top", None, False}
+        Plot location of divergences on the traceplots. Options are "bottom", "top", or False-y.
     figsize : figure size tuple
         If None, size is (12, variables * 2)
     textsize: float
@@ -173,10 +173,14 @@ def plot_trace(
             for chain, chain_divs in enumerate(divs):
                 div_idxs = np.arange(len(chain_divs))[chain_divs]
                 if div_idxs.size > 0:
+                    if divergences == "top":
+                        ylocs = [ylim[1] for ylim in ylims]
+                    else:
+                        ylocs = [ylim[0] for ylim in ylims]
                     values = value[chain, div_idxs]
                     axes[idx, 1].plot(
                         div_idxs,
-                        np.zeros_like(div_idxs) + ylims[1][0],
+                        np.zeros_like(div_idxs) + ylocs[1],
                         marker="|",
                         color="black",
                         markeredgewidth=1.5,
@@ -188,7 +192,7 @@ def plot_trace(
                     axes[idx, 1].set_ylim(*ylims[1])
                     axes[idx, 0].plot(
                         values,
-                        np.zeros_like(values),
+                        np.zeros_like(values) + ylocs[0],
                         marker="|",
                         color="black",
                         markeredgewidth=1.5,

--- a/arviz/plots/traceplot.py
+++ b/arviz/plots/traceplot.py
@@ -99,9 +99,6 @@ def plot_trace(
     data = convert_to_dataset(data, group="posterior")
     var_names = _var_names(var_names)
 
-    if var_names is None:
-        var_names = list(data.data_vars)
-
     if coords is None:
         coords = {}
 

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -131,6 +131,7 @@ def test_plot_density_discrete(discrete_model):
         {"var_names": "mu"},
         {"var_names": ["mu", "tau"]},
         {"combined": True},
+        {"divergences": False},
         {"lines": [("mu", {}, [1, 2])]},
         {"lines": [("mu", 0)]},
     ],

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -131,6 +131,7 @@ def test_plot_density_discrete(discrete_model):
         {"var_names": "mu"},
         {"var_names": ["mu", "tau"]},
         {"combined": True},
+        {"divergences": "top"},
         {"divergences": False},
         {"lines": [("mu", {}, [1, 2])]},
         {"lines": [("mu", 0)]},


### PR DESCRIPTION
Fixes #385 

This adds vertical dashed lines wherever there are divergences. I have turned it on by default mostly to be provocative - I'm ok to have it off by default.  I sort of like that the markers are visually distracting whenever you *should* be distracted by divergences.

A lot of the shuffling of the code was done so that these lines (and the `lines` argument) would not change the x or y limits of the plots. Note that this happens on master right now!

Here is an example of the output for the centered and non-centered eight schools:

![image](https://user-images.githubusercontent.com/2295568/47920561-b649ab80-de88-11e8-8600-f42b73713127.png)
