### PR TITLE
plot_pair: Refactor code and minor tweaks

### DIFF
--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -182,29 +182,25 @@ def plot_pair(
 
                 elif kind == "kde":
                     plot_kde(
-                        var1,
-                        var2,
-                        contour=contour,
-                        fill_last=fill_last,
-                        ax=ax[j, i],
-                        **plot_kwargs
+                        var1, var2, contour=contour, fill_last=fill_last, ax=ax[j, i], **plot_kwargs
                     )
 
                 else:
                     ax[j, i].grid(False)
-                    hexbin = ax[j, i].hexbin(
-                        var1, var2, mincnt=1, gridsize=gridsize, **plot_kwargs
-                    )
+                    hexbin = ax[j, i].hexbin(var1, var2, mincnt=1, gridsize=gridsize, **plot_kwargs)
                 if kind == "hexbin" and colorbar:
                     hexbin_values.append(hexbin.norm.vmin)
                     hexbin_values.append(hexbin.norm.vmax)
-                    if j == i == 0:
-                        hexbin_first = hexbin
+                    if j == i == 0 and colorbar:
+                        divider = make_axes_locatable(ax[0, 1])
+                        cax = divider.append_axes("left", size="7%")
+                        cbar = fig.colorbar(
+                            hexbin, ticks=[hexbin.norm.vmin, hexbin.norm.vmax], cax=cax
+                        )
+                        cbar.ax.set_yticklabels(["low", "high"], fontsize=ax_labelsize)
 
                 if divergences:
-                    ax[j, i].plot(
-                        var1[diverging_mask], var2[diverging_mask], **divergences_kwargs
-                    )
+                    ax[j, i].plot(var1[diverging_mask], var2[diverging_mask], **divergences_kwargs)
 
                 if j + 1 != numvars - 1:
                     ax[j, i].axes.get_xaxis().set_major_formatter(NullFormatter())
@@ -213,19 +209,9 @@ def plot_pair(
                 if i != 0:
                     ax[j, i].axes.get_yaxis().set_major_formatter(NullFormatter())
                 else:
-                    ax[j, i].set_ylabel(
-                        "{}".format(flat_var_names[j + 1]), fontsize=ax_labelsize
-                    )
+                    ax[j, i].set_ylabel("{}".format(flat_var_names[j + 1]), fontsize=ax_labelsize)
 
                 ax[j, i].tick_params(labelsize=xt_labelsize)
                 axs.append(ax)
-
-        if kind == "hexbin" and colorbar:
-            divider = make_axes_locatable(ax[0, 1])
-            cax = divider.append_axes("left", size="7%")
-            cbar = fig.colorbar(
-                hexbin_first, ticks=[min(hexbin_values), max(hexbin_values)], cax=cax
-            )
-            cbar.ax.set_yticklabels(["low", "high"], fontsize=ax_labelsize)
 
     return axs

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -275,7 +275,7 @@ def test_plot_khat():
 )
 def test_plot_pair(models, model_fit, kwargs):
     obj = getattr(models, model_fit)
-    ax, _ = plot_pair(obj, **kwargs)
+    ax = plot_pair(obj, **kwargs)
     assert ax
 
 
@@ -284,7 +284,7 @@ def test_plot_pair(models, model_fit, kwargs):
 )
 def test_plot_pair_2var(discrete_model, fig_ax, kwargs):
     _, ax = fig_ax
-    ax, _ = plot_pair(discrete_model, ax=ax, **kwargs)
+    ax = plot_pair(discrete_model, ax=ax, **kwargs)
     assert ax
 
 


### PR DESCRIPTION
This removes the need to use gridspec and use `plot` instead of `scatter`. I did not run a formal benchmark, but it seems to run faster now. I also changed how divergences are rendered and now the auto-scaling works better.

some pics :-)

![lala_00](https://user-images.githubusercontent.com/1338958/49316693-78b06080-f4d0-11e8-915e-6d876307441c.png)

![lala_01](https://user-images.githubusercontent.com/1338958/49316698-7e0dab00-f4d0-11e8-9994-f9274b936745.png)

![lala_02](https://user-images.githubusercontent.com/1338958/49317475-5e2bb680-f4d3-11e8-8fab-1b4aa99dfab4.png)
