### PR TITLE
get axes from current figure

### DIFF
--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -18,7 +18,6 @@ def plot_kde(
     rotated=False,
     contour=True,
     fill_last=True,
-    figsize=None,
     textsize=None,
     plot_kwargs=None,
     fill_kwargs=None,
@@ -51,8 +50,6 @@ def plot_kde(
         If True plot the 2D KDE using contours, otherwise plot a smooth 2D KDE. Defaults to True.
     fill_last : bool
         If True fill the last contour of the 2D KDE plot. Defaults to True.
-    figsize : tuple
-        Figure size. If None it will be defined automatically.
     textsize: float
         Text size scaling factor for labels, titles and lines. If None it will be autoscaled based
         on figsize.
@@ -124,13 +121,12 @@ def plot_kde(
         >>> az.plot_kde(mu_posterior, values2=tau_posterior, contour=False)
 
     """
-    if figsize is None and ax:
-        figsize = ax.get_figure().get_size_inches()
-
-    figsize, *_, linewidth, markersize = _scale_fig_size(figsize, textsize, 1, 1)
-
     if ax is None:
-        _, ax = plt.subplots(figsize=figsize)
+        ax = plt.gca()
+
+    figsize = ax.get_figure().get_size_inches()
+
+    figsize, *_, xt_labelsize, linewidth, markersize = _scale_fig_size(figsize, textsize, 1, 1)
 
     if values2 is None:
         if plot_kwargs is None:
@@ -165,6 +161,8 @@ def plot_kde(
             x, density = density, x
             fill_func = ax.fill_betweenx
 
+        ax.tick_params(labelsize=xt_labelsize)
+
         ax.plot(x, density, label=label, **plot_kwargs)
         if rotated:
             ax.set_xlim(0, auto=True)
@@ -196,7 +194,9 @@ def plot_kde(
             qcfs = ax.contourf(x_x, y_y, density, antialiased=True)
             if not fill_last:
                 qcfs.collections[0].set_alpha(0)
-            ax.contour(x_x, y_y, density, **contour_kwargs)
+            qcs = ax.contour(x_x, y_y, density, **contour_kwargs)
+            if not fill_last:
+                qcs.collections[0].set_alpha(0)
         else:
             ax.pcolormesh(x_x, y_y, density)
 


### PR DESCRIPTION
Before this PR,

to get a plot like this one:
![2rug](https://user-images.githubusercontent.com/1338958/49220540-3fcf9900-f3b5-11e8-87cd-6eba46b721fb.png)


One should explicitly pass the axes to `plot_kde`, now we can just write

```python
plt.figure(figsize=(10,4))
az.plot_kde(data1, rug=True)
az.plot_kde(data2, rug=True, plot_kwargs={'color':'C1'});
plt.yticks([])
```

or 

```python
_, ax = plt.subplots(figsize=(10,4))
az.plot_kde(data1, rug=True)
az.plot_kde(data2, rug=True, plot_kwargs={'color':'C1'});
ax.set_yticks([]);
```

While being there :-) I made another change now `fill_last` argument also affects the countour lines, when `fill_last = False` we get:
![lala_0](https://user-images.githubusercontent.com/1338958/49220933-54606100-f3b6-11e8-9d92-e1a6e4a35361.png)


instead of:

![lala_1](https://user-images.githubusercontent.com/1338958/49220945-617d5000-f3b6-11e8-9649-6da3d33e885b.png)


 



