### PR TITLE
wrap titles

### DIFF
--- a/arviz/plots/autocorrplot.py
+++ b/arviz/plots/autocorrplot.py
@@ -102,7 +102,7 @@ def plot_autocorr(data, var_names=None, max_lag=100, combined=False, figsize=Non
 
         ax.vlines(x=np.arange(0, max_lag), ymin=0, ymax=y[0:max_lag], lw=linewidth)
         ax.hlines(0, 0, max_lag, "steelblue")
-        ax.set_title(make_label(var_name, selection), fontsize=titlesize)
+        ax.set_title(make_label(var_name, selection), fontsize=titlesize, wrap=True)
         ax.tick_params(labelsize=xt_labelsize)
 
     if axes.size > 0:

--- a/arviz/plots/densityplot.py
+++ b/arviz/plots/densityplot.py
@@ -304,7 +304,7 @@ def _d_helper(
         ax.plot(est, 0, "o", color=color, markeredgecolor="k", markersize=markersize)
 
     ax.set_yticks([])
-    ax.set_title(vname, fontsize=titlesize)
+    ax.set_title(vname, fontsize=titlesize, wrap=True)
     for pos in ["left", "right", "top"]:
         ax.spines[pos].set_visible(0)
     ax.tick_params(labelsize=xt_labelsize)

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -319,7 +319,9 @@ class PlotHandler:
                     color=color,
                 )
         ax.tick_params(labelsize=xt_labelsize)
-        ax.set_title("{:.1%} Credible Interval".format(credible_interval), fontsize=titlesize)
+        ax.set_title(
+            "{:.1%} Credible Interval".format(credible_interval), fontsize=titlesize, wrap=True
+        )
 
         return ax
 
@@ -338,7 +340,7 @@ class PlotHandler:
                         markeredgecolor="k",
                     )
         ax.set_xlim(left=0)
-        ax.set_title("eff_n", fontsize=titlesize)
+        ax.set_title("eff_n", fontsize=titlesize, wrap=True)
         ax.tick_params(labelsize=xt_labelsize)
         return ax
 
@@ -351,7 +353,7 @@ class PlotHandler:
         ax.set_xlim(left=0.9, right=2.1)
         ax.set_xticks([1, 2])
         ax.tick_params(labelsize=xt_labelsize)
-        ax.set_title("r_hat", fontsize=titlesize)
+        ax.set_title("r_hat", fontsize=titlesize, wrap=True)
         return ax
 
     def make_bands(self, ax):

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -183,7 +183,7 @@ def plot_posterior(
             **kwargs
         )
 
-        ax_.set_title(make_label(var_name, selection), fontsize=titlesize)
+        ax_.set_title(make_label(var_name, selection), fontsize=titlesize, wrap=True)
 
     return ax
 


### PR DESCRIPTION
I add `wrap=True` to several plots, as I realize tittle get cropped for the saved figures (but not to the figures rendered inside notebooks)