### PR TITLE
Rename N_effective to S_effective

### DIFF
--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 
 from ..data import convert_to_dataset
 from ..stats import hpd
-from ..stats.diagnostics import _get_neff, _get_split_rhat
+from ..stats.diagnostics import _get_seff, _get_split_rhat
 from .plot_utils import _scale_fig_size, xarray_var_iter, make_label
 from .kdeplot import _fast_kde
 from ..utils import _var_names
@@ -495,7 +495,7 @@ class VarHandler:
             if value.ndim != 2 or value.shape[0] < 2:
                 yield y, None, color
             else:
-                yield y, _get_neff(value), color
+                yield y, _get_seff(value), color
 
     def r_hat(self):
         """Get rhat data for the variable."""

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 
 from ..data import convert_to_dataset
 from ..stats import hpd
-from ..stats.diagnostics import _get_seff, _get_split_rhat
+from ..stats.diagnostics import _get_ess, _get_split_rhat
 from .plot_utils import _scale_fig_size, xarray_var_iter, make_label
 from .kdeplot import _fast_kde
 from ..utils import _var_names
@@ -495,7 +495,7 @@ class VarHandler:
             if value.ndim != 2 or value.shape[0] < 2:
                 yield y, None, color
             else:
-                yield y, _get_seff(value), color
+                yield y, _get_ess(value), color
 
     def r_hat(self):
         """Get rhat data for the variable."""

--- a/arviz/stats/__init__.py
+++ b/arviz/stats/__init__.py
@@ -13,7 +13,7 @@ __all__ = [
     "r2_score",
     "summary",
     "waic",
-    "effective_s",
+    "effective_sample_size",
     "rhat",
     "geweke",
     "autocorr",

--- a/arviz/stats/__init__.py
+++ b/arviz/stats/__init__.py
@@ -13,7 +13,7 @@ __all__ = [
     "r2_score",
     "summary",
     "waic",
-    "effective_n",
+    "effective_s",
     "rhat",
     "geweke",
     "autocorr",

--- a/arviz/stats/diagnostics.py
+++ b/arviz/stats/diagnostics.py
@@ -47,8 +47,7 @@ def effective_sample_size(data, *, var_names=None):
 
     References
     ----------
-    Section 15.4.2
-    https://mc-stan.org/docs/2_18/reference-manual/effective-sample-size-section.html
+    https://mc-stan.org/docs/2_18/reference-manual/effective-sample-size-section.html Section 15.4.2
 
     Gelman et al. BDA (2014) Formula 11.8
     """

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -9,7 +9,7 @@ from scipy.optimize import minimize
 import xarray as xr
 
 from ..data import convert_to_inference_data, convert_to_dataset
-from .diagnostics import effective_n, rhat
+from .diagnostics import effective_s, rhat
 from ..utils import _var_names
 
 __all__ = ["bfmi", "compare", "hpd", "loo", "psislw", "r2_score", "summary", "waic"]
@@ -326,7 +326,7 @@ def loo(data, pointwise=False, reff=None):
         if n_chains == 1:
             reff = 1.0
         else:
-            eff_n = effective_n(posterior)
+            eff_n = effective_s(posterior)
             # this mean is over all data variables
             reff = (
                 np.hstack([eff_n[v].values.flatten() for v in eff_n.data_vars]).mean() / n_samples
@@ -714,7 +714,7 @@ def summary(
         metric_names.append("circular hpd {:.2%}".format(1 - alpha / 2))
 
     if len(posterior.chain) > 1:
-        metrics.append(effective_n(posterior, var_names=var_names))
+        metrics.append(effective_s(posterior, var_names=var_names))
         metric_names.append("eff_n")
 
         metrics.append(rhat(posterior, var_names=var_names))

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -9,7 +9,7 @@ from scipy.optimize import minimize
 import xarray as xr
 
 from ..data import convert_to_inference_data, convert_to_dataset
-from .diagnostics import effective_s, rhat
+from .diagnostics import effective_sample_size, rhat
 from ..utils import _var_names
 
 __all__ = ["bfmi", "compare", "hpd", "loo", "psislw", "r2_score", "summary", "waic"]
@@ -326,7 +326,7 @@ def loo(data, pointwise=False, reff=None):
         if n_chains == 1:
             reff = 1.0
         else:
-            eff_n = effective_s(posterior)
+            eff_n = effective_sample_size(posterior)
             # this mean is over all data variables
             reff = (
                 np.hstack([eff_n[v].values.flatten() for v in eff_n.data_vars]).mean() / n_samples
@@ -714,7 +714,7 @@ def summary(
         metric_names.append("circular hpd {:.2%}".format(1 - alpha / 2))
 
     if len(posterior.chain) > 1:
-        metrics.append(effective_s(posterior, var_names=var_names))
+        metrics.append(effective_sample_size(posterior, var_names=var_names))
         metric_names.append("eff_n")
 
         metrics.append(rhat(posterior, var_names=var_names))

--- a/arviz/tests/test_diagnostics.py
+++ b/arviz/tests/test_diagnostics.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from ..data import load_arviz_data
-from ..stats import rhat, effective_n, geweke
+from ..stats import rhat, effective_s, geweke
 
 GOOD_RHAT = 1.1
 
@@ -34,13 +34,13 @@ class TestDiagnostics:
         assert 1 / GOOD_RHAT > r_hat or GOOD_RHAT < r_hat
 
     def test_effective_n_array(self):
-        eff_n = effective_n(np.random.randn(4, 100))
+        eff_n = effective_s(np.random.randn(4, 100))
         assert eff_n > 100
         assert eff_n < 800
 
     @pytest.mark.parametrize("var_names", (None, "mu", ["mu", "tau"]))
     def test_effective_n_dataset(self, data, var_names):
-        eff_n = effective_n(data, var_names=var_names)
+        eff_n = effective_s(data, var_names=var_names)
         assert eff_n.mu > 100  # This might break if the data is regenerated
 
     def test_geweke(self):

--- a/arviz/tests/test_diagnostics.py
+++ b/arviz/tests/test_diagnostics.py
@@ -33,15 +33,15 @@ class TestDiagnostics:
         r_hat = rhat(np.vstack([20 + np.random.randn(1, 100), np.random.randn(1, 100)]))
         assert 1 / GOOD_RHAT > r_hat or GOOD_RHAT < r_hat
 
-    def test_effective_n_array(self):
-        eff_n = effective_s(np.random.randn(4, 100))
-        assert eff_n > 100
-        assert eff_n < 800
+    def test_effective_s_array(self):
+        eff_s = effective_s(np.random.randn(4, 100))
+        assert eff_s > 100
+        assert eff_s < 800
 
     @pytest.mark.parametrize("var_names", (None, "mu", ["mu", "tau"]))
-    def test_effective_n_dataset(self, data, var_names):
-        eff_n = effective_s(data, var_names=var_names)
-        assert eff_n.mu > 100  # This might break if the data is regenerated
+    def test_effective_s_dataset(self, data, var_names):
+        eff_s = effective_s(data, var_names=var_names)
+        assert eff_s.mu > 100  # This might break if the data is regenerated
 
     def test_geweke(self):
         first = 0.1

--- a/arviz/tests/test_diagnostics.py
+++ b/arviz/tests/test_diagnostics.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from ..data import load_arviz_data
-from ..stats import rhat, effective_s, geweke
+from ..stats import rhat, effective_sample_size, geweke
 
 GOOD_RHAT = 1.1
 
@@ -33,15 +33,15 @@ class TestDiagnostics:
         r_hat = rhat(np.vstack([20 + np.random.randn(1, 100), np.random.randn(1, 100)]))
         assert 1 / GOOD_RHAT > r_hat or GOOD_RHAT < r_hat
 
-    def test_effective_s_array(self):
-        eff_s = effective_s(np.random.randn(4, 100))
-        assert eff_s > 100
-        assert eff_s < 800
+    def test_effective_sample_size_array(self):
+        eff_n_hat = effective_sample_size(np.random.randn(4, 100))
+        assert eff_n_hat > 100
+        assert eff_n_hat < 800
 
     @pytest.mark.parametrize("var_names", (None, "mu", ["mu", "tau"]))
-    def test_effective_s_dataset(self, data, var_names):
-        eff_s = effective_s(data, var_names=var_names)
-        assert eff_s.mu > 100  # This might break if the data is regenerated
+    def test_effective_sample_size_dataset(self, data, var_names):
+        eff_n_hat = effective_sample_size(data, var_names=var_names)
+        assert eff_n_hat.mu > 100  # This might break if the data is regenerated
 
     def test_geweke(self):
         first = 0.1


### PR DESCRIPTION
Trying to make it more clear to users and newcomers to Bayesian methodology what calculation is being done and where to look for further reference
 
Review requested more for the idea of the change, and less so the code.

I can add deprecation or rename warning to `n_effective` to make this a non breaking change