### PR TITLE
Add logging to test helpers model generation

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -250,7 +250,8 @@ good-names=i,
            tr,
            ex,
            Run,
-           _
+           _,
+           _log
 
 # Include a hint for the correct naming format with invalid-name
 include-naming-hint=no

--- a/arviz/__init__.py
+++ b/arviz/__init__.py
@@ -6,7 +6,7 @@ import logging
 from matplotlib.pyplot import style
 
 # Configure logging before importing arviz internals
-_log = logging.getLogger(__name__)
+_log = logging.getLogger("arviz")
 
 if not logging.root.handlers:
     handler = logging.StreamHandler()

--- a/arviz/__init__.py
+++ b/arviz/__init__.py
@@ -16,4 +16,3 @@ if not logging.root.handlers:
 from .data import *
 from .plots import *
 from .stats import *
-

--- a/arviz/__init__.py
+++ b/arviz/__init__.py
@@ -5,9 +5,15 @@ __version__ = "0.2.1"
 import logging
 from matplotlib.pyplot import style
 
+# Configure logging before importing arviz internals
+_log = logging.getLogger(__name__)
+
+if not logging.root.handlers:
+    handler = logging.StreamHandler()
+    _log.setLevel(logging.INFO)
+    _log.addHandler(handler)
+
 from .data import *
 from .plots import *
 from .stats import *
 
-if not logging.root.handlers:
-    logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -14,6 +14,10 @@ import pystan
 import scipy.optimize as op
 import torch
 
+import logging
+
+_log = logging.getLogger(__name__)
+
 
 def _emcee_neg_lnlike(theta, x, y, yerr):
     """Proper function to allow pickling."""
@@ -183,7 +187,7 @@ def pymc3_noncentered_schools(data, draws, chains):
 
 
 def load_cached_models(draws, chains):
-    """Load pymc3, pystan, and emcee models from pickle."""
+    """Load pymc3, pystan, emcee, and pyro models from pickle."""
     here = os.path.dirname(os.path.abspath(__file__))
     data = eight_schools_params()
     supported = (
@@ -201,9 +205,13 @@ def load_cached_models(draws, chains):
         )
         path = os.path.join(data_directory, fname)
         if not os.path.exists(path):
+
             with open(path, "wb") as buff:
+                _log.info("Generating and caching %s" % fname)
                 pickle.dump(func(data, draws, chains), buff)
+
         with open(path, "rb") as buff:
+
             models[library.__name__] = pickle.load(buff)
     return models
 

--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -2,6 +2,7 @@
 import os
 import pickle
 import sys
+import logging
 import pytest
 
 import emcee
@@ -14,7 +15,6 @@ import pystan
 import scipy.optimize as op
 import torch
 
-import logging
 
 _log = logging.getLogger(__name__)
 
@@ -198,21 +198,24 @@ def load_cached_models(draws, chains):
     )
     data_directory = os.path.join(here, "saved_models")
     models = {}
+
     for library, func in supported:
         py_version = sys.version_info
         fname = "{0.major}.{0.minor}_{1.__name__}_{1.__version__}_{2}_{3}_{4}.pkl".format(
             py_version, library, sys.platform, draws, chains
         )
+
         path = os.path.join(data_directory, fname)
         if not os.path.exists(path):
 
             with open(path, "wb") as buff:
-                _log.info("Generating and caching %s" % fname)
+                _log.info("Generating and caching %s", fname)
                 pickle.dump(func(data, draws, chains), buff)
 
         with open(path, "rb") as buff:
-
+            _log.info("Loading %s from cache", fname)
             models[library.__name__] = pickle.load(buff)
+
     return models
 
 


### PR DESCRIPTION
Generating models takes a long time in tests, providing messages should help with understanding status