### PR TITLE
KDE: Display quantiles

### DIFF
--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -157,6 +157,7 @@ def plot_kde(
         rug_space = max(density) * rug_kwargs.pop("space")
 
         x = np.linspace(lower, upper, len(density))
+        x_q = x
         fill_func = ax.fill_between
         fill_x, fill_y = x, density
         if rotated:
@@ -178,14 +179,16 @@ def plot_kde(
         if quartiles:
             fill_kwargs.setdefault("alpha", 0.75)
 
-            perct = np.percentile(values, [0, 25.0, 50.0, 75.0, 100])
+            perct = np.percentile(values, [25.0, 50.0, 75.0])
 
-            x_range = np.linspace(lower, upper, len(density))
-            idx0 = 0
-            for p in perct:
-                idx1 = np.argsort(np.abs(x_range - p))[0]
-                fill_func(fill_x[idx0:idx1], fill_y[idx0:idx1], **fill_kwargs)
-                idx0 = idx1
+            idx = [np.argsort(np.abs(x_q - perct_i))[0] for perct_i in perct]
+
+            fill_func(
+                fill_x,
+                fill_y,
+                where=np.isin(fill_x, fill_x[idx], invert=True, assume_unique=True),
+                **fill_kwargs
+            )
         else:
             fill_kwargs.setdefault("alpha", 0)
             ax.plot(x, density, label=label, **plot_kwargs)

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -46,7 +46,8 @@ def plot_kde(
         smoother the KDE will be. Defaults to 4.5 which is essentially the same as the Scott's
         rule of thumb (the default rule used by SciPy).
     quantiles : list
-        Quantiles in ascending order used to segment the KDE. Use [.25, .5, .75] for quartiles. Defaults to None.
+        Quantiles in ascending order used to segment the KDE. Use [.25, .5, .75] for quartiles.
+        Defaults to None.
     rotated : bool
         Whether to rotate the 1D KDE plot 90 degrees.
     contour : bool
@@ -255,7 +256,6 @@ def _fast_kde(x, cumulative=False, bw=4.5):
 
     n_bins = min(int(len_x ** (1 / 3) * std_x * 2), 200)
     grid, _ = np.histogram(x, bins=n_bins)
-    d_x = (xmax - xmin) / (n_bins - 1)
 
     scotts_factor = len_x ** (-0.2)
     kern_nx = int(scotts_factor * 2 * np.pi * std_x)

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -97,6 +97,12 @@ def discrete_model():
     return {"x": np.random.randint(10, size=100), "y": np.random.randint(10, size=100)}
 
 
+@pytest.fixture(scope="module")
+def continuous_model():
+    """Simple fixture for random continuous model"""
+    return {"x": np.random.beta(2, 5, size=100), "y": np.random.beta(2, 5, size=100)}
+
+
 @pytest.fixture(scope="function")
 def fig_ax():
     fig, ax = plt.subplots(1, 1)
@@ -228,16 +234,22 @@ def test_plot_joint_discrete(discrete_model):
         {"contour": False},
     ],
 )
-def test_plot_kde(discrete_model, kwargs):
-    axes = plot_kde(discrete_model["x"], discrete_model["y"], **kwargs)
+def test_plot_kde(continuous_model, kwargs):
+    axes = plot_kde(continuous_model["x"], continuous_model["y"], **kwargs)
+    assert axes
+
+
+@pytest.mark.parametrize("kwargs", [{"cumulative": True}, {"rug": True}])
+def test_plot_kde_cumulative(continuous_model, kwargs):
+    axes = plot_kde(continuous_model["x"], quantiles=[0.25, 0.5, 0.75], **kwargs)
     assert axes
 
 
 @pytest.mark.parametrize(
     "kwargs", [{"plot_kwargs": {"linestyle": "-"}}, {"cumulative": True}, {"rug": True}]
 )
-def test_plot_kde_cumulative(discrete_model, kwargs):
-    axes = plot_kde(discrete_model["x"], **kwargs)
+def test_plot_kde_quantiles(continuous_model, kwargs):
+    axes = plot_kde(continuous_model["x"], **kwargs)
     assert axes
 
 

--- a/examples/plot_kde_quantiles.py
+++ b/examples/plot_kde_quantiles.py
@@ -1,0 +1,13 @@
+"""
+KDE quantiles
+=============
+
+_thumb: .2, .8
+"""
+import arviz as az
+import numpy as np
+
+az.style.use("arviz-darkgrid")
+
+dist = np.random.beta(np.random.uniform(0.5, 10), 5, size=1000)
+az.plot_kde(dist, quantiles=[0.25, 0.5, 0.75])


### PR DESCRIPTION
This add the option to get a KDE segmented into quartiles (or more general quantiles). There are still a few things to fix and improve

![gauss_q](https://user-images.githubusercontent.com/1338958/50564898-db7f5c80-0d07-11e9-9b90-dd44e5a49bf1.png)

![expo_q](https://user-images.githubusercontent.com/1338958/50564899-dfab7a00-0d07-11e9-9fda-42d59469b092.png)


