### PR TITLE
Add root directory to conf.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_script:
 script:
   - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then . ./scripts/lint.sh ; fi
   - pytest -v arviz/tests/ --cov=arviz/
-  - travis-sphinx build --nowarn --source=doc -vvv
+  - travis-sphinx build --nowarn --source=doc
 
 after_success:
   - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then travis-sphinx deploy; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_script:
 script:
   - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then . ./scripts/lint.sh ; fi
   - pytest -v arviz/tests/ --cov=arviz/
-  - travis-sphinx build --nowarn --source=doc
+  - travis-sphinx build --nowarn --source=doc -vvv
 
 after_success:
   - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then travis-sphinx deploy; fi

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,6 +19,8 @@
 #
 import os
 import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import sphinx_bootstrap_theme
 import arviz
 
@@ -32,23 +34,22 @@ import arviz
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-sys.path.insert(0, os.path.abspath('sphinxext'))
-
+sys.path.insert(0, os.path.abspath("sphinxext"))
 
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.doctest',
-    'sphinx.ext.coverage',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.mathjax',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.githubpages',
-    'matplotlib.sphinxext.plot_directive',
-    'numpydoc',
-    'nbsphinx',
-    'IPython.sphinxext.ipython_console_highlighting',
-    'gallery_generator',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.doctest",
+    "sphinx.ext.coverage",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.githubpages",
+    "matplotlib.sphinxext.plot_directive",
+    "numpydoc",
+    "nbsphinx",
+    "IPython.sphinxext.ipython_console_highlighting",
+    "gallery_generator",
 ]
 
 # Copy plot options from Seaborn
@@ -63,21 +64,21 @@ autosummary_generate = True
 numpydoc_show_class_members = False
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = 'ArviZ'
-copyright = '2018, ArviZ devs'
-author = 'ArviZ devs'
+project = "ArviZ"
+copyright = "2018, ArviZ devs"
+author = "ArviZ devs"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -98,10 +99,10 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'notebooks/.ipynb_checkpoints']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "notebooks/.ipynb_checkpoints"]
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
@@ -112,62 +113,62 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'bootstrap'
+html_theme = "bootstrap"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
 html_theme_options = {
-    'source_link_position': 'footer',
-    'navbar_title': ' ',
-    'globaltoc_depth': 0,
-    'bootswatch_theme': 'paper',
-    'navbar_pagenav': False,
-    'navbar_sidebarrel': False,
-    'navbar_links': [
-        ('Gallery', 'examples/index'),
-        ('Quickstart', 'notebooks/Introduction'),
-        ('Cookbook', 'notebooks/InferenceDataCookbook'),
-        ('API', 'api'),
-        ('Usage', 'usage'),
-        ('About', 'about'),
+    "source_link_position": "footer",
+    "navbar_title": " ",
+    "globaltoc_depth": 0,
+    "bootswatch_theme": "paper",
+    "navbar_pagenav": False,
+    "navbar_sidebarrel": False,
+    "navbar_links": [
+        ("Gallery", "examples/index"),
+        ("Quickstart", "notebooks/Introduction"),
+        ("Cookbook", "notebooks/InferenceDataCookbook"),
+        ("API", "api"),
+        ("Usage", "usage"),
+        ("About", "about"),
     ],
 }
-
 
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_theme_path = sphinx_bootstrap_theme.get_html_theme_path()
-html_static_path = ['_static', 'example_thumbs']
+html_static_path = ["_static", "example_thumbs"]
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
-#html_sidebars = {}
+# html_sidebars = {}
 
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'ArviZdoc'
+htmlhelp_basename = "ArviZdoc"
 
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-html_short_title = 'ArviZ'
+html_short_title = "ArviZ"
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-html_logo = '_static/logo.png'
+html_logo = "_static/logo.png"
 
 
 # The name of an image file (relative to this directory) to use as a favicon of
 # the docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-html_favicon = '_static/favicon.ico'
+html_favicon = "_static/favicon.ico"
+
 
 def setup(app):
-    app.add_stylesheet('custom.css')
+    app.add_stylesheet("custom.css")
 
 
 # -- Options for LaTeX output ---------------------------------------------
@@ -176,15 +177,12 @@ latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',
-
     # The font size ('10pt', '11pt' or '12pt').
     #
     # 'pointsize': '10pt',
-
     # Additional stuff for the LaTeX preamble.
     #
     # 'preamble': '',
-
     # Latex figure (float) alignment
     #
     # 'figure_align': 'htbp',
@@ -193,20 +191,14 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
-latex_documents = [
-    (master_doc, 'ArviZ.tex', 'ArviZ Documentation',
-     'ArviZ devs', 'manual'),
-]
+latex_documents = [(master_doc, "ArviZ.tex", "ArviZ Documentation", "ArviZ devs", "manual")]
 
 
 # -- Options for manual page output ---------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'arviz', 'ArviZ Documentation',
-     [author], 1)
-]
+man_pages = [(master_doc, "arviz", "ArviZ Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -215,11 +207,16 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'ArviZ', 'ArviZ Documentation',
-     author, 'ArviZ', 'One line description of project.',
-     'Miscellaneous'),
+    (
+        master_doc,
+        "ArviZ",
+        "ArviZ Documentation",
+        author,
+        "ArviZ",
+        "One line description of project.",
+        "Miscellaneous",
+    )
 ]
-
 
 
 # -- Options for Epub output ----------------------------------------------
@@ -240,9 +237,9 @@ epub_copyright = copyright
 # epub_uid = ''
 
 # A list of files that should not be packed into the epub file.
-epub_exclude_files = ['search.html']
-
+epub_exclude_files = ["search.html"]
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-#intersphinx_mapping = {'https://docs.python.org/': None}
+# intersphinx_mapping = {'https://docs.python.org/': None}
+


### PR DESCRIPTION
Docs are currently broken. This fixes the docs on my local machine. I don't know why this only popped up now, but probably good to add the root directory to the sphinx build.

This looks like a big PR because `black` ran on `conf.py`, but the only real change is 

```python
sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
```

which is a portable way to add `../` to the path.