### PR TITLE
Normalize from_xyz functions

### DIFF
--- a/arviz/data/__init__.py
+++ b/arviz/data/__init__.py
@@ -1,6 +1,6 @@
 """Code for loading and manipulating data structures."""
 from .inference_data import InferenceData
-from .io_netcdf import load_data, save_data
+from .io_netcdf import load_data, save_data, from_netcdf, to_netcdf
 from .datasets import load_arviz_data, list_datasets, clear_data_home
 from .base import numpy_to_data_array, dict_to_dataset
 from .converters import convert_to_dataset, convert_to_inference_data

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -6,7 +6,7 @@ import xarray as xr
 class InferenceData:
     """Container for accessing netCDF files using xarray."""
 
-    def __init__(self, *_, **kwargs):
+    def __init__(self, *, **kwargs):
         """Initialize InferenceData object from keyword xarray datasets.
 
         Examples

--- a/arviz/data/io_cmdstan.py
+++ b/arviz/data/io_cmdstan.py
@@ -665,8 +665,8 @@ def _unpack_dataframes(dfs):
 
 
 def from_cmdstan(
-    *,
     posterior=None,
+    *,
     posterior_predictive=None,
     prior=None,
     prior_predictive=None,

--- a/arviz/data/io_emcee.py
+++ b/arviz/data/io_emcee.py
@@ -94,7 +94,7 @@ class EmceeConverter:
         )
 
 
-def from_emcee(sampler, *, var_names=None, arg_names=None, coords=None, dims=None):
+def from_emcee(sampler=None, *, var_names=None, arg_names=None, coords=None, dims=None):
     """Convert emcee data into an InferenceData object.
 
     Parameters
@@ -111,5 +111,5 @@ def from_emcee(sampler, *, var_names=None, arg_names=None, coords=None, dims=Non
         Map variable names to their coordinates
     """
     return EmceeConverter(
-        sampler, var_names=var_names, arg_names=arg_names, coords=coords, dims=dims
+        sampler=sampler, var_names=var_names, arg_names=arg_names, coords=coords, dims=dims
     ).to_inference_data()

--- a/arviz/data/io_emcee.py
+++ b/arviz/data/io_emcee.py
@@ -54,7 +54,7 @@ def _verify_names(sampler, var_names, arg_names):
 class EmceeConverter:
     """Encapsulate emcee specific logic."""
 
-    def __init__(self, sampler, *_, var_names=None, arg_names=None, coords=None, dims=None):
+    def __init__(self, *, sampler, var_names=None, arg_names=None, coords=None, dims=None):
         var_names, arg_names = _verify_names(sampler, var_names, arg_names)
         self.sampler = sampler
         self.var_names = var_names

--- a/arviz/data/io_netcdf.py
+++ b/arviz/data/io_netcdf.py
@@ -39,3 +39,7 @@ def save_data(data, filename, *, group="posterior", coords=None, dims=None):
     """
     inference_data = convert_to_inference_data(data, group=group, coords=coords, dims=dims)
     return inference_data.to_netcdf(filename)
+
+
+from_netcdf = load_data
+to_netcdf = save_data

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -10,7 +10,7 @@ class PyMC3Converter:
     """Encapsulate PyMC3 specific logic."""
 
     def __init__(
-        self, *_, trace=None, prior=None, posterior_predictive=None, coords=None, dims=None
+        self, *, trace=None, prior=None, posterior_predictive=None, coords=None, dims=None
     ):
         self.trace = trace
         self.prior = prior
@@ -142,7 +142,7 @@ class PyMC3Converter:
         )
 
 
-def from_pymc3(*, trace=None, prior=None, posterior_predictive=None, coords=None, dims=None):
+def from_pymc3(trace=None, *, prior=None, posterior_predictive=None, coords=None, dims=None):
     """Convert pymc3 data into an InferenceData object."""
     return PyMC3Converter(
         trace=trace,

--- a/arviz/data/io_pyro.py
+++ b/arviz/data/io_pyro.py
@@ -28,7 +28,7 @@ def _get_var_names(posterior):
 class PyroConverter:
     """Encapsulate Pyro specific logic."""
 
-    def __init__(self, posterior, *_, coords=None, dims=None):
+    def __init__(self, *, posterior, coords=None, dims=None):
         """Convert pyro data into an InferenceData object.
 
         Parameters

--- a/arviz/data/io_pyro.py
+++ b/arviz/data/io_pyro.py
@@ -103,7 +103,7 @@ class PyroConverter:
         )
 
 
-def from_pyro(posterior, *, coords=None, dims=None):
+def from_pyro(posterior=None, *, coords=None, dims=None):
     """Convert pyro data into an InferenceData object.
 
     Parameters

--- a/arviz/data/io_pystan.py
+++ b/arviz/data/io_pystan.py
@@ -15,7 +15,7 @@ class PyStanConverter:
 
     def __init__(
         self,
-        *_,
+        *,
         posterior=None,
         posterior_predictive=None,
         prior=None,
@@ -170,7 +170,7 @@ class PyStan3Converter:
     # pylint: disable=too-many-instance-attributes
     def __init__(
         self,
-        *_,
+        *,
         posterior=None,
         posterior_model=None,
         posterior_predictive=None,
@@ -523,8 +523,8 @@ def infer_dtypes(fit, model=None):
 
 # pylint disable=too-many-instance-attributes
 def from_pystan(
-    *,
     posterior=None,
+    *,
     posterior_predictive=None,
     prior=None,
     prior_predictive=None,
@@ -539,11 +539,11 @@ def from_pystan(
 
     Parameters
     ----------
-    posterior : StanFit4Model
+    posterior : StanFit4Model or stan.fit.Fit
         PyStan fit object for posterior.
     posterior_predictive : str, a list of str
         Posterior predictive samples for the posterior.
-    prior : StanFit4Model
+    prior : StanFit4Model or stan.fit.Fit
         PyStan fit object for prior.
     prior_predictive : str, a list of str
         Posterior predictive samples for the prior.

--- a/arviz/data/io_tfp.py
+++ b/arviz/data/io_tfp.py
@@ -13,8 +13,8 @@ class TfpConverter:
 
     def __init__(
         self,
-        posterior,
         *,
+        posterior,
         var_names=None,
         model_fn=None,
         feed_dict=None,

--- a/arviz/data/io_tfp.py
+++ b/arviz/data/io_tfp.py
@@ -163,7 +163,7 @@ class TfpConverter:
 
 
 def from_tfp(
-    posterior,
+    posterior=None,
     *,
     var_names=None,
     model_fn=None,


### PR DESCRIPTION
Use `kw1=None, *, kw2=None, ...` in all of the `from_xyz` functions.

Each library can still use their nomenclature if needed.

created aliases for `load_data` (`from_netcdf`) and `save_data` (`to_netcdf`)