### PR TITLE
make single figure, fix arviz-white style

### DIFF
--- a/arviz/plots/styles/arviz-white.mplstyle
+++ b/arviz/plots/styles/arviz-white.mplstyle
@@ -25,8 +25,10 @@ legend.fontsize: 14
 
 axes.grid: False
 axes.facecolor: white
-axes.edgecolor: .8
+axes.edgecolor: 0
 axes.linewidth: 1
+axes.spines.top: False
+axes.spines.right: False
 xtick.major.size: 0
 ytick.major.size: 0
 xtick.minor.size: 0

--- a/examples/styles.py
+++ b/examples/styles.py
@@ -18,12 +18,14 @@ style_list = ['default',
               'arviz-whitegrid',
               'arviz-white']
 
-for style in style_list:
+fig = plt.figure(figsize=(12, 12))
+for idx, style in enumerate(style_list):
     with az.style.context(style):
-        plt.figure()
+        ax = fig.add_subplot(3,2, idx+1, label=idx)
         for i in range(10):
-            plt.plot(x, dist - i, f'C{i}', label=f'C{i}')
-        plt.title(style)
-        plt.xlabel('x')
-        plt.ylabel('f(x)', rotation=0, labelpad=15)
-        plt.legend(bbox_to_anchor=(1, 1))
+            ax.plot(x, dist - i, f'C{i}', label=f'C{i}')
+        ax.set_title(style)
+        ax.set_xlabel('x')
+        ax.set_ylabel('f(x)', rotation=0, labelpad=15)
+        ax.legend(bbox_to_anchor=(1, 1))
+plt.tight_layout()


### PR DESCRIPTION
This creates a single figure with subplots with different styles. Also adds the correct parameters for `arviz-white` style.

![styles](https://user-images.githubusercontent.com/1338958/48665048-d5e6f380-ea86-11e8-9394-f2a05073a866.png)
