### PR TITLE
Added rope to forestplot.py in forestplot()

### DIFF
--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -137,7 +137,14 @@ def plot_forest(
     axes = np.atleast_1d(axes)
     if kind == "forestplot":
         plot_handler.forestplot(
-            credible_interval, quartiles, xt_labelsize, titlesize, linewidth, markersize, axes[0], rope
+            credible_interval,
+            quartiles,
+            xt_labelsize,
+            titlesize,
+            linewidth,
+            markersize,
+            axes[0],
+            rope,
         )
     elif kind == "ridgeplot":
         plot_handler.ridgeplot(ridgeplot_overlap, linewidth, ridgeplot_alpha, axes[0])
@@ -247,7 +254,7 @@ class PlotHandler:
         vals = dict(rope[rope_var][0])["rope"]
         ax.plot(
             vals,
-            (y+.05, y+.05),
+            (y + 0.05, y + 0.05),
             lw=linewidth * 2,
             color="C2",
             solid_capstyle="round",
@@ -317,7 +324,7 @@ class PlotHandler:
             for y, values, color in plotter.treeplot(qlist, credible_interval):
                 if isinstance(rope, dict):
                     label, ticks = self.labels_and_ticks()
-                    self.display_multiple_ropes(rope, ax, y, linewidth, label[ticks==y][0])
+                    self.display_multiple_ropes(rope, ax, y, linewidth, label[ticks == y][0])
                 mid = len(values) // 2
                 param_iter = zip(
                     np.linspace(2 * linewidth, linewidth, mid, endpoint=True)[-1::-1], range(mid)
@@ -339,7 +346,7 @@ class PlotHandler:
         if rope is None or isinstance(rope, dict):
             return
         elif len(rope) == 2:
-            ax.axvspan(rope[0], rope[1], 0, self.y_max(), color='C2', alpha=.5)
+            ax.axvspan(rope[0], rope[1], 0, self.y_max(), color="C2", alpha=0.5)
         else:
             raise ValueError(
                 "Argument `rope` must be None, a dictionary like"

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -28,6 +28,7 @@ def plot_forest(
     combined=False,
     credible_interval=0.94,
     quartiles=True,
+    rope=None,
     eff_n=False,
     r_hat=False,
     colors="cycle",
@@ -36,6 +37,7 @@ def plot_forest(
     markersize=None,
     ridgeplot_alpha=None,
     ridgeplot_overlap=2,
+    rope_alpha=.5,
     figsize=None,
 ):
     """Forest plot to compare credible intervals from a number of distributions.
@@ -64,6 +66,8 @@ def plot_forest(
     quartiles : bool, optional
         Flag for plotting the interquartile range, in addition to the credible_interval intervals.
         Defaults to True
+    rope: tuple
+        Lower and upper values of the Region Of Practical Equivalence defined for all displayed variables
     r_hat : bool, optional
         Flag for plotting Split R-hat statistics. Requires 2 or more chains. Defaults to False
     eff_n : bool, optional
@@ -85,6 +89,8 @@ def plot_forest(
         a black outline is used.
     ridgeplot_overlap : float
         Overlap height for ridgeplots.
+    rope_alpha : float
+        Transparency for rope interval.
     figsize : tuple
         Figure size. If None it will be defined automatically.
 
@@ -134,7 +140,8 @@ def plot_forest(
     axes = np.atleast_1d(axes)
     if kind == "forestplot":
         plot_handler.forestplot(
-            credible_interval, quartiles, xt_labelsize, titlesize, linewidth, markersize, axes[0]
+            credible_interval, quartiles, xt_labelsize, titlesize, linewidth,
+            markersize, axes[0], rope, rope_alpha
         )
     elif kind == "ridgeplot":
         plot_handler.ridgeplot(ridgeplot_overlap, xt_labelsize, linewidth, ridgeplot_alpha, axes[0])
@@ -274,7 +281,7 @@ class PlotHandler:
         return ax
 
     def forestplot(
-        self, credible_interval, quartiles, xt_labelsize, titlesize, linewidth, markersize, ax
+        self, credible_interval, quartiles, xt_labelsize, titlesize, linewidth, markersize, ax, rope, rope_alpha
     ):
         """Draw forestplot for each plotter.
 
@@ -318,6 +325,11 @@ class PlotHandler:
                     markersize=markersize * 0.75,
                     color=color,
                 )
+        if rope is not None and len(rope) == 2:
+            ax.axvspan(rope[0], rope[1], 0, values[-1], color='C2', alpha=rope_alpha)
+        elif rope is not None:
+            raise ValueError('Argument `rope` must be None or an '
+                             'iterable of length 2')
         ax.tick_params(labelsize=xt_labelsize)
         ax.set_title(
             "{:.1%} Credible Interval".format(credible_interval), fontsize=titlesize, wrap=True

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -550,4 +550,6 @@ class VarHandler:
 
     def y_mean(self):
         """Get max y value for the variable."""
-        return np.mean(list(y for y, *_ in self.iterator()))
+        mean_y = np.mean(list(y for y, *_ in self.iterator()))
+
+        return mean_y

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -259,8 +259,9 @@ class PlotHandler:
         )
         text_props = {"size": xt_labelsize, "horizontalalignment": "center", "color": "C2"}
         if rope_values:
-            ax.text(vals[0], y+.08, vals[0])#, **text_props)
-            ax.text(vals[1], y+.08, vals[1])#, **text_props)
+            ax.text(vals[0], y+.08, vals[0], **text_props)
+            ax.text(vals[1], y+.08, vals[1], **text_props)
+        return ax
 
 
     def ridgeplot(self, mult, xt_labelsize, linewidth, alpha, ax):
@@ -292,10 +293,6 @@ class PlotHandler:
                 ax.plot(x, y_min, "-", linewidth=linewidth, color=border, zorder=zorder)
                 ax.fill_between(x, y_min, y_max, alpha=alpha, color=color, zorder=zorder)
                 zorder -= 1
-
-        ax.tick_params(labelsize=xt_labelsize)
-
-        return ax
 
     def forestplot(
         self, credible_interval, quartiles, xt_labelsize, titlesize, linewidth, markersize, ax, rope, rope_values
@@ -329,6 +326,8 @@ class PlotHandler:
         label, ticks = self.labels_and_ticks()
         for plotter in self.plotters.values():
             for y, values, color in plotter.treeplot(qlist, credible_interval):
+                if isinstance(rope, dict):
+                    self.display_multiple_ropes(rope, ax, y, linewidth, label[ticks==y][0],markersize, rope_values,xt_labelsize)
                 mid = len(values) // 2
                 param_iter = zip(
                     np.linspace(2 * linewidth, linewidth, mid, endpoint=True)[-1::-1], range(mid)
@@ -343,8 +342,10 @@ class PlotHandler:
                     markersize=markersize * 0.75,
                     color=color,
                 )
-                if isinstance(rope, dict):
-                    self.display_multiple_ropes(rope, ax, y, linewidth, label[ticks==y][0],markersize, rope_values,xt_labelsize)
+        ax.tick_params(labelsize=xt_labelsize)
+        ax.set_title(
+            "{:.1%} Credible Interval".format(credible_interval), fontsize=titlesize, wrap=True
+        )
         if rope is None or isinstance(rope, dict):
             return
         elif len(rope) == 2:
@@ -355,10 +356,7 @@ class PlotHandler:
                 '{"var_name": {"rope": (lo, hi)}}, or an '
                 "iterable of length 2"
             )
-        ax.tick_params(labelsize=xt_labelsize)
-        ax.set_title(
-            "{:.1%} Credible Interval".format(credible_interval), fontsize=titlesize, wrap=True
-        )
+
 
         return ax
 

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -63,8 +63,9 @@ def plot_forest(
     credible_interval : float, optional
         Credible interval to plot. Defaults to 0.94.
     rope: tuple or dictionary of tuples
-        Lower and upper values of the Region Of Practical Equivalence. If a list with one interval only is provided, the ROPE will be displayed across the y-axis. If more than one interval is provided the
-        length of the list should match the number of variables.
+        Lower and upper values of the Region Of Practical Equivalence. If a list with one
+        interval only is provided, the ROPE will be displayed across the y-axis. If more than one
+        interval is provided the length of the list should match the number of variables.
     quartiles : bool, optional
         Flag for plotting the interquartile range, in addition to the credible_interval intervals.
         Defaults to True
@@ -290,6 +291,7 @@ class PlotHandler:
                 ax.plot(x, y_min, "-", linewidth=linewidth, color=border, zorder=zorder)
                 ax.fill_between(x, y_min, y_max, alpha=alpha, color=color, zorder=zorder)
                 zorder -= 1
+        return ax
 
     def forestplot(
         self, credible_interval, quartiles, xt_labelsize, titlesize, linewidth, markersize, ax, rope

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -326,7 +326,7 @@ class PlotHandler:
                     color=color,
                 )
         if rope is not None and len(rope) == 2:
-            ax.axvspan(rope[0], rope[1], 0, values[-1], color='C2', alpha=rope_alpha)
+            ax.axvspan(rope[0], rope[1], 0, len(values), color='C2', alpha=rope_alpha)
         elif rope is not None:
             raise ValueError('Argument `rope` must be None or an '
                              'iterable of length 2')

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -192,9 +192,9 @@ def plot_forest(
 
 class PlotHandler:
     """Class to handle logic from ForestPlot."""
-    
+
     # pylint: disable=inconsistent-return-statements
-    
+
     def __init__(self, data, var_names, model_names, combined, colors):
         if not isinstance(data, (list, tuple)):
             data = [data]

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -140,7 +140,7 @@ def plot_forest(
             credible_interval, quartiles, xt_labelsize, titlesize, linewidth, markersize, axes[0], rope
         )
     elif kind == "ridgeplot":
-        plot_handler.ridgeplot(ridgeplot_overlap, xt_labelsize, linewidth, ridgeplot_alpha, axes[0])
+        plot_handler.ridgeplot(ridgeplot_overlap, linewidth, ridgeplot_alpha, axes[0])
     else:
         raise TypeError(
             "Argument 'kind' must be one of 'forestplot' or "
@@ -264,8 +264,6 @@ class PlotHandler:
         ----------
         mult : float
             How much to multiply height by. Set this to greater than 1 to have some overlap.
-        xt_labelsize : float
-            Size of tick text
         linewidth : float
             Width of line on border of ridges
         alpha : float

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -28,7 +28,6 @@ def plot_forest(
     combined=False,
     credible_interval=0.94,
     rope=None,
-    rope_values=True,
     quartiles=True,
     eff_n=False,
     r_hat=False,
@@ -66,8 +65,6 @@ def plot_forest(
     rope: tuple or dictionary of tuples
         Lower and upper values of the Region Of Practical Equivalence. If a list with one interval only is provided, the ROPE will be displayed across the y-axis. If more than one interval is provided the
         length of the list should match the number of variables.
-    rope_values : bool, optional
-        Flag for plotting lower and upper values of the Region Of Practical Equivalence as text
     quartiles : bool, optional
         Flag for plotting the interquartile range, in addition to the credible_interval intervals.
         Defaults to True
@@ -141,7 +138,7 @@ def plot_forest(
     axes = np.atleast_1d(axes)
     if kind == "forestplot":
         plot_handler.forestplot(
-            credible_interval, quartiles, xt_labelsize, titlesize, linewidth, markersize, axes[0], rope, rope_values
+            credible_interval, quartiles, xt_labelsize, titlesize, linewidth, markersize, axes[0], rope
         )
     elif kind == "ridgeplot":
         plot_handler.ridgeplot(ridgeplot_overlap, xt_labelsize, linewidth, ridgeplot_alpha, axes[0])
@@ -246,7 +243,7 @@ class PlotHandler:
             idxs.append(sub_idxs)
         return np.concatenate(labels), np.concatenate(idxs)
 
-    def display_multiple_ropes(self, rope, ax, y, linewidth, rope_var,markersize, rope_values,xt_labelsize):
+    def display_multiple_ropes(self, rope, ax, y, linewidth, rope_var,markersize,xt_labelsize):
         vals = dict(rope[rope_var][0])["rope"]
         ax.plot(
             vals,
@@ -257,10 +254,6 @@ class PlotHandler:
             zorder=0,
             alpha=0.7,
         )
-        text_props = {"size": xt_labelsize, "horizontalalignment": "center", "color": "C2"}
-        if rope_values:
-            ax.text(vals[0], y+.08, vals[0], **text_props)
-            ax.text(vals[1], y+.08, vals[1], **text_props)
         return ax
 
 
@@ -295,7 +288,7 @@ class PlotHandler:
                 zorder -= 1
 
     def forestplot(
-        self, credible_interval, quartiles, xt_labelsize, titlesize, linewidth, markersize, ax, rope, rope_values
+        self, credible_interval, quartiles, xt_labelsize, titlesize, linewidth, markersize, ax, rope
     ):
         """Draw forestplot for each plotter.
 
@@ -327,7 +320,7 @@ class PlotHandler:
         for plotter in self.plotters.values():
             for y, values, color in plotter.treeplot(qlist, credible_interval):
                 if isinstance(rope, dict):
-                    self.display_multiple_ropes(rope, ax, y, linewidth, label[ticks==y][0],markersize, rope_values,xt_labelsize)
+                    self.display_multiple_ropes(rope, ax, y, linewidth, label[ticks==y][0],markersize, xt_labelsize)
                 mid = len(values) // 2
                 param_iter = zip(
                     np.linspace(2 * linewidth, linewidth, mid, endpoint=True)[-1::-1], range(mid)

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -38,7 +38,7 @@ def plot_forest(
     ridgeplot_alpha=None,
     ridgeplot_overlap=2,
     rope_alpha=.5,
-    figsize=None,
+    figsize=None
 ):
     """Forest plot to compare credible intervals from a number of distributions.
 

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -350,6 +350,7 @@ class PlotHandler:
         elif len(rope) == 2:
             ax.axvspan(rope[0], rope[1], 0, self.y_max(), color="C2", alpha=0.5)
         else:
+            # pylint: disable=inconsistent-return-statements
             raise ValueError(
                 "Argument `rope` must be None, a dictionary like"
                 '{"var_name": {"rope": (lo, hi)}}, or an '

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -95,7 +95,6 @@ def plot_forest(
     Returns
     -------
     gridspec : matplotlib GridSpec
-
     """
     var_names = _var_names(var_names)
 
@@ -244,7 +243,7 @@ class PlotHandler:
         return np.concatenate(labels), np.concatenate(idxs)
 
     def display_multiple_ropes(self, rope, ax, y, linewidth, rope_var):
-        """ Displays ROPE when more than one interval is provided"""
+        """ Display ROPE when more than one interval is provided."""
         vals = dict(rope[rope_var][0])["rope"]
         ax.plot(
             vals,

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -243,7 +243,7 @@ class PlotHandler:
         return np.concatenate(labels), np.concatenate(idxs)
 
     def display_multiple_ropes(self, rope, ax, y, linewidth, rope_var):
-        """ Display ROPE when more than one interval is provided."""
+        """Display ROPE when more than one interval is provided."""
         vals = dict(rope[rope_var][0])["rope"]
         ax.plot(
             vals,
@@ -255,7 +255,6 @@ class PlotHandler:
             alpha=0.7,
         )
         return ax
-
 
     def ridgeplot(self, mult, linewidth, alpha, ax):
         """Draw ridgeplot for each plotter.
@@ -347,8 +346,6 @@ class PlotHandler:
                 '{"var_name": {"rope": (lo, hi)}}, or an '
                 "iterable of length 2"
             )
-
-
         return ax
 
     def plot_neff(self, ax, xt_labelsize, titlesize, markersize):

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -192,7 +192,9 @@ def plot_forest(
 
 class PlotHandler:
     """Class to handle logic from ForestPlot."""
-
+    
+    # pylint: disable=inconsistent-return-statements
+    
     def __init__(self, data, var_names, model_names, combined, colors):
         if not isinstance(data, (list, tuple)):
             data = [data]
@@ -350,7 +352,6 @@ class PlotHandler:
         elif len(rope) == 2:
             ax.axvspan(rope[0], rope[1], 0, self.y_max(), color="C2", alpha=0.5)
         else:
-            # pylint: disable=inconsistent-return-statements
             raise ValueError(
                 "Argument `rope` must be None, a dictionary like"
                 '{"var_name": {"rope": (lo, hi)}}, or an '

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -243,7 +243,8 @@ class PlotHandler:
             idxs.append(sub_idxs)
         return np.concatenate(labels), np.concatenate(idxs)
 
-    def display_multiple_ropes(self, rope, ax, y, linewidth, rope_var,markersize,xt_labelsize):
+    def display_multiple_ropes(self, rope, ax, y, linewidth, rope_var):
+        """ Displays ROPE when more than one interval is provided"""
         vals = dict(rope[rope_var][0])["rope"]
         ax.plot(
             vals,
@@ -257,7 +258,7 @@ class PlotHandler:
         return ax
 
 
-    def ridgeplot(self, mult, xt_labelsize, linewidth, alpha, ax):
+    def ridgeplot(self, mult, linewidth, alpha, ax):
         """Draw ridgeplot for each plotter.
 
         Parameters
@@ -316,11 +317,11 @@ class PlotHandler:
         else:
             qlist = [endpoint, 50, 100 - endpoint]
 
-        label, ticks = self.labels_and_ticks()
         for plotter in self.plotters.values():
             for y, values, color in plotter.treeplot(qlist, credible_interval):
                 if isinstance(rope, dict):
-                    self.display_multiple_ropes(rope, ax, y, linewidth, label[ticks==y][0],markersize, xt_labelsize)
+                    label, ticks = self.labels_and_ticks()
+                    self.display_multiple_ropes(rope, ax, y, linewidth, label[ticks==y][0])
                 mid = len(values) // 2
                 param_iter = zip(
                     np.linspace(2 * linewidth, linewidth, mid, endpoint=True)[-1::-1], range(mid)

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -176,6 +176,7 @@ def test_plot_trace_discrete(discrete_model):
     [
         ({}, 1),
         ({"var_names": "mu"}, 1),
+        ({"var_names": "mu", "rope": (-1, 1)}, 1),
         ({"r_hat": True, "quartiles": False}, 2),
         ({"var_names": ["mu"], "colors": "C0", "eff_n": True, "combined": True}, 2),
         ({"kind": "ridgeplot", "r_hat": True, "eff_n": True}, 3),
@@ -194,6 +195,12 @@ def test_plot_forest(models, model_fits, args_expected):
     args, expected = args_expected
     _, axes = plot_forest(obj, **args)
     assert axes.shape == (expected,)
+
+
+def test_plot_forest_rope_exception():
+    with pytest.raises(ValueError) as err:
+        plot_forest({"x": [1]}, rope="not_correct_format")
+    assert "Argument `rope` must be None, a dictionary like" in str(err)
 
 
 def test_plot_forest_single_value():

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -180,6 +180,13 @@ def test_plot_trace_discrete(discrete_model):
         ({"var_names": ["mu"], "colors": "C0", "eff_n": True, "combined": True}, 2),
         ({"kind": "ridgeplot", "r_hat": True, "eff_n": True}, 3),
         ({"kind": "ridgeplot", "r_hat": True, "eff_n": True, "ridgeplot_alpha": 0}, 3),
+        (
+            {
+                "var_names": ["mu", "tau"],
+                "rope": {"mu": [{"rope": (-0.1, 0.1)}], "tau": [{"rope": (0.2, 0.5)}]},
+            },
+            1,
+        ),
     ],
 )
 def test_plot_forest(models, model_fits, args_expected):


### PR DESCRIPTION
The new argument rope adds a shaded region of practical equivalence for all displayed variables in forestplot, shade is controlled by rope_alpha (default =.5). Contrary to posteriorplot rope can only be a tuple of length 2.
Not big but it is highly useful for me hence I assume it should be useful for others too.