### PR TITLE
Add InferenceData tutorial in header

### DIFF
--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -29,3 +29,7 @@ h4, .h4 {
 h5, .h5 {
   font-size: 10px
 }
+
+.nbtable p {
+	margin: 0 0 0 0;
+}

--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -30,6 +30,6 @@ h5, .h5 {
   font-size: 10px
 }
 
-.nbtable p {
+ul li p {
 	margin: 0 0 0 0;
 }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -130,6 +130,7 @@ html_theme_options = {
         ("Gallery", "examples/index"),
         ("Quickstart", "notebooks/Introduction"),
         ("Cookbook", "notebooks/InferenceDataCookbook"),
+        ("InferenceData", "notebooks/XarrayforArviZ"),
         ("API", "api"),
         ("Usage", "usage"),
         ("About", "about"),

--- a/doc/notebooks/XarrayforArviZ.ipynb
+++ b/doc/notebooks/XarrayforArviZ.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Introduction to xarray for ArviZ"
+    "# Introduction to xarray, InferenceData, and netCDF for ArviZ"
    ]
   },
   {
@@ -13,21 +13,33 @@
    "source": [
     "While ArviZ supports plotting from familiar datatypes, such as dictionaries and numpy arrays, there are a couple data structures central to ArviZ that are useful to know when using the library. \n",
     "\n",
-    "They are\n",
-    "* xarray.Dataset\n",
-    "* arviz.InferenceData\n",
-    "* NetCDF\n",
+    "They are  \n",
+    "\n",
+    "<ul class=nbtable>\n",
+    "  <!-- HTML Table to allow proper rendering in sphinx -->\n",
+    "  <li>xarray.Dataset</li>\n",
+    "  <li>arviz.InferenceData</li>\n",
+    "  <li>netCDF</li>\n",
+    "</ul> \n",
     "\n",
     "\n",
     "## Why more than one data structure?\n",
     "Bayesian Inference generates numerous datasets that represent different aspects of the model. For example in a single analysis a Bayesian practioner could end up with any of the following data.\n",
-    "* Prior Distribution for N number of variables\n",
-    "* Posterior Distribution for N number of variables\n",
-    "* Prior Predictive Distribution\n",
-    "* Posterior Predictive Distribution\n",
-    "* Trace data for each of the above\n",
-    "* Sample statistics for each inference run\n",
-    "* Whatever else\n",
+    "\n",
+    "\n",
+    "\n",
+    "<ul class=nbtable>\n",
+    "  <!-- HTML Table to allow proper rendering in sphinx -->\n",
+    "  <li>Prior Distribution for N number of variables</li>\n",
+    "  <li>Posterior Distribution for N number of variables</li>\n",
+    "  <li>Prior Predictive Distribution</li>\n",
+    "  <li>Posterior Predictive Distribution</li>\n",
+    "  <li>Trace data for each of the above</li>\n",
+    "  <li>Sample statistics for each inference run</li>\n",
+    "  <li>Any other array like data source</li>\n",
+    "\n",
+    "</ul> \n",
+    "\n",
     "\n",
     "## Why not Pandas Dataframes or Numpy Arrays?\n",
     "Data from probabilistic programming is naturally high dimensional. To add to the complexity ArviZ must handle the data generated from multiple Bayesian Modeling libraries, such as pymc3 and pystan. This is an application that the *xarray* package handles quite well. The xarray package lets users manage high dimensional data with human readable dimensions and coordinates quite easily.\n",
@@ -230,9 +242,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "arviz3.6",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "arviz3_6"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -244,7 +256,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/doc/notebooks/XarrayforArviZ.ipynb
+++ b/doc/notebooks/XarrayforArviZ.ipynb
@@ -15,7 +15,7 @@
     "\n",
     "They are  \n",
     "\n",
-    "<ul class=nbtable>\n",
+    "<ul>\n",
     "  <!-- HTML Table to allow proper rendering in sphinx -->\n",
     "  <li>xarray.Dataset</li>\n",
     "  <li>arviz.InferenceData</li>\n",
@@ -28,7 +28,7 @@
     "\n",
     "\n",
     "\n",
-    "<ul class=nbtable>\n",
+    "<ul>\n",
     "  <!-- HTML Table to allow proper rendering in sphinx -->\n",
     "  <li>Prior Distribution for N number of variables</li>\n",
     "  <li>Posterior Distribution for N number of variables</li>\n",
@@ -256,7 +256,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Will add InferenceData tutorial in header to meet paper review feedback.

In making this documentation I tried first creating a Tutorial page like Seaborn
https://seaborn.pydata.org/tutorial.html

However it seems getting to this will require more work. Seaborn doesn't use the nbconvert plugin, instead providing its own Makefiles and scripts that convert the notebooks to .rst and .html at the appropriate times
https://github.com/mwaskom/seaborn/blob/master/doc/Makefile
https://github.com/mwaskom/seaborn/tree/master/doc/tools
https://github.com/mwaskom/seaborn/blob/master/doc/tutorial/Makefile

I think it would be great to implement this eventually, but for now just want to get the existing tutorial visible for the paper review