### PR TITLE
Fix example gallery in paper

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -80,20 +80,26 @@ Pareto-smoothed importance sampling leave-one-out cross validation (PSIS-LOO-CV)
 [@VehtariPracticalBayesianModel2015], and widely applicable information criterion (WAIC)
 [@watanabe_widely_2013].  
 
-# Example plots  
-Some sample plots are shown in Figure 2 through Figure 5.  
-![Bivariate hexbin plot with marginal distributions](plot_joint.png)  
-
-![2D Kernel Density estimation](plot_kde_2d.png)  
-
-![Markov Chain Monte Carlo Trace Plot](plot_trace.png)  
-
-![John Kruschke styled posterior distribution plots](plot_posterior.png)  
-
-
 # Funding
 
 Work by Osvaldo Martin was supported by CONICET-Argentina and ANPCyT-Argentina (PICT-0218).
+
+
+# Example plots  
+
+A portion of ArviZ's functionality is shown in Figure 2 through Figure 5.  
+
+![Bivariate hexbin plot with marginal distributions](plot_joint.png)  
+
+
+![2D Kernel Density estimation](plot_kde_2d.png)  
+
+ 
+![Markov Chain Monte Carlo Trace Plot](plot_trace.png)  
+
+
+![John Kruschke styled posterior distribution plots](plot_posterior.png)  
+
 
 # Acknowledgments
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -80,15 +80,12 @@ Pareto-smoothed importance sampling leave-one-out cross validation (PSIS-LOO-CV)
 [@VehtariPracticalBayesianModel2015], and widely applicable information criterion (WAIC)
 [@watanabe_widely_2013].  
 
-# Funding
-
-Work by Osvaldo Martin was supported by CONICET-Argentina and ANPCyT-Argentina (PICT-0218).
-
-
 # Example plots  
-
 A portion of ArviZ's functionality is shown in Figure 2 through Figure 5.  
+ArviZ supports more plotting and inference diagnostics, in addition to the ones shown here.
+Additional examples can be found ArviZ documentation gallery
 
+## Plots
 ![Bivariate hexbin plot with marginal distributions](plot_joint.png)  
 
 
@@ -100,6 +97,11 @@ A portion of ArviZ's functionality is shown in Figure 2 through Figure 5.
 
 ![John Kruschke styled posterior distribution plots](plot_posterior.png)  
 
+## 
+
+# Funding
+
+Work by Osvaldo Martin was supported by CONICET-Argentina and ANPCyT-Argentina (PICT-0218).
 
 # Acknowledgments
 


### PR DESCRIPTION
Moved funding bullet up which for some reason fixes plots. Let me know if this is acceptable.

Rendered PDF is attached
[paper.pdf](https://github.com/arviz-devs/arviz/files/2722088/paper.pdf)


Rendered using pandoc 1.19.2.4

```
pandoc --filter pandoc-citeproc --bibliography=paper.bib  --variable papersize=a4paper -s paper.md -o paper.pdf
```

[paper.pdf](https://github.com/arviz-devs/arviz/files/2722091/paper.pdf)

Commit https://github.com/arviz-devs/arviz/pull/484/commits/5e1322c0d9268032fb3b636897277701258f1722