### PR TITLE
fix for from_pyro with multiple chains

### DIFF
--- a/arviz/data/io_pyro.py
+++ b/arviz/data/io_pyro.py
@@ -53,12 +53,10 @@ class PyroConverter:
         # Do not make pyro a requirement
         from pyro.infer import EmpiricalMarginal
 
-        def expand_if_single_chain(x):
-            return np.expand_dims(x, 0) if self.posterior.num_chains == 1 else x
-
         try:  # Try pyro>=0.3 release syntax
             data = {
-                name: expand_if_single_chain(samples.enumerate_support())
+                name: np.expand_dims(samples.enumerate_support(), 0)
+                if self.posterior.num_chains == 1 else samples.enumerate_support()
                 for name, samples in self.posterior.marginal(
                     sites=self.latent_vars
                 ).empirical.items()

--- a/arviz/data/io_pyro.py
+++ b/arviz/data/io_pyro.py
@@ -69,7 +69,7 @@ class PyroConverter:
                 samples = EmpiricalMarginal(
                     self.posterior, sites=var_name
                 ).get_samples_and_weights()[0]
-                data[var_name] = expand_if_single_chain(samples.numpy().squeeze())
+                data[var_name] = np.expand_dims(samples.numpy().squeeze(), 0)
         return dict_to_dataset(data, library=self.pyro, coords=self.coords, dims=self.dims)
 
     def observed_data_to_xarray(self):

--- a/arviz/data/io_pyro.py
+++ b/arviz/data/io_pyro.py
@@ -56,7 +56,8 @@ class PyroConverter:
         try:  # Try pyro>=0.3 release syntax
             data = {
                 name: np.expand_dims(samples.enumerate_support(), 0)
-                if self.posterior.num_chains == 1 else samples.enumerate_support()
+                if self.posterior.num_chains == 1
+                else samples.enumerate_support()
                 for name, samples in self.posterior.marginal(
                     sites=self.latent_vars
                 ).empirical.items()


### PR DESCRIPTION
As per #462 - we should only expand the dimension of the samples if the number of chains is 1. Please note I have not tested this for pyro versions less than 0.3.

For the example in the #462, this now correctly prints:

```python
>>> az.summary(data)
          mean    sd  mc error  hpd 3%  hpd 97%  eff_n  r_hat
alpha    45.46  0.08       0.0   45.30    45.59  142.0   1.00
beta[0]   1.25  0.08       0.0    1.11     1.41  164.0   1.01
beta[1]   2.21  0.09       0.0    2.05     2.40  141.0   1.00
sigma     0.79  0.06       0.0    0.69     0.89   77.0   1.00
```

when running with 2 chains.