### PR TITLE
Add arviz-white and arviz-colors styles

### DIFF
--- a/arviz/plots/styles/arviz-colors.mplstyle
+++ b/arviz/plots/styles/arviz-colors.mplstyle
@@ -1,0 +1,2 @@
+# color-blind friendly cycle designed using https://colorcyclepicker.mpetroff.net/
+axes.prop_cycle: cycler('color', ['2a2eec', 'fa7c17', '328c06', 'c10c90', '933708', '65e5f3', 'e6e135', '1ccd6a', 'bd8ad5', 'b16b57'])

--- a/arviz/plots/styles/arviz-white.mplstyle
+++ b/arviz/plots/styles/arviz-white.mplstyle
@@ -1,4 +1,4 @@
-# This style is based on Seaborn-darkgrid parameters, the main differences are
+# This style is based on Seaborn-white parameters, the main differences are
 # Default matplotlib font (no problem using Greek letters!)
 # Larger font size for several elements
 # Colorblind friendly color cycle
@@ -15,7 +15,6 @@ ytick.direction: out
 xtick.color: .15
 ytick.color: .15
 axes.axisbelow: True
-grid.linestyle: -
 lines.solid_capstyle: round
 
 axes.labelsize: 15
@@ -24,11 +23,10 @@ xtick.labelsize: 14
 ytick.labelsize: 14
 legend.fontsize: 14
 
-axes.grid: True
-axes.facecolor: eeeeee
-axes.edgecolor: white
-axes.linewidth: 0
-grid.color: white
+axes.grid: False
+axes.facecolor: white
+axes.edgecolor: .8
+axes.linewidth: 1
 xtick.major.size: 0
 ytick.major.size: 0
 xtick.minor.size: 0

--- a/arviz/plots/styles/arviz-whitegrid.mplstyle
+++ b/arviz/plots/styles/arviz-whitegrid.mplstyle
@@ -1,10 +1,9 @@
 # This style is based on Seaborn-whitegrid parameters, the main differences are
 # Default matplotlib font (no problem using Greek letters!)
 # Larger font size for several elements
-# Colorblind friendly color cycle 
-# .15 = dark_gray
-# .8 = light_gray
+# Colorblind friendly color cycle
 figure.figsize: 7.2, 4.8
+figure.dpi: 100.0
 figure.facecolor: white
 text.color: .15
 axes.labelcolor: .15

--- a/examples/styles.py
+++ b/examples/styles.py
@@ -1,0 +1,24 @@
+"""
+Styles
+======
+
+_thumb: .8, .8
+"""
+x = np.linspace(0, 1, 100)
+dist = stats.beta(2, 5).pdf(x)
+
+style_list = ['default',
+              ['default', 'arviz-colors'],
+              'arviz-darkgrid',
+              'arviz-whitegrid',
+              'arviz-white']
+
+for style in style_list:
+    with plt.style.context(style):
+        plt.figure()
+        for i in range(10):
+            plt.plot(x, dist - i, f'C{i}', label=f'C{i}')
+        plt.title(style)
+        plt.xlabel('x')
+        plt.ylabel('f(x)', rotation=0, labelpad=15)
+        plt.legend(bbox_to_anchor=(1, 1))


### PR DESCRIPTION
Also adds one example and increase the default dpi from 72 to 100.

The `arviz-white` style is for those that dislike having a grid and a background (for _strict Tufte followers_), the `arviz-colors` style is for those that want to any style they might like but with our color discrete pallet. 