### PR TITLE
Support PyStan3

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -249,6 +249,7 @@ good-names=i,
            mu,
            tr,
            ex,
+	   eta,
            Run,
            _,
            _log

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ matrix:
   - name: "Python 3.6 Unit Test"
     python: 3.6
     env: PYSTAN_VERSION=latest NAME="UNIT"
+  - name: "Python 3.6 Unit Test - PyStan preview"
+    python: 3.6
+    env: PYSTAN_VERSION=preview NAME="UNIT"
   - name: "Python 3.5 Unit Test"
     python: 3.5
     env: PYSTAN_VERSION=latest NAME="UNIT"

--- a/arviz/data/converters.py
+++ b/arviz/data/converters.py
@@ -53,6 +53,8 @@ def convert_to_inference_data(obj, *, group="posterior", coords=None, dims=None,
         return InferenceData.from_netcdf(obj)
     elif obj.__class__.__name__ == "StanFit4Model":  # ugly, but doesn't make PyStan a requirement
         return from_pystan(posterior=obj, coords=coords, dims=dims, **kwargs)
+    elif obj.__class__.__module__ == "stan.fit":  # ugly, but doesn't make PyStan3 a requirement
+        return from_pystan(posterior=obj, coords=coords, dims=dims, **kwargs)
     elif obj.__class__.__name__ == "MultiTrace":  # ugly, but doesn't make PyMC3 a requirement
         return from_pymc3(trace=obj, coords=coords, dims=dims, **kwargs)
     elif obj.__class__.__name__ == "EnsembleSampler":  # ugly, but doesn't make emcee a requirement

--- a/arviz/data/io_pystan.py
+++ b/arviz/data/io_pystan.py
@@ -10,7 +10,6 @@ from .inference_data import InferenceData
 from .base import requires, dict_to_dataset, generate_dims_coords, make_attrs
 
 
-# pylint disable=too-many-instance-attributes, import-error
 class PyStanConverter:
     """Encapsulate PyStan specific logic."""
 
@@ -25,7 +24,7 @@ class PyStanConverter:
         log_likelihood=None,
         coords=None,
         dims=None
-    ):  # pylint: disable=too-many-instance-attributes
+    ):
         self.posterior = posterior
         self.posterior_predictive = posterior_predictive
         self.prior = prior

--- a/arviz/data/io_pystan.py
+++ b/arviz/data/io_pystan.py
@@ -550,7 +550,7 @@ def from_pystan(
     observed_data : str or a list of str
         observed data used in the sampling.
         Observed data is extracted from the `posterior.data`.
-        PyStan3 needs model object for the extraction. 
+        PyStan3 needs model object for the extraction.
         See `posterior_model`.
     log_likelihood : str
         Pointwise log_likelihood for the data.

--- a/arviz/data/io_pystan.py
+++ b/arviz/data/io_pystan.py
@@ -23,7 +23,7 @@ class PyStanConverter:
         observed_data=None,
         log_likelihood=None,
         coords=None,
-        dims=None
+        dims=None,
     ):
         self.posterior = posterior
         self.posterior_predictive = posterior_predictive
@@ -33,6 +33,7 @@ class PyStanConverter:
         self.log_likelihood = log_likelihood
         self.coords = coords
         self.dims = dims
+
         import pystan
 
         self.pystan = pystan
@@ -63,26 +64,6 @@ class PyStanConverter:
     def sample_stats_to_xarray(self):
         """Extract sample_stats from posterior."""
         posterior = self.posterior
-        dtypes = {"divergent__": bool, "n_leapfrog__": np.int64, "treedepth__": np.int64}
-
-        ndraws = [s - w for s, w in zip(posterior.sim["n_save"], posterior.sim["warmup2"])]
-
-        extraction = OrderedDict()
-        for chain, (pyholder, ndraws) in enumerate(zip(posterior.sim["samples"], ndraws)):
-            if chain == 0:
-                for key in pyholder["sampler_param_names"]:
-                    extraction[key] = []
-            for key, values in zip(pyholder["sampler_param_names"], pyholder["sampler_params"]):
-                extraction[key].append(values[-ndraws:])
-
-        data = OrderedDict()
-        for key, values in extraction.items():
-            values = np.stack(values, axis=0)
-            dtype = dtypes.get(key)
-            values = values.astype(dtype)
-            name = re.sub("__$", "", key)
-            name = "diverging" if name == "divergent" else name
-            data[name] = values
 
         # copy dims and coords
         dims = deepcopy(self.dims) if self.dims is not None else {}
@@ -91,16 +72,12 @@ class PyStanConverter:
         # log_likelihood
         log_likelihood = self.log_likelihood
         if log_likelihood is not None:
-            log_likelihood_data = get_draws(posterior, variables=log_likelihood)
-            data["log_likelihood"] = log_likelihood_data[log_likelihood]
             if isinstance(log_likelihood, str) and log_likelihood in dims:
                 dims["log_likelihood"] = dims.pop(log_likelihood)
             if isinstance(log_likelihood, str) and log_likelihood in coords:
                 coords["log_likelihood"] = coords.pop(log_likelihood)
 
-        # lp__
-        stat_lp = get_draws(posterior, variables="lp__")
-        data["lp"] = stat_lp["lp__"]
+        data = get_sample_stats(posterior, log_likelihood)
 
         return dict_to_dataset(data, library=self.pystan, coords=coords, dims=dims)
 
@@ -133,31 +110,7 @@ class PyStanConverter:
     def sample_stats_prior_to_xarray(self):
         """Extract sample_stats_prior from prior."""
         prior = self.prior
-        dtypes = {"divergent__": bool, "n_leapfrog__": np.int64, "treedepth__": np.int64}
-
-        ndraws = [s - w for s, w in zip(prior.sim["n_save"], prior.sim["warmup2"])]
-
-        extraction = OrderedDict()
-        for chain, (pyholder, ndraws) in enumerate(zip(prior.sim["samples"], ndraws)):
-            if chain == 0:
-                for key in pyholder["sampler_param_names"]:
-                    extraction[key] = []
-            for key, values in zip(pyholder["sampler_param_names"], pyholder["sampler_params"]):
-                extraction[key].append(values[-ndraws:])
-
-        data = OrderedDict()
-        for key, values in extraction.items():
-            values = np.stack(values, axis=0)
-            dtype = dtypes.get(key)
-            values = values.astype(dtype)
-            name = re.sub("__$", "", key)
-            name = "diverging" if name == "divergent" else name
-            data[name] = values
-
-        # lp__
-        stat_lp = get_draws(prior, variables="lp__")
-        data["lp"] = stat_lp["lp__"]
-
+        data = get_sample_stats(prior)
         return dict_to_dataset(data, library=self.pystan, coords=self.coords, dims=self.dims)
 
     @requires("prior")
@@ -190,6 +143,172 @@ class PyStanConverter:
             )
             observed_data[key] = xr.DataArray(vals, dims=val_dims, coords=coords)
         return xr.Dataset(data_vars=observed_data, attrs=make_attrs(library=self.pystan))
+
+    def to_inference_data(self):
+        """Convert all available data to an InferenceData object.
+
+        Note that if groups can not be created (i.e., there is no `fit`, so
+        the `posterior` and `sample_stats` can not be extracted), then the InferenceData
+        will not have those groups.
+        """
+        return InferenceData(
+            **{
+                "posterior": self.posterior_to_xarray(),
+                "sample_stats": self.sample_stats_to_xarray(),
+                "posterior_predictive": self.posterior_predictive_to_xarray(),
+                "prior": self.prior_to_xarray(),
+                "sample_stats_prior": self.sample_stats_prior_to_xarray(),
+                "prior_predictive": self.prior_predictive_to_xarray(),
+                "observed_data": self.observed_data_to_xarray(),
+            }
+        )
+
+
+class PyStan3Converter:
+    """Encapsulate PyStan3 specific logic."""
+
+    # pylint disable=too-many-instance-attributes, import-error
+    def __init__(
+        self,
+        *_,
+        posterior=None,
+        posterior_model=None,
+        posterior_predictive=None,
+        prior=None,
+        prior_model=None,
+        prior_predictive=None,
+        observed_data=None,
+        log_likelihood=None,
+        coords=None,
+        dims=None,
+    ):
+        self.posterior = posterior
+        self.posterior_model = posterior_model
+        self.posterior_predictive = posterior_predictive
+        self.prior = prior
+        self.prior_model = prior_model
+        self.prior_predictive = prior_predictive
+        self.observed_data = observed_data
+        self.log_likelihood = log_likelihood
+        self.coords = coords
+        self.dims = dims
+
+        import stan
+
+        self.stan = stan
+
+    @requires("posterior")
+    def posterior_to_xarray(self):
+        """Extract posterior samples from fit."""
+        posterior = self.posterior
+        posterior_model = self.posterior_model
+        # filter posterior_predictive and log_likelihood
+        posterior_predictive = self.posterior_predictive
+        if posterior_predictive is None:
+            posterior_predictive = []
+        elif isinstance(posterior_predictive, str):
+            posterior_predictive = [posterior_predictive]
+        log_likelihood = self.log_likelihood
+        if not isinstance(log_likelihood, str):
+            log_likelihood = []
+        else:
+            log_likelihood = [log_likelihood]
+
+        ignore = posterior_predictive + log_likelihood
+
+        data = get_draws_stan3(posterior, model=posterior_model, ignore=ignore)
+
+        return dict_to_dataset(data, library=self.stan, coords=self.coords, dims=self.dims)
+
+    @requires("posterior")
+    def sample_stats_to_xarray(self):
+        """Extract sample_stats from posterior."""
+        posterior = self.posterior
+        posterior_model = self.posterior_model
+        # copy dims and coords
+        dims = deepcopy(self.dims) if self.dims is not None else {}
+        coords = deepcopy(self.coords) if self.coords is not None else {}
+
+        # log_likelihood
+        log_likelihood = self.log_likelihood
+        if log_likelihood is not None:
+            if isinstance(log_likelihood, str) and log_likelihood in dims:
+                dims["log_likelihood"] = dims.pop(log_likelihood)
+            if isinstance(log_likelihood, str) and log_likelihood in coords:
+                coords["log_likelihood"] = coords.pop(log_likelihood)
+
+        data = get_sample_stats_stan3(
+            posterior, model=posterior_model, log_likelihood=log_likelihood
+        )
+
+        return dict_to_dataset(data, library=self.stan, coords=coords, dims=dims)
+
+    @requires("posterior")
+    @requires("posterior_predictive")
+    def posterior_predictive_to_xarray(self):
+        """Convert posterior_predictive samples to xarray."""
+        posterior = self.posterior
+        posterior_model = self.posterior_model
+        posterior_predictive = self.posterior_predictive
+        data = get_draws_stan3(posterior, model=posterior_model, variables=posterior_predictive)
+        return dict_to_dataset(data, library=self.stan, coords=self.coords, dims=self.dims)
+
+    @requires("prior")
+    def prior_to_xarray(self):
+        """Convert prior samples to xarray."""
+        prior = self.prior
+        prior_model = self.prior_model
+        # filter posterior_predictive and log_likelihood
+        prior_predictive = self.prior_predictive
+        if prior_predictive is None:
+            prior_predictive = []
+        elif isinstance(prior_predictive, str):
+            prior_predictive = [prior_predictive]
+
+        ignore = prior_predictive
+
+        data = get_draws_stan3(prior, model=prior_model, ignore=ignore)
+        return dict_to_dataset(data, library=self.stan, coords=self.coords, dims=self.dims)
+
+    @requires("prior")
+    def sample_stats_prior_to_xarray(self):
+        """Extract sample_stats_prior from prior."""
+        prior = self.prior
+        prior_model = self.prior_model
+        data = get_sample_stats_stan3(prior, model=prior_model)
+        return dict_to_dataset(data, library=self.stan, coords=self.coords, dims=self.dims)
+
+    @requires("prior")
+    @requires("prior_predictive")
+    def prior_predictive_to_xarray(self):
+        """Convert prior_predictive samples to xarray."""
+        prior = self.prior
+        prior_model = self.prior_model
+        prior_predictive = self.prior_predictive
+        data = get_draws_stan3(prior, model=prior_model, variables=prior_predictive)
+        return dict_to_dataset(data, library=self.stan, coords=self.coords, dims=self.dims)
+
+    @requires("posterior_model")
+    @requires("observed_data")
+    def observed_data_to_xarray(self):
+        """Convert observed data to xarray."""
+        posterior_model = self.posterior_model
+        if self.dims is None:
+            dims = {}
+        else:
+            dims = self.dims
+        observed_names = self.observed_data
+        if isinstance(observed_names, str):
+            observed_names = [observed_names]
+        observed_data = OrderedDict()
+        for key in observed_names:
+            vals = np.atleast_1d(posterior_model.data[key])
+            val_dims = dims.get(key)
+            val_dims, coords = generate_dims_coords(
+                vals.shape, key, dims=val_dims, coords=self.coords
+            )
+            observed_data[key] = xr.DataArray(vals, dims=val_dims, coords=coords)
+        return xr.Dataset(data_vars=observed_data, attrs=make_attrs(library=self.stan))
 
     def to_inference_data(self):
         """Convert all available data to an InferenceData object.
@@ -273,7 +392,100 @@ def get_draws(fit, variables=None, ignore=None):
     return data
 
 
-def infer_dtypes(fit):
+def get_sample_stats(fit, log_likelihood=None):
+    """Extract sample stats from PyStan fit."""
+    dtypes = {"divergent__": bool, "n_leapfrog__": np.int64, "treedepth__": np.int64}
+
+    ndraws = [s - w for s, w in zip(fit.sim["n_save"], fit.sim["warmup2"])]
+
+    extraction = OrderedDict()
+    for chain, (pyholder, ndraws) in enumerate(zip(fit.sim["samples"], ndraws)):
+        if chain == 0:
+            for key in pyholder["sampler_param_names"]:
+                extraction[key] = []
+        for key, values in zip(pyholder["sampler_param_names"], pyholder["sampler_params"]):
+            extraction[key].append(values[-ndraws:])
+
+    data = OrderedDict()
+    for key, values in extraction.items():
+        values = np.stack(values, axis=0)
+        dtype = dtypes.get(key)
+        values = values.astype(dtype)
+        name = re.sub("__$", "", key)
+        name = "diverging" if name == "divergent" else name
+        data[name] = values
+
+    # log_likelihood
+    if log_likelihood is not None:
+        log_likelihood_data = get_draws(fit, variables=log_likelihood)
+        data["log_likelihood"] = log_likelihood_data[log_likelihood]
+
+    # lp__
+    stat_lp = get_draws(fit, variables="lp__")
+    data["lp"] = stat_lp["lp__"]
+
+    return data
+
+
+def get_draws_stan3(fit, model=None, variables=None, ignore=None):
+    """Extract draws from PyStan3 fit."""
+    if ignore is None:
+        ignore = []
+
+    dtypes = {}
+    if model is not None:
+        dtypes = infer_dtypes(fit, model)
+
+    if variables is None:
+        variables = fit.param_names
+    elif isinstance(variables, str):
+        variables = [variables]
+    variables = list(variables)
+
+    data = OrderedDict()
+
+    for var in variables:
+        if var in data:
+            continue
+        dtype = dtypes.get(var)
+
+        # todo: correct number of draws if fit.save_warmup is True
+        new_shape = *fit.dims[fit.param_names.index(var)], -1, fit.num_chains
+        values = fit._draws[fit._parameter_indexes(var), :]
+        values = values.reshape(new_shape, order="F")
+        values = np.moveaxis(values, [-2, -1], [1, 0])
+        values = values.astype(dtype)
+        data[var] = values
+
+    return data
+
+
+# pylint disable=protected-access
+def get_sample_stats_stan3(fit, model=None, log_likelihood=None):
+    """Extract sample stats from PyStan3 fit."""
+    dtypes = {"divergent__": bool, "n_leapfrog__": np.int64, "treedepth__": np.int64}
+
+    data = OrderedDict()
+    for key in fit.sample_and_sampler_param_names:
+        new_shape = -1, fit.num_chains
+        values = fit._draws[fit._parameter_indexes(key)]
+        values = values.reshape(new_shape, order="F")
+        values = np.moveaxis(values, [-2, -1], [1, 0])
+        dtype = dtypes.get(key)
+        values = values.astype(dtype)
+        name = re.sub("__$", "", key)
+        name = "diverging" if name == "divergent" else name
+        data[name] = values
+
+    # log_likelihood
+    if log_likelihood is not None:
+        log_likelihood_data = get_draws_stan3(fit, model=model, variables=log_likelihood)
+        data["log_likelihood"] = log_likelihood_data[log_likelihood]
+
+    return data
+
+
+def infer_dtypes(fit, model=None):
     """Infer dtypes from Stan model code.
 
     Function strips out generated quantities block and searchs for `int`
@@ -289,7 +501,12 @@ def infer_dtypes(fit):
     pattern_int = re.compile(
         "".join((stan_integer, stan_ws, stan_limits, stan_ws, stan_param)), re.IGNORECASE
     )
-    stan_code = fit.get_stancode()
+    if model is None:
+        stan_code = fit.get_stancode()
+        model_pars = fit.model_pars
+    else:
+        stan_code = model.program_code
+        model_pars = fit.param_names
     # remove deprecated comments
     stan_code = "\n".join(
         line if "#" not in line else line[: line.find("#")] for line in stan_code.splitlines()
@@ -297,10 +514,11 @@ def infer_dtypes(fit):
     stan_code = re.sub(pattern_remove_comments, "", stan_code)
     stan_code = stan_code.split("generated quantities")[-1]
     dtypes = re.findall(pattern_int, stan_code)
-    dtypes = {item.strip(): "int" for item in dtypes if item.strip() in fit.model_pars}
+    dtypes = {item.strip(): "int" for item in dtypes if item.strip() in model_pars}
     return dtypes
 
 
+# pylint disable=too-many-instance-attributes
 def from_pystan(
     *,
     posterior=None,
@@ -310,7 +528,9 @@ def from_pystan(
     observed_data=None,
     log_likelihood=None,
     coords=None,
-    dims=None
+    dims=None,
+    posterior_model=None,
+    prior_model=None,
 ):
     """Convert PyStan data into an InferenceData object.
 
@@ -335,18 +555,38 @@ def from_pystan(
         is the name of the dimension, the values are the index values.
     dims : dict[str, List(str)]
         A mapping from variables to a list of coordinate names for the variable.
+    posterior_model : stan.model.Model
+        PyStan3 specific model object.
+    prior_model : stan.model.Model
+        PyStan3 specific model object.
 
     Returns
     -------
     InferenceData object
     """
-    return PyStanConverter(
-        posterior=posterior,
-        posterior_predictive=posterior_predictive,
-        prior=prior,
-        prior_predictive=prior_predictive,
-        observed_data=observed_data,
-        log_likelihood=log_likelihood,
-        coords=coords,
-        dims=dims,
-    ).to_inference_data()
+    check_posterior = (posterior is not None) and (type(posterior).__module__ == "stan.fit")
+    check_prior = (prior is not None) and (type(prior).__module__ == "stan.fit")
+    if check_posterior or check_prior:
+        return PyStan3Converter(
+            posterior=posterior,
+            posterior_model=posterior_model,
+            posterior_predictive=posterior_predictive,
+            prior=prior,
+            prior_model=prior_model,
+            prior_predictive=prior_predictive,
+            observed_data=observed_data,
+            log_likelihood=log_likelihood,
+            coords=coords,
+            dims=dims,
+        ).to_inference_data()
+    else:
+        return PyStanConverter(
+            posterior=posterior,
+            posterior_predictive=posterior_predictive,
+            prior=prior,
+            prior_predictive=prior_predictive,
+            observed_data=observed_data,
+            log_likelihood=log_likelihood,
+            coords=coords,
+            dims=dims,
+        ).to_inference_data()

--- a/arviz/data/io_pystan.py
+++ b/arviz/data/io_pystan.py
@@ -550,6 +550,8 @@ def from_pystan(
     observed_data : str or a list of str
         observed data used in the sampling.
         Observed data is extracted from the `posterior.data`.
+        PyStan3 needs model object for the extraction. 
+        See `posterior_model`.
     log_likelihood : str
         Pointwise log_likelihood for the data.
         log_likelihood is extracted from the posterior.
@@ -559,9 +561,10 @@ def from_pystan(
     dims : dict[str, List(str)]
         A mapping from variables to a list of coordinate names for the variable.
     posterior_model : stan.model.Model
-        PyStan3 specific model object.
+        PyStan3 specific model object. Needed for automatic dtype parsing
+        and for the extraction of observed data.
     prior_model : stan.model.Model
-        PyStan3 specific model object.
+        PyStan3 specific model object. Needed for automatic dtype parsing.
 
     Returns
     -------

--- a/arviz/data/io_pystan.py
+++ b/arviz/data/io_pystan.py
@@ -10,6 +10,7 @@ from .inference_data import InferenceData
 from .base import requires, dict_to_dataset, generate_dims_coords, make_attrs
 
 
+# pylint disable=too-many-instance-attributes, import-error
 class PyStanConverter:
     """Encapsulate PyStan specific logic."""
 
@@ -23,8 +24,8 @@ class PyStanConverter:
         observed_data=None,
         log_likelihood=None,
         coords=None,
-        dims=None,
-    ):
+        dims=None
+    ):  # pylint: disable=too-many-instance-attributes
         self.posterior = posterior
         self.posterior_predictive = posterior_predictive
         self.prior = prior
@@ -34,7 +35,7 @@ class PyStanConverter:
         self.coords = coords
         self.dims = dims
 
-        import pystan
+        import pystan  # pylint: disable=import-error
 
         self.pystan = pystan
 
@@ -167,7 +168,7 @@ class PyStanConverter:
 class PyStan3Converter:
     """Encapsulate PyStan3 specific logic."""
 
-    # pylint disable=too-many-instance-attributes, import-error
+    # pylint: disable=too-many-instance-attributes
     def __init__(
         self,
         *_,
@@ -180,7 +181,7 @@ class PyStan3Converter:
         observed_data=None,
         log_likelihood=None,
         coords=None,
-        dims=None,
+        dims=None
     ):
         self.posterior = posterior
         self.posterior_model = posterior_model
@@ -193,7 +194,7 @@ class PyStan3Converter:
         self.coords = coords
         self.dims = dims
 
-        import stan
+        import stan  # pylint: disable=import-error
 
         self.stan = stan
 
@@ -449,9 +450,13 @@ def get_draws_stan3(fit, model=None, variables=None, ignore=None):
             continue
         dtype = dtypes.get(var)
 
-        # todo: correct number of draws if fit.save_warmup is True
-        new_shape = *fit.dims[fit.param_names.index(var)], -1, fit.num_chains
-        values = fit._draws[fit._parameter_indexes(var), :]
+        # in future fix the correct number of draws if fit.save_warmup is True
+        new_shape = (
+            *fit.dims[fit.param_names.index(var)],
+            -1,
+            fit.num_chains,
+        )  # pylint: disable=protected-access
+        values = fit._draws[fit._parameter_indexes(var), :]  # pylint: disable=protected-access
         values = values.reshape(new_shape, order="F")
         values = np.moveaxis(values, [-2, -1], [1, 0])
         values = values.astype(dtype)
@@ -460,7 +465,6 @@ def get_draws_stan3(fit, model=None, variables=None, ignore=None):
     return data
 
 
-# pylint disable=protected-access
 def get_sample_stats_stan3(fit, model=None, log_likelihood=None):
     """Extract sample stats from PyStan3 fit."""
     dtypes = {"divergent__": bool, "n_leapfrog__": np.int64, "treedepth__": np.int64}
@@ -468,7 +472,7 @@ def get_sample_stats_stan3(fit, model=None, log_likelihood=None):
     data = OrderedDict()
     for key in fit.sample_and_sampler_param_names:
         new_shape = -1, fit.num_chains
-        values = fit._draws[fit._parameter_indexes(key)]
+        values = fit._draws[fit._parameter_indexes(key)]  # pylint: disable=protected-access
         values = values.reshape(new_shape, order="F")
         values = np.moveaxis(values, [-2, -1], [1, 0])
         dtype = dtypes.get(key)
@@ -530,7 +534,7 @@ def from_pystan(
     coords=None,
     dims=None,
     posterior_model=None,
-    prior_model=None,
+    prior_model=None
 ):
     """Convert PyStan data into an InferenceData object.
 

--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -352,7 +352,7 @@ def stan_extract_dict(fit, var_names=None):
 
 
 def pystan_version():
-    """Check PyStan versionself.
+    """Check PyStan version.
 
     Returns
     -------

--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -230,7 +230,7 @@ def pystan_noncentered_schools(data, draws, chains):
             }
         }
     """
-    if pystan.__version__.startswith("2"):
+    if pystan_version() == 2:
         stan_model = pystan.StanModel(model_code=schools_code)
         fit = stan_model.sampling(data=data, iter=draws, warmup=0, chains=chains)
     else:
@@ -349,3 +349,7 @@ def stan_extract_dict(fit, var_names=None):
         data[var] = values
 
     return data
+
+
+def pystan_version():
+    return int(pystan.__version__[0])

--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -276,16 +276,21 @@ def load_cached_models(eight_school_params, draws, chains):
             py_version, library, sys.platform, draws, chains
         )
 
-        path = os.path.join(data_directory, fname)
-        if not os.path.exists(path):
+        if STAN_VERSION == 2:
+            path = os.path.join(data_directory, fname)
+            if not os.path.exists(path):
 
-            with open(path, "wb") as buff:
-                _log.info("Generating and caching %s", fname)
-                pickle.dump(func(eight_school_params, draws, chains), buff)
+                with open(path, "wb") as buff:
+                    _log.info("Generating and caching %s", fname)
+                    pickle.dump(func(eight_school_params, draws, chains), buff)
 
-        with open(path, "rb") as buff:
-            _log.info("Loading %s from cache", fname)
-            models[library.__name__] = pickle.load(buff)
+            with open(path, "rb") as buff:
+                _log.info("Loading %s from cache", fname)
+                models[library.__name__] = pickle.load(buff)
+        else:
+            # Currently, PyStan 3 doesn't support pickling
+            _log.info("Generating and loading %s", fname)
+            models[library.__name__] = func(eight_school_params, draws, chains)
 
     return models
 

--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -234,6 +234,13 @@ def pystan_noncentered_schools(data, draws, chains):
         stan_model = pystan.StanModel(model_code=schools_code)
         fit = stan_model.sampling(data=data, iter=draws, warmup=0, chains=chains)
     else:
+        # hard code schools data
+        # bug in PyStan3 preview. It modify data in-place
+        data = {
+            "J": 8,
+            "y": np.array([28.0, 8.0, -3.0, 7.0, -1.0, 1.0, 18.0, 12.0]),
+            "sigma": np.array([15.0, 10.0, 16.0, 11.0, 9.0, 11.0, 10.0, 18.0]),
+        }
         stan_model = pystan.build(schools_code, data=data)
         fit = stan_model.sample(
             num_chains=chains, num_samples=draws, num_warmup=0, save_warmup=False

--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -11,7 +11,19 @@ import pymc3 as pm
 import pyro
 import pyro.distributions as dist
 from pyro.infer.mcmc import MCMC, NUTS
-import pystan
+
+# pylint: disable=try-except-raise
+try:
+    import pystan
+
+    STAN = 2
+except ImportError:
+    import stan
+
+    STAN = 3
+except:
+    raise
+
 import tensorflow_probability as tfp
 import tensorflow_probability.python.edward2 as ed
 import scipy.optimize as op
@@ -224,8 +236,12 @@ def pystan_noncentered_schools(data, draws, chains):
             }
         }
     """
-    stan_model = pystan.StanModel(model_code=schools_code)
-    fit = stan_model.sampling(data=data, iter=draws, warmup=0, chains=chains)
+    if STAN == 2:
+        stan_model = pystan.StanModel(model_code=schools_code)
+        fit = stan_model.sampling(data=data, iter=draws, warmup=0, chains=chains)
+    else:
+        stan_model = stan.build(schools_code, data=data)
+        fit = stan_model.sample(num_chains=chains, num_samples=draws, num_warmup=0)
     return stan_model, fit
 
 

--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -236,7 +236,7 @@ def pystan_noncentered_schools(data, draws, chains):
     else:
         stan_model = pystan.build(schools_code, data=data)
         fit = stan_model.sample(
-            num_chains=chains, num_samples=draws, num_warmup=100, save_warmup=False
+            num_chains=chains, num_samples=draws, num_warmup=0, save_warmup=False
         )
     return stan_model, fit
 

--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -352,4 +352,11 @@ def stan_extract_dict(fit, var_names=None):
 
 
 def pystan_version():
+    """Check PyStan versionself.
+
+    Returns
+    -------
+    int
+        Major version number
+    """
     return int(pystan.__version__[0])

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -23,6 +23,7 @@ from .helpers import (  # pylint: disable=unused-import
     load_cached_models,
     pystan_extract_unpermuted,
     stan_extract_dict,
+    pystan_version,
 )
 
 
@@ -246,13 +247,13 @@ class TestDictNetCDFUtils:
 
         class Data:
             _, stan_fit = load_cached_models(eight_schools_params, draws, chains)["pystan"]
-            try:
+            if pystan_version() == 2:
                 stan_dict = pystan_extract_unpermuted(stan_fit)
                 obj = {}
                 for name, vals in stan_dict.items():
                     if name not in {"y_hat", "log_lik"}:  # extra vars
                         obj[name] = np.swapaxes(vals, 0, 1)
-            except:
+            else:
                 stan_dict = stan_extract_dict(stan_fit)
                 obj = {}
                 for name, vals in stan_dict.items():

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -262,7 +262,7 @@ class TestDictNetCDFUtils:
         return Data
 
     def check_var_names_coords_dims(self, dataset):
-        assert set(dataset.data_vars) == {"mu", "tau", "theta_tilde", "theta"}
+        assert set(dataset.data_vars) == {"mu", "tau", "eta", "theta"}
         assert set(dataset.coords) == {"chain", "draw", "school"}
 
     def get_inference_data(self, data, eight_schools_params):
@@ -270,7 +270,7 @@ class TestDictNetCDFUtils:
             data.obj,
             group="posterior",
             coords={"school": np.arange(eight_schools_params["J"])},
-            dims={"theta": ["school"], "theta_tilde": ["school"]},
+            dims={"theta": ["school"], "eta": ["school"]},
         )
 
     def test_convert_to_inference_data(self, data, eight_schools_params):
@@ -283,7 +283,7 @@ class TestDictNetCDFUtils:
             data.obj,
             group="posterior",
             coords={"school": np.arange(eight_schools_params["J"])},
-            dims={"theta": ["school"], "theta_tilde": ["school"]},
+            dims={"theta": ["school"], "eta": ["school"]},
         )
         assert dataset.draw.shape == (draws,)
         assert dataset.chain.shape == (chains,)
@@ -328,7 +328,7 @@ class TestPyMC3NetCDFUtils:
             prior=prior,
             posterior_predictive=posterior_predictive,
             coords={"school": np.arange(eight_schools_params["J"])},
-            dims={"theta": ["school"], "theta_tilde": ["school"]},
+            dims={"theta": ["school"], "eta": ["school"]},
         )
 
     def test_sampler_stats(self, data, eight_schools_params):
@@ -369,7 +369,7 @@ class TestPyStanNetCDFUtils:
                 "y": ["school"],
                 "log_lik": ["school"],
                 "y_hat": ["school"],
-                "theta_tilde": ["school"],
+                "eta": ["school"],
             },
         )
 
@@ -390,7 +390,7 @@ class TestPyStanNetCDFUtils:
                 "theta": ["school"],
                 "y": ["school"],
                 "y_hat": ["school"],
-                "theta_tilde": ["school"],
+                "eta": ["school"],
                 "log_lik": ["log_likelihood_dim"],
             },
         )
@@ -404,12 +404,7 @@ class TestPyStanNetCDFUtils:
             prior_predictive=["y_hat", "log_lik"],
             observed_data="y",
             coords={"school": np.arange(eight_schools_params["J"])},
-            dims={
-                "theta": ["school"],
-                "y": ["school"],
-                "y_hat": ["school"],
-                "theta_tilde": ["school"],
-            },
+            dims={"theta": ["school"], "y": ["school"], "y_hat": ["school"], "eta": ["school"]},
         )
 
     def get_inference_data4(self, data):
@@ -594,7 +589,7 @@ class TestCmdStanNetCDFUtils:
                     "y": ["school"],
                     "log_lik": ["school"],
                     "y_hat": ["school"],
-                    "theta_tilde": ["school"],
+                    "eta": ["school"],
                 },
             )
             assert hasattr(inference_data, "posterior")
@@ -626,7 +621,7 @@ class TestCmdStanNetCDFUtils:
                     "y": ["school"],
                     "log_lik": ["school"],
                     "y_hat": ["school"],
-                    "theta_tilde": ["school"],
+                    "eta": ["school"],
                 },
             )
             assert hasattr(inference_data, "posterior")
@@ -655,12 +650,7 @@ class TestCmdStanNetCDFUtils:
                 observed_data_var=["y"],
                 log_likelihood="log_lik",
                 coords={"school": np.arange(8), "log_lik_dim_0": np.arange(8)},
-                dims={
-                    "theta": ["school"],
-                    "y": ["school"],
-                    "y_hat": ["school"],
-                    "theta_tilde": ["school"],
-                },
+                dims={"theta": ["school"], "y": ["school"], "y_hat": ["school"], "eta": ["school"]},
             )
             assert hasattr(inference_data, "posterior")
             assert hasattr(inference_data, "sample_stats")
@@ -717,7 +707,7 @@ class TestCmdStanNetCDFUtils:
                     "y": ["school"],
                     "log_lik": ["log_lik_dim"],
                     "y_hat": ["school"],
-                    "theta_tilde": ["school"],
+                    "eta": ["school"],
                 },
             )
             assert hasattr(inference_data, "posterior")

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -357,10 +357,8 @@ class TestPyStanNetCDFUtils:
         """vars as str."""
         return from_pystan(
             posterior=data.obj,
-            posterior_model=data.model,
             posterior_predictive="y_hat",
             prior=data.obj,
-            prior_model=data.model,
             prior_predictive="y_hat",
             observed_data="y",
             log_likelihood="log_lik",
@@ -372,6 +370,8 @@ class TestPyStanNetCDFUtils:
                 "y_hat": ["school"],
                 "eta": ["school"],
             },
+            posterior_model=data.model,
+            prior_model=data.model,
         )
 
     def get_inference_data2(self, data, eight_schools_params):
@@ -394,6 +394,8 @@ class TestPyStanNetCDFUtils:
                 "eta": ["school"],
                 "log_lik": ["log_likelihood_dim"],
             },
+            posterior_model=data.model,
+            prior_model=data.model,
         )
 
     def get_inference_data3(self, data, eight_schools_params):
@@ -406,6 +408,8 @@ class TestPyStanNetCDFUtils:
             observed_data="y",
             coords={"school": np.arange(eight_schools_params["J"])},
             dims={"theta": ["school"], "y": ["school"], "y_hat": ["school"], "eta": ["school"]},
+            posterior_model=data.model,
+            prior_model=data.model,
         )
 
     def get_inference_data4(self, data):
@@ -418,6 +422,8 @@ class TestPyStanNetCDFUtils:
             observed_data="y",
             coords=None,
             dims=None,
+            posterior_model=data.model,
+            prior_model=data.model,
         )
 
     def test_sampler_stats(self, data, eight_schools_params):

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -13,7 +13,7 @@ PYSTAN_VERSION=${PYSTAN_VERSION:-latest}
 
 
 if [[ $* != *--global* ]]; then
-    ENVNAME="testenv${PYTHON_VERSION}_PYSTAN${PYSTAN_VERSION}"
+    ENVNAME="testenv_${PYTHON_VERSION}_PYSTAN_${PYSTAN_VERSION}"
 
     if conda env list | grep -q ${ENVNAME}
     then
@@ -21,7 +21,6 @@ if [[ $* != *--global* ]]; then
     else
         echo "Creating environment ${ENVNAME}"
         conda create -n ${ENVNAME} --yes pip python=${PYTHON_VERSION}
-
     fi
 
     # Activate environment immediately
@@ -35,6 +34,8 @@ if [[ $* != *--global* ]]; then
     fi
 fi
 
+pip install --upgrade pip
+
 # Pyro install with pip is ~511MB. These binaries are ~91MB, somehow, and do not
 # break the build. The first is the Python 3.5 wheel, the second is 3.6.
 if [ "$PYTHON_VERSION" = "3.5" ]; then
@@ -46,10 +47,12 @@ fi
 if [ "$PYSTAN_VERSION" = "latest" ]; then
     pip --no-cache-dir install pystan
 else
+  if [ "$PYSTAN_VERSION" = "preview" ]; then
+    pip --no-cache-dir install --pre pystan
+  else
     pip --no-cache-dir install pystan==${PYSTAN_VERSION}
+  fi
 fi
-
-pip install --upgrade pip
 
 #  Install editable using the setup.py
 pip install  --no-cache-dir -r requirements.txt

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -48,6 +48,8 @@ if [ "$PYSTAN_VERSION" = "latest" ]; then
     pip --no-cache-dir install pystan
 else
   if [ "$PYSTAN_VERSION" = "preview" ]; then
+    # try to skip other pre-releases than pystan
+    pip --no-cache-dir install numpy uvloop marshmallow PyYAML
     pip --no-cache-dir install --pre pystan
   else
     pip --no-cache-dir install pystan==${PYSTAN_VERSION}


### PR DESCRIPTION
Support PyStan3

Automatic dtypes and `observed_data` needs `posterior_model`.

This PR implements the same groups as does PyStan 2.x code.