### PR TITLE
Resize headers in Sphinx docs

### DIFF
--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -9,3 +9,23 @@ a {
 .navbar-brand img {
   height: 150%;
 }
+
+h1, .h1 {
+  font-size: 40px
+}
+
+h2, .h2 {
+  font-size: 25px
+}
+
+h3, .h3 {
+  font-size: 20px
+}
+
+h4, .h4 {
+  font-size: 15px
+}
+
+h5, .h5 {
+  font-size: 10px
+}


### PR DESCRIPTION
I think the headers in our docs seem a bit large. Let me know if anyone agrees

**Current**
![currentheadingsize](https://user-images.githubusercontent.com/7213793/49093637-58a34780-f219-11e8-9cfb-cd94cdba55c9.png)

**Resized**
![headerresize2](https://user-images.githubusercontent.com/7213793/49093613-4cb78580-f219-11e8-9be7-a1c38a31be8e.png)
