### PR TITLE
Pin pytest version to avoid coverage exceptions

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ pylint
 pyro-ppl
 tensorflow
 tensorflow-probability
-pytest
+pytest=4.0.2
 pytest-cov
 Sphinx
 sphinx-bootstrap-theme

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,10 +9,10 @@ pylint
 pyro-ppl
 tensorflow
 tensorflow-probability
-pytest=4.0.2
+pytest == 4.0.2
 pytest-cov
 Sphinx
 sphinx-bootstrap-theme
 sphinx-gallery
-travis-sphinx==2.0.0
+travis-sphinx == 2.0.0
 black; python_version == '3.6'


### PR DESCRIPTION
Pytest updated to version 4.1.0 which is causing failures with coverage

Pinning version for now and can open issue ticket so we remember to check on this every now and then

Additional details for future reference
https://docs.pytest.org/en/latest/changelog.html