### PR TITLE
make arviz styles available without copy them

### DIFF
--- a/arviz/__init__.py
+++ b/arviz/__init__.py
@@ -2,8 +2,15 @@
 """ArviZ is a library for exploratory analysis of Bayesian models."""
 __version__ = "0.2.1"
 
+import os
 import logging
 from matplotlib.pyplot import style
+
+# add ArviZ's styles to matplotlib's styles
+arviz_style_path = os.path.join(os.path.dirname(__file__), "plots", "styles")
+style.core.USER_LIBRARY_PATHS.append(arviz_style_path)
+style.core.reload_library()
+print(arviz_style_path)
 
 # Configure logging before importing arviz internals
 _log = logging.getLogger("arviz")

--- a/arviz/__init__.py
+++ b/arviz/__init__.py
@@ -10,7 +10,6 @@ from matplotlib.pyplot import style
 arviz_style_path = os.path.join(os.path.dirname(__file__), "plots", "styles")
 style.core.USER_LIBRARY_PATHS.append(arviz_style_path)
 style.core.reload_library()
-print(arviz_style_path)
 
 # Configure logging before importing arviz internals
 _log = logging.getLogger("arviz")

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import codecs
-import shutil
 import os
 import re
 
@@ -15,10 +14,6 @@ README_FILE = os.path.join(PROJECT_ROOT, 'README.md')
 VERSION_FILE = os.path.join(PROJECT_ROOT, 'arviz', '__init__.py')
 
 
-# Ensure matplotlib dependencies are available to copy
-# styles over
-setuptools.dist.Distribution().fetch_build_eggs(['matplotlib>=3.0'])
-
 def get_requirements():
     with codecs.open(REQUIREMENTS_FILE) as buff:
         return buff.read().splitlines()
@@ -27,29 +22,6 @@ def get_requirements():
 def get_long_description():
     with codecs.open(README_FILE, 'rt') as buff:
         return buff.read()
-
-
-def copy_styles():
-    from matplotlib import get_configdir
-    sd = os.path.join(get_configdir(), "stylelib")
-    source = os.path.dirname(os.path.realpath(__file__))
-    lsd = os.path.join(source, 'arviz', 'plots', 'styles')
-    styles = [f for f in os.listdir(lsd)]
-    if not os.path.isdir(sd):
-        os.makedirs(sd)
-    for s in styles:
-        shutil.copy(os.path.join(lsd, s), os.path.join(sd, s))
-
-
-class DevelopStyles(develop):
-    def run(self):
-        copy_styles()
-        develop.run(self)
-
-class InstallStyles(install):
-    def run(self):
-        copy_styles()
-        install.run(self)
 
 def get_version():
     lines = open(VERSION_FILE, 'rt').readlines()
@@ -71,8 +43,4 @@ setup(
     long_description=get_long_description(),
     long_description_content_type='text/markdown',
     include_package_data=True,
-    cmdclass={
-        'develop': DevelopStyles,
-        'install': InstallStyles,
-    },
 )


### PR DESCRIPTION
Following discussion with @ahartikainen this PR proposes an alternative way to make ArviZ styles available without the need to copy files to matplotlib config folder. This should fix #377