### PR TITLE
WIP: Add parameter indexing & plot style support to plot_ppc #375

### DIFF
--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -259,7 +259,7 @@ def xarray_var_iter(data, var_names=None, combined=False, skip_dims=None, revers
     for var_name in var_names:
         if var_name in data:
             new_dims = [dim for dim in data[var_name].dims if dim not in skip_dims]
-            vals = [data[var_name][dim].values for dim in new_dims]
+            vals = [set(data[var_name][dim].values) for dim in new_dims]
             dims = [{k: v for k, v in zip(new_dims, prod)} for prod in product(*vals)]
             if reverse_selections:
                 dims = reversed(dims)

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -259,7 +259,7 @@ def xarray_var_iter(data, var_names=None, combined=False, skip_dims=None, revers
     for var_name in var_names:
         if var_name in data:
             new_dims = [dim for dim in data[var_name].dims if dim not in skip_dims]
-            vals = [set(data[var_name][dim].values) for dim in new_dims]
+            vals = [data[var_name][dim].values for dim in new_dims]
             dims = [{k: v for k, v in zip(new_dims, prod)} for prod in product(*vals)]
             if reverse_selections:
                 dims = reversed(dims)

--- a/arviz/plots/ppcplot.py
+++ b/arviz/plots/ppcplot.py
@@ -1,70 +1,35 @@
 """Posterior predictive plot."""
 import numpy as np
 from .kdeplot import plot_kde, _fast_kde
-from .plot_utils import (
-    xarray_var_iter,
-    _scale_fig_size,
-    make_label,
-    default_grid,
-    _create_axes_grid,
-    get_coords,
-)
-from ..utils import _var_names
+from .plot_utils import _scale_fig_size, _create_axes_grid, default_grid
 
 
-def plot_ppc(data, var_names=None, coords=None, flatten=None,
-             obs_plot_style="auto", pp_plot_style="auto", pp_flatten="auto",
-             alpha=0.2, mean=True, figsize=None, textsize=None, data_pairs=None):
+def plot_ppc(
+    data, kind="density", alpha=0.2, mean=True, figsize=None, textsize=None, data_pairs=None
+):
     """
     Plot for Posterior Predictive checks.
+
+    Note that this plot will flatten out any dimensions in the posterior predictive variables.
 
     Parameters
     ----------
     data : az.InferenceData object
         InferenceData object containing the observed and posterior
         predictive data.
-    var_names : list
-        List of variables to be plotted. Defaults to all variables in the
-        model if None.
-    coords : dict
-        Dictionary mapping dimensions to selected coordinates to be plotted.
-        Passed to `Dataset.sel`. Dimensions without a mapping specified will
-        include all coordinates for that dimension. Defaults to including all
-        coordinates for all dimensions if None.
-    flatten : list
-        List of dimensions to flatten. Only flattens across the coordinates
-        specified in the coords argument. Defaults to flattening all of the dimensions.
-    obs_plot_style: str
-        The style to plot the observed data with. Must be in ('auto',
-        'scatter', 'pdf', 'cdf', 'hist'). 'scatter' will plot a 1d
-        scatter of the data. 'cdf' and 'pdf' will plot cumulative and kernel
-        density estimates of the data respectively. 'hist' will plot a  histogram of the
-        data. Defaults to 'auto' where 'scatter' is chosen if the number of
-        observations is less than 30, otherwise 'pdf'.
-    pp_plot_style: str
-        The style to plot the posterior predictive data with. Must be in ('auto',
-        'pdf', 'cdf'). 'cdf' and 'pdf' will plot cumulative and kernel
-        density estimates of the data respectively. Defaults to 'auto' where 'cdf'
-        is chosen if the obs_plot_style is also 'cdf', otherwise 'pdf'.
-    pp_flatten: str
-        Whether to flatten the posterior predictive density plot across samples.
-        Must be in ('auto', 'individual', 'combined', 'both').
-        If 'individual', it will plot a separate density for each individual
-        posterior predictive sample. If 'combined', it will plot a single
-        density for all of the posterior predictive data flattened across
-        samples. If 'both', it will plot both the flattened and individual
-        kdes. Defaults to 'auto' where 'combined' is chosen if the number of
-        observations in each sample is less than 30, otherwise 'both'.
+    kind : str
+        Type of plot to display (density or cumulative). Defaults to density.
     alpha : float
         Opacity of posterior predictive density curves. Defaults to 0.2.
+    mean : bool
+        Whether or not to plot the mean posterior predictive distribution. Defaults to True
     figsize : tuple
         Figure size. If None it will be defined automatically.
     textsize: float
-        Text size scaling factor for labels, titles and lines.
-        If None it will be autoscaled based on figsize.
+        Text size scaling factor for labels, titles and lines. If None it will be
+        autoscaled based on figsize.
     data_pairs : dict
-        Dictionary containing relations between observed data and posterior
-        predictive data.
+        Dictionary containing relations between observed data and posterior predictive data.
         Dictionary structure:
             Key = data var_name
 
@@ -103,92 +68,38 @@ def plot_ppc(data, var_names=None, coords=None, flatten=None,
                 '`data` argument must have the group "{group}" for ppcplot'.format(group=group)
             )
 
-    observed = data.observed_data
-    posterior_predictive = data.posterior_predictive
-
-    #if density_type.lower() not in ("pdf", "cdf"):
-    #    raise TypeError("`kind` argument must be either `pdf` or `cdf`")
+    if kind.lower() not in ("density", "cumulative"):
+        raise TypeError("`kind` argument must be either `density` or `cumulative`")
 
     if data_pairs is None:
         data_pairs = {}
 
-    data_threshold = 30
+    observed = data.observed_data
+    posterior_predictive = data.posterior_predictive
 
-    if var_names is None:
-        var_names = observed.data_vars;
-    var_names = _var_names(var_names)
-    pp_var_names = [data_pairs.get(var, var) for var in var_names]
+    rows, cols = default_grid(len(observed.data_vars))
 
-    if flatten is None:
-      flatten = list(observed.dims.keys())
-
-    if coords is None:
-        coords = {}
-
-
-    new_coords = {}
-    for key in coords.keys():
-        vals = coords[key]
-        new_coords[key] = np.where(np.in1d(observed[key], vals))[0]
-    coords = new_coords
-
-    obs_plotters = list(xarray_var_iter(observed.isel(coords),
-                                        skip_dims=set(flatten),
-                                        var_names=var_names,
-                                        combined=True))
-    pp_plotters = list(xarray_var_iter(posterior_predictive.isel(coords),
-                                       var_names=pp_var_names,
-                                       skip_dims=set(flatten),
-                                       combined=True))
-    length_plotters = len(obs_plotters)
-    print(length_plotters)
-    rows, cols = default_grid(length_plotters)
-
-
-    # TODO: Validate new argument inputs
-    assert(len(pp_plotters) == length_plotters)
-
-    (figsize, ax_labelsize, _, xt_labelsize, linewidth, markersize) = _scale_fig_size(
+    (figsize, ax_labelsize, _, xt_labelsize, linewidth, _) = _scale_fig_size(
         figsize, textsize, rows, cols
     )
 
-    _, axes = _create_axes_grid(length_plotters, rows, cols, figsize=figsize)
-    print(axes.shape)
+    _, axes = _create_axes_grid(len(observed.data_vars), rows, cols, figsize=figsize)
 
-    for i, ax in enumerate(np.ravel(axes)):
-
-        # plot the observed data
-        var_name, selection, x = obs_plotters[i]
+    for ax, var_name in zip(np.atleast_1d(axes), observed.data_vars):
         dtype = observed[var_name].dtype.kind
-        print(var_name)
-        print(selection)
-        print(x.shape)
-        x = x.flatten()
-        print(x.shape)
-        num_obs = len(x)
-
-        # Plot the observed data
-        if obs_plot_style == "auto":
-            if num_obs < data_threshold:
-                kind = "scatter"
-            else:
-                kind = "pdf"
-        else:
-            kind = obs_plot_style
-
-        ax.set_title(make_label(var_name, selection))
-        if kind == "pdf":
+        if kind == "density":
             if dtype == "f":
                 plot_kde(
-                    x,
+                    observed[var_name].values.flatten(),
                     label="Observed {}".format(var_name),
                     plot_kwargs={"color": "k", "linewidth": linewidth, "zorder": 3},
                     fill_kwargs={"alpha": 0},
                     ax=ax,
                 )
             else:
-                nbins = round(len(x) ** 0.5)
-                hist, bin_edges = np.histogram(x, bins=nbins, density=True)
+                vals = observed[var_name].values.flatten()
+                nbins = round(len(vals) ** 0.5)
+                hist, bin_edges = np.histogram(vals, bins=nbins, density=True)
                 hist = np.concatenate((hist[:1], hist))
                 ax.plot(
                     bin_edges,
@@ -199,62 +110,11 @@ def plot_ppc(data, var_names=None, coords=None, flatten=None,
                     zorder=3,
                     drawstyle="steps-pre",
                 )
-        elif kind == "cdf":
-            if dtype == "f":
-                ax.plot(
-                    *_empirical_cdf(x),
-                    color="k",
-                    linewidth=linewidth,
-                    label="Observed {}".format(var_name),
-                    zorder=3
-                )
-            else:
-                ax.plot(
-                    *_empirical_cdf(x),
-                    color="k",
-                    linewidth=linewidth,
-                    label="Observed {}".format(var_name),
-                    drawstyle="steps-pre",
-                    zorder=3
-                )
-        elif kind == "scatter":
-            ax.plot(x, np.zeros_like(x), 'o', markersize=markersize)
-        elif kind == "hist":
-            # TODO: histogram support
-            print("Figure out arviz way to histogram. Appropriate to add in this PR?")
-        else:
-            # TODO: Handle invalid obs_plot_type
-            print("Invalid observed data plot type: %s" % kind)
-
-        # Plot posterior predictive data
-        pp_var_name, selection, x = pp_plotters[i]
-        print(pp_var_name)
-        print(selection)
-        print(x.shape)
-        x = x.squeeze()
-        if len(x.shape) > 2:
-            x = x.reshape((x.shape[0], np.prod(x.shape[1:])))
-        print(x.shape)
-
-        if pp_flatten == "auto":
-          if num_obs < data_threshold:
-              flatten = 'combined'
-          else:
-              flatten = 'both'
-        else:
-            flatten = pp_flatten
-
-        if pp_plot_style == "auto":
-            if obs_plot_style == "cdf":
-                kind = "cdf"
-            else:
-                kind = "pdf"
-
-        if kind == "pdf":
-            if flatten in ['individual', 'both']:
-                # run plot_kde manually with one plot call
-                pp_densities = []
-                for vals in x:
+            pp_var_name = data_pairs.get(var_name, var_name)
+            # run plot_kde manually with one plot call
+            pp_densities = []
+            for _, chain_vals in posterior_predictive[pp_var_name].groupby("chain"):
+                for _, vals in chain_vals.groupby("draw"):
                     if dtype == "f":
                         pp_density, lower, upper = _fast_kde(vals)
                         pp_x = np.linspace(lower, upper, len(pp_density))
@@ -264,15 +124,15 @@ def plot_ppc(data, var_names=None, coords=None, flatten=None,
                         hist, bin_edges = np.histogram(vals, bins=nbins, density=True)
                         hist = np.concatenate((hist[:1], hist))
                         pp_densities.extend([bin_edges, hist])
-                plot_kwargs = {"color": "C5", "alpha": alpha, "linewidth": 0.5 * linewidth}
-                if dtype == "i":
-                    plot_kwargs["drawstyle"] = "steps-pre"
-                ax.plot(*pp_densities, **plot_kwargs)
-                ax.plot([], color="C5", label="Posterior predictive {}".format(pp_var_name))
-            if flatten in ['combined', 'both']:
+            plot_kwargs = {"color": "C5", "alpha": alpha, "linewidth": 0.5 * linewidth}
+            if dtype == "i":
+                plot_kwargs["drawstyle"] = "steps-pre"
+            ax.plot(*pp_densities, **plot_kwargs)
+            ax.plot([], color="C5", label="Posterior predictive {}".format(pp_var_name))
+            if mean:
                 if dtype == "f":
                     plot_kde(
-                        x.flatten(),
+                        posterior_predictive[pp_var_name].values.flatten(),
                         plot_kwargs={
                             "color": "C0",
                             "linestyle": "--",
@@ -283,7 +143,7 @@ def plot_ppc(data, var_names=None, coords=None, flatten=None,
                         ax=ax,
                     )
                 else:
-                    vals = x.flatten()
+                    vals = posterior_predictive[pp_var_name].values.flatten()
                     nbins = round(len(vals) ** 0.5)
                     hist, bin_edges = np.histogram(vals, bins=nbins, density=True)
                     hist = np.concatenate((hist[:1], hist))
@@ -305,29 +165,46 @@ def plot_ppc(data, var_names=None, coords=None, flatten=None,
             ax.tick_params(labelsize=xt_labelsize)
             ax.set_yticks([])
 
-        elif kind == "cdf":
-            if flatten in ['individual', 'both']:
-              # run plot_kde manually with one plot call
-              pp_densities = []
-              for vals in x:
-                  pp_x, pp_density = _empirical_cdf(vals)
-                  pp_densities.extend([pp_x, pp_density])
-              if dtype == "f":
-                  ax.plot(*pp_densities, alpha=alpha, color="C5", linewidth=linewidth)
-              else:
-                  ax.plot(
-                      *pp_densities,
-                      alpha=alpha,
-                      color="C5",
-                      drawstyle="steps-pre",
-                      linewidth=linewidth
-                  )
-              ax.plot([], color="C5", label="Posterior predictive {}".format(pp_var_name))
-
-            if flatten in ['combined', 'both']:
+        elif kind == "cumulative":
+            if dtype == "f":
+                ax.plot(
+                    *_empirical_cdf(observed[var_name].values.flatten()),
+                    color="k",
+                    linewidth=linewidth,
+                    label="Observed {}".format(var_name),
+                    zorder=3
+                )
+            else:
+                ax.plot(
+                    *_empirical_cdf(observed[var_name].values.flatten()),
+                    color="k",
+                    linewidth=linewidth,
+                    label="Observed {}".format(var_name),
+                    drawstyle="steps-pre",
+                    zorder=3
+                )
+            pp_var_name = data_pairs.get(var_name, var_name)
+            # run plot_kde manually with one plot call
+            pp_densities = []
+            for _, chain_vals in posterior_predictive[pp_var_name].groupby("chain"):
+                for _, vals in chain_vals.groupby("draw"):
+                    pp_x, pp_density = _empirical_cdf(vals)
+                    pp_densities.extend([pp_x, pp_density])
+            if dtype == "f":
+                ax.plot(*pp_densities, alpha=alpha, color="C5", linewidth=linewidth)
+            else:
+                ax.plot(
+                    *pp_densities,
+                    alpha=alpha,
+                    color="C5",
+                    drawstyle="steps-pre",
+                    linewidth=linewidth
+                )
+            ax.plot([], color="C5", label="Posterior predictive {}".format(pp_var_name))
+            if mean:
                 if dtype == "f":
                     ax.plot(
-                        *_empirical_cdf(x.flatten()),
+                        *_empirical_cdf(posterior_predictive[pp_var_name].values.flatten()),
                         color="C0",
                         linestyle="--",
                         linewidth=linewidth,
@@ -335,7 +212,7 @@ def plot_ppc(data, var_names=None, coords=None, flatten=None,
                     )
                 else:
                     ax.plot(
-                        *_empirical_cdf(x.flatten()),
+                        *_empirical_cdf(posterior_predictive[pp_var_name].values.flatten()),
                         color="C0",
                         linestyle="--",
                         linewidth=linewidth,

--- a/arviz/plots/ppcplot.py
+++ b/arviz/plots/ppcplot.py
@@ -1,35 +1,70 @@
 """Posterior predictive plot."""
 import numpy as np
 from .kdeplot import plot_kde, _fast_kde
-from .plot_utils import _scale_fig_size, _create_axes_grid, default_grid
+from .plot_utils import (
+    xarray_var_iter,
+    _scale_fig_size,
+    make_label,
+    default_grid,
+    _create_axes_grid,
+    get_coords,
+)
+from ..utils import _var_names
 
 
-def plot_ppc(
-    data, kind="density", alpha=0.2, mean=True, figsize=None, textsize=None, data_pairs=None
-):
+def plot_ppc(data, var_names=None, coords=None, flatten=None,
+             obs_plot_style="auto", pp_plot_style="auto", pp_flatten="auto",
+             alpha=0.2, mean=True, figsize=None, textsize=None, data_pairs=None):
     """
     Plot for Posterior Predictive checks.
-
-    Note that this plot will flatten out any dimensions in the posterior predictive variables.
 
     Parameters
     ----------
     data : az.InferenceData object
         InferenceData object containing the observed and posterior
         predictive data.
-    kind : str
-        Type of plot to display (density or cumulative). Defaults to density.
+    var_names : list
+        List of variables to be plotted. Defaults to all variables in the
+        model if None.
+    coords : dict
+        Dictionary mapping dimensions to selected coordinates to be plotted.
+        Passed to `Dataset.sel`. Dimensions without a mapping specified will
+        include all coordinates for that dimension. Defaults to including all
+        coordinates for all dimensions if None.
+    flatten : list
+        List of dimensions to flatten. Only flattens across the coordinates
+        specified in the coords argument. Defaults to flattening all of the dimensions.
+    obs_plot_style: str
+        The style to plot the observed data with. Must be in ('auto',
+        'scatter', 'pdf', 'cdf', 'hist'). 'scatter' will plot a 1d
+        scatter of the data. 'cdf' and 'pdf' will plot cumulative and kernel
+        density estimates of the data respectively. 'hist' will plot a  histogram of the
+        data. Defaults to 'auto' where 'scatter' is chosen if the number of
+        observations is less than 30, otherwise 'pdf'.
+    pp_plot_style: str
+        The style to plot the posterior predictive data with. Must be in ('auto',
+        'pdf', 'cdf'). 'cdf' and 'pdf' will plot cumulative and kernel
+        density estimates of the data respectively. Defaults to 'auto' where 'cdf'
+        is chosen if the obs_plot_style is also 'cdf', otherwise 'pdf'.
+    pp_flatten: str
+        Whether to flatten the posterior predictive density plot across samples.
+        Must be in ('auto', 'individual', 'combined', 'both').
+        If 'individual', it will plot a separate density for each individual
+        posterior predictive sample. If 'combined', it will plot a single
+        density for all of the posterior predictive data flattened across
+        samples. If 'both', it will plot both the flattened and individual
+        kdes. Defaults to 'auto' where 'combined' is chosen if the number of
+        observations in each sample is less than 30, otherwise 'both'.
     alpha : float
         Opacity of posterior predictive density curves. Defaults to 0.2.
-    mean : bool
-        Whether or not to plot the mean posterior predictive distribution. Defaults to True
     figsize : tuple
         Figure size. If None it will be defined automatically.
     textsize: float
-        Text size scaling factor for labels, titles and lines. If None it will be
-        autoscaled based on figsize.
+        Text size scaling factor for labels, titles and lines.
+        If None it will be autoscaled based on figsize.
     data_pairs : dict
-        Dictionary containing relations between observed data and posterior predictive data.
+        Dictionary containing relations between observed data and posterior
+        predictive data.
         Dictionary structure:
             Key = data var_name
 
@@ -68,38 +103,92 @@ def plot_ppc(
                 '`data` argument must have the group "{group}" for ppcplot'.format(group=group)
             )
 
-    if kind.lower() not in ("density", "cumulative"):
-        raise TypeError("`kind` argument must be either `density` or `cumulative`")
+    observed = data.observed_data
+    posterior_predictive = data.posterior_predictive
+
+    #if density_type.lower() not in ("pdf", "cdf"):
+    #    raise TypeError("`kind` argument must be either `pdf` or `cdf`")
 
     if data_pairs is None:
         data_pairs = {}
 
-    observed = data.observed_data
-    posterior_predictive = data.posterior_predictive
+    data_threshold = 30
 
-    rows, cols = default_grid(len(observed.data_vars))
+    if var_names is None:
+        var_names = observed.data_vars;
+    var_names = _var_names(var_names)
+    pp_var_names = [data_pairs.get(var, var) for var in var_names]
 
-    (figsize, ax_labelsize, _, xt_labelsize, linewidth, _) = _scale_fig_size(
+    if flatten is None:
+      flatten = list(observed.dims.keys())
+
+    if coords is None:
+        coords = {}
+
+
+    new_coords = {}
+    for key in coords.keys():
+        vals = coords[key]
+        new_coords[key] = np.where(np.in1d(observed[key], vals))[0]
+    coords = new_coords
+
+    obs_plotters = list(xarray_var_iter(observed.isel(coords),
+                                        skip_dims=set(flatten),
+                                        var_names=var_names,
+                                        combined=True))
+    pp_plotters = list(xarray_var_iter(posterior_predictive.isel(coords),
+                                       var_names=pp_var_names,
+                                       skip_dims=set(flatten),
+                                       combined=True))
+    length_plotters = len(obs_plotters)
+    print(length_plotters)
+    rows, cols = default_grid(length_plotters)
+
+
+    # TODO: Validate new argument inputs
+    assert(len(pp_plotters) == length_plotters)
+
+    (figsize, ax_labelsize, _, xt_labelsize, linewidth, markersize) = _scale_fig_size(
         figsize, textsize, rows, cols
     )
 
-    _, axes = _create_axes_grid(len(observed.data_vars), rows, cols, figsize=figsize)
+    _, axes = _create_axes_grid(length_plotters, rows, cols, figsize=figsize)
+    print(axes.shape)
 
-    for ax, var_name in zip(np.atleast_1d(axes), observed.data_vars):
+    for i, ax in enumerate(np.ravel(axes)):
+
+        # plot the observed data
+        var_name, selection, x = obs_plotters[i]
         dtype = observed[var_name].dtype.kind
-        if kind == "density":
+        print(var_name)
+        print(selection)
+        print(x.shape)
+        x = x.flatten()
+        print(x.shape)
+        num_obs = len(x)
+
+        # Plot the observed data
+        if obs_plot_style == "auto":
+            if num_obs < data_threshold:
+                kind = "scatter"
+            else:
+                kind = "pdf"
+        else:
+            kind = obs_plot_style
+
+        ax.set_title(make_label(var_name, selection))
+        if kind == "pdf":
             if dtype == "f":
                 plot_kde(
-                    observed[var_name].values.flatten(),
+                    x,
                     label="Observed {}".format(var_name),
                     plot_kwargs={"color": "k", "linewidth": linewidth, "zorder": 3},
                     fill_kwargs={"alpha": 0},
                     ax=ax,
                 )
             else:
-                vals = observed[var_name].values.flatten()
-                nbins = round(len(vals) ** 0.5)
-                hist, bin_edges = np.histogram(vals, bins=nbins, density=True)
+                nbins = round(len(x) ** 0.5)
+                hist, bin_edges = np.histogram(x, bins=nbins, density=True)
                 hist = np.concatenate((hist[:1], hist))
                 ax.plot(
                     bin_edges,
@@ -110,11 +199,62 @@ def plot_ppc(
                     zorder=3,
                     drawstyle="steps-pre",
                 )
-            pp_var_name = data_pairs.get(var_name, var_name)
-            # run plot_kde manually with one plot call
-            pp_densities = []
-            for _, chain_vals in posterior_predictive[pp_var_name].groupby("chain"):
-                for _, vals in chain_vals.groupby("draw"):
+        elif kind == "cdf":
+            if dtype == "f":
+                ax.plot(
+                    *_empirical_cdf(x),
+                    color="k",
+                    linewidth=linewidth,
+                    label="Observed {}".format(var_name),
+                    zorder=3
+                )
+            else:
+                ax.plot(
+                    *_empirical_cdf(x),
+                    color="k",
+                    linewidth=linewidth,
+                    label="Observed {}".format(var_name),
+                    drawstyle="steps-pre",
+                    zorder=3
+                )
+        elif kind == "scatter":
+            ax.plot(x, np.zeros_like(x), 'o', markersize=markersize)
+        elif kind == "hist":
+            # TODO: histogram support
+            print("Figure out arviz way to histogram. Appropriate to add in this PR?")
+        else:
+            # TODO: Handle invalid obs_plot_type
+            print("Invalid observed data plot type: %s" % kind)
+
+        # Plot posterior predictive data
+        pp_var_name, selection, x = pp_plotters[i]
+        print(pp_var_name)
+        print(selection)
+        print(x.shape)
+        x = x.squeeze()
+        if len(x.shape) > 2:
+            x = x.reshape((x.shape[0], np.prod(x.shape[1:])))
+        print(x.shape)
+
+        if pp_flatten == "auto":
+          if num_obs < data_threshold:
+              flatten = 'combined'
+          else:
+              flatten = 'both'
+        else:
+            flatten = pp_flatten
+
+        if pp_plot_style == "auto":
+            if obs_plot_style == "cdf":
+                kind = "cdf"
+            else:
+                kind = "pdf"
+
+        if kind == "pdf":
+            if flatten in ['individual', 'both']:
+                # run plot_kde manually with one plot call
+                pp_densities = []
+                for vals in x:
                     if dtype == "f":
                         pp_density, lower, upper = _fast_kde(vals)
                         pp_x = np.linspace(lower, upper, len(pp_density))
@@ -124,15 +264,15 @@ def plot_ppc(
                         hist, bin_edges = np.histogram(vals, bins=nbins, density=True)
                         hist = np.concatenate((hist[:1], hist))
                         pp_densities.extend([bin_edges, hist])
-            plot_kwargs = {"color": "C5", "alpha": alpha, "linewidth": 0.5 * linewidth}
-            if dtype == "i":
-                plot_kwargs["drawstyle"] = "steps-pre"
-            ax.plot(*pp_densities, **plot_kwargs)
-            ax.plot([], color="C5", label="Posterior predictive {}".format(pp_var_name))
-            if mean:
+                plot_kwargs = {"color": "C5", "alpha": alpha, "linewidth": 0.5 * linewidth}
+                if dtype == "i":
+                    plot_kwargs["drawstyle"] = "steps-pre"
+                ax.plot(*pp_densities, **plot_kwargs)
+                ax.plot([], color="C5", label="Posterior predictive {}".format(pp_var_name))
+            if flatten in ['combined', 'both']:
                 if dtype == "f":
                     plot_kde(
-                        posterior_predictive[pp_var_name].values.flatten(),
+                        x.flatten(),
                         plot_kwargs={
                             "color": "C0",
                             "linestyle": "--",
@@ -143,7 +283,7 @@ def plot_ppc(
                         ax=ax,
                     )
                 else:
-                    vals = posterior_predictive[pp_var_name].values.flatten()
+                    vals = x.flatten()
                     nbins = round(len(vals) ** 0.5)
                     hist, bin_edges = np.histogram(vals, bins=nbins, density=True)
                     hist = np.concatenate((hist[:1], hist))
@@ -165,46 +305,29 @@ def plot_ppc(
             ax.tick_params(labelsize=xt_labelsize)
             ax.set_yticks([])
 
-        elif kind == "cumulative":
-            if dtype == "f":
-                ax.plot(
-                    *_empirical_cdf(observed[var_name].values.flatten()),
-                    color="k",
-                    linewidth=linewidth,
-                    label="Observed {}".format(var_name),
-                    zorder=3
-                )
-            else:
-                ax.plot(
-                    *_empirical_cdf(observed[var_name].values.flatten()),
-                    color="k",
-                    linewidth=linewidth,
-                    label="Observed {}".format(var_name),
-                    drawstyle="steps-pre",
-                    zorder=3
-                )
-            pp_var_name = data_pairs.get(var_name, var_name)
-            # run plot_kde manually with one plot call
-            pp_densities = []
-            for _, chain_vals in posterior_predictive[pp_var_name].groupby("chain"):
-                for _, vals in chain_vals.groupby("draw"):
-                    pp_x, pp_density = _empirical_cdf(vals)
-                    pp_densities.extend([pp_x, pp_density])
-            if dtype == "f":
-                ax.plot(*pp_densities, alpha=alpha, color="C5", linewidth=linewidth)
-            else:
-                ax.plot(
-                    *pp_densities,
-                    alpha=alpha,
-                    color="C5",
-                    drawstyle="steps-pre",
-                    linewidth=linewidth
-                )
-            ax.plot([], color="C5", label="Posterior predictive {}".format(pp_var_name))
-            if mean:
+        elif kind == "cdf":
+            if flatten in ['individual', 'both']:
+              # run plot_kde manually with one plot call
+              pp_densities = []
+              for vals in x:
+                  pp_x, pp_density = _empirical_cdf(vals)
+                  pp_densities.extend([pp_x, pp_density])
+              if dtype == "f":
+                  ax.plot(*pp_densities, alpha=alpha, color="C5", linewidth=linewidth)
+              else:
+                  ax.plot(
+                      *pp_densities,
+                      alpha=alpha,
+                      color="C5",
+                      drawstyle="steps-pre",
+                      linewidth=linewidth
+                  )
+              ax.plot([], color="C5", label="Posterior predictive {}".format(pp_var_name))
+
+            if flatten in ['combined', 'both']:
                 if dtype == "f":
                     ax.plot(
-                        *_empirical_cdf(posterior_predictive[pp_var_name].values.flatten()),
+                        *_empirical_cdf(x.flatten()),
                         color="C0",
                         linestyle="--",
                         linewidth=linewidth,
@@ -212,7 +335,7 @@ def plot_ppc(
                     )
                 else:
                     ax.plot(
-                        *_empirical_cdf(posterior_predictive[pp_var_name].values.flatten()),
+                        *_empirical_cdf(x.flatten()),
                         color="C0",
                         linestyle="--",
                         linewidth=linewidth,

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -292,14 +292,14 @@ def test_plot_pair_2var(discrete_model, fig_ax, kwargs):
     assert ax
 
 
-@pytest.mark.parametrize("kind", ["density", "cumulative"])
+@pytest.mark.parametrize("kind", ["density", "cumulative", "scatter"])
 def test_plot_ppc(models, pymc3_sample_ppc, kind):
     data = from_pymc3(trace=models.pymc3_fit, posterior_predictive=pymc3_sample_ppc)
     axes = plot_ppc(data, kind=kind)
     assert axes
 
 
-@pytest.mark.parametrize("kind", ["density", "cumulative"])
+@pytest.mark.parametrize("kind", ["density", "cumulative", "scatter"])
 def test_plot_ppc_discrete(kind):
     data = MagicMock(spec=InferenceData)
     observed_data = xr.Dataset({"obs": (["obs_dim_0"], [9, 9])}, coords={"obs_dim_0": [1, 2]})
@@ -314,7 +314,17 @@ def test_plot_ppc_discrete(kind):
     assert axes
 
 
-@pytest.mark.parametrize("model_fit", ["pymc3_fit", "stan_fit", "pyro_fit", "tfp_fit"])
+def test_plot_ppc_grid(models, pymc3_sample_ppc):
+    data = from_pymc3(trace=models.pymc3_fit, posterior_predictive=pymc3_sample_ppc)
+    axes = plot_ppc(data, kind="scatter", flatten=[])
+    assert len(axes) == 8
+    axes = plot_ppc(data, kind="scatter", flatten=[], coords={"obs_dim_0": [1, 2, 3]})
+    assert len(axes) == 3
+    axes = plot_ppc(data, kind="scatter", flatten=["obs_dim_0"], coords={"obs_dim_0": [1, 2, 3]})
+    assert len(axes) == 1
+
+
+@pytest.mark.parametrize("model_fit", ["pymc3_fit", "stan_fit", "pyro_fit"])
 @pytest.mark.parametrize("var_names", (None, "mu", ["mu", "tau"]))
 def test_plot_violin(models, model_fit, var_names):
     obj = getattr(models, model_fit)


### PR DESCRIPTION
This pull request adds two new sets of features to the plot_ppc function:

1. Variable subsetting: Added var_names, coords, and flatten parameters to allow for sub-selection and gridding of variables across dimensions.
2. Plot style control: Added obs_plot_style, pp_plot_style, and pp_flatten parameters to allow for better control of plotting styles. This was particularly in response to the "wonkiness" of density plots for datasets with few observations (like the current eight schools example).

Needs more work and clean up to be merged, but first wanted to get feedback on the new API design approach. Do these changes seem reasonable? Is there a better way to do it?

See below for examples and see the updated docstring for more in depth parameter descriptions.