### PR TITLE
Use constrained layout everywhere

### DIFF
--- a/arviz/plots/compareplot.py
+++ b/arviz/plots/compareplot.py
@@ -53,7 +53,7 @@ def plot_compare(
     figsize, ax_labelsize, _, xt_labelsize, linewidth, _ = _scale_fig_size(figsize, textsize, 1, 1)
 
     if ax is None:
-        _, ax = plt.subplots(figsize=figsize)
+        _, ax = plt.subplots(figsize=figsize, constrained_layout=True)
 
     if plot_kwargs is None:
         plot_kwargs = {}

--- a/arviz/plots/energyplot.py
+++ b/arviz/plots/energyplot.py
@@ -65,7 +65,7 @@ def plot_energy(
     energy = convert_to_dataset(data, group="sample_stats").energy.values
 
     if ax is None:
-        _, ax = plt.subplots(figsize=figsize)
+        _, ax = plt.subplots(figsize=figsize, constrained_layout=True)
 
     if fill_kwargs is None:
         fill_kwargs = {}

--- a/arviz/plots/jointplot.py
+++ b/arviz/plots/jointplot.py
@@ -83,7 +83,7 @@ def plot_joint(
         marginal_kwargs = {}
 
     # Instantiate figure and grid
-    fig, _ = plt.subplots(0, 0, figsize=figsize)
+    fig, _ = plt.subplots(0, 0, figsize=figsize, constrained_layout=True)
     grid = plt.GridSpec(4, 4, hspace=0.1, wspace=0.1)
 
     # Set up main plot

--- a/arviz/plots/khatplot.py
+++ b/arviz/plots/khatplot.py
@@ -46,7 +46,7 @@ def plot_khat(
         markersize = scaled_markersize
 
     if ax is None:
-        _, ax = plt.subplots(1, 1, figsize=figsize)
+        _, ax = plt.subplots(1, 1, figsize=figsize, constrained_layout=True)
 
     ax.hlines(
         [0, 0.5, 0.7, 1],

--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -123,7 +123,7 @@ def plot_pair(
         )
 
         if ax is None:
-            fig, ax = plt.subplots(figsize=figsize)
+            fig, ax = plt.subplots(figsize=figsize, constrained_layout=True)
 
         if kind == "scatter":
             ax.plot(_posterior[0], _posterior[1], **plot_kwargs)

--- a/arviz/plots/parallelplot.py
+++ b/arviz/plots/parallelplot.py
@@ -77,7 +77,7 @@ def plot_parallel(
     figsize, _, _, xt_labelsize, _, _ = _scale_fig_size(figsize, textsize, 1, 1)
 
     if ax is None:
-        _, ax = plt.subplots(figsize=figsize)
+        _, ax = plt.subplots(figsize=figsize, constrained_layout=True)
 
     ax.plot(_posterior[:, ~diverging_mask], color=colornd, alpha=shadend)
 

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -158,6 +158,7 @@ def _create_axes_grid(length_plotters, rows, cols, **kwargs):
     fig : matplotlib figure
     ax : matplotlib axes
     """
+    kwargs.setdefault("constrained_layout", True)
     fig, ax = plt.subplots(rows, cols, **kwargs)
     ax = np.ravel(ax)
     extra = (rows * cols) - length_plotters

--- a/arviz/plots/violinplot.py
+++ b/arviz/plots/violinplot.py
@@ -76,7 +76,9 @@ def plot_violin(
     ax_labelsize *= 2
 
     if ax is None:
-        fig, ax = plt.subplots(1, len(plotters), figsize=figsize, sharey=sharey)
+        fig, ax = plt.subplots(
+            1, len(plotters), figsize=figsize, sharey=sharey, constrained_layout=True
+        )
 
     else:
         fig = ax.figure


### PR DESCRIPTION
This fixes a few layout problems with titles and labels running off the side of the plot.

For example, the `plot_ppc` docs currently look like this:
![image](https://user-images.githubusercontent.com/2295568/49687808-82d8ed00-fad6-11e8-9c31-3f0d9408d8ab.png)


and with this change look like this:
![image](https://user-images.githubusercontent.com/2295568/49687799-57560280-fad6-11e8-93c9-dc1fa826282e.png)
