### PR TITLE
add conditional_jit decorator and speed up _fast_kde 2x

### DIFF
--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -256,7 +256,7 @@ def _fast_kde(x, cumulative=False, bw=4.5):
     std_x = entropy(x - xmin) * bw
 
     n_bins = min(int(len_x ** (1 / 3) * std_x * 2), 200)
-    grid = histogram(x, n_bins)
+    grid = _histogram(x, n_bins)
 
     scotts_factor = len_x ** (-0.2)
     kern_nx = int(scotts_factor * 2 * np.pi * std_x)
@@ -275,7 +275,7 @@ def _fast_kde(x, cumulative=False, bw=4.5):
 
 
 @conditional_jit
-def histogram(x, n_bins):
+def _histogram(x, n_bins):
     grid, _ = np.histogram(x, bins=n_bins)
     return grid
 

--- a/arviz/tests/test_utils.py
+++ b/arviz/tests/test_utils.py
@@ -32,7 +32,7 @@ def test_utils_fixture(utils_with_numba_import_fail):
     """Meta test of utils fixture to ensure things are mocked out correctly"""
 
     # If Numba doesn't exist in dev environment this should fail immediately
-    import numba  # pylint: disable=W0612
+    import numba  # pylint: disable=W0611,W0612
 
     with pytest.raises(ImportError):
         utils_with_numba_import_fail.importlib.import_module("numba")

--- a/arviz/tests/test_utils.py
+++ b/arviz/tests/test_utils.py
@@ -29,10 +29,10 @@ def utils_with_numba_import_fail(monkeypatch):
 
 
 def test_utils_fixture(utils_with_numba_import_fail):
-    """Meta test of utils fixture to ensure things are mocked out correctly"""
+    """Test of utils fixture to ensure mock is applied correctly"""
 
-    # If Numba doesn't exist in dev environment this should fail immediately
-    import numba  # pylint: disable=W0611,W0612
+    # If Numba doesn't exist in dev environment this will raise an ImportError
+    import numba  # pylint: disable=unused-import,W0612
 
     with pytest.raises(ImportError):
         utils_with_numba_import_fail.importlib.import_module("numba")

--- a/arviz/tests/test_utils.py
+++ b/arviz/tests/test_utils.py
@@ -2,7 +2,9 @@
 Tests for arviz.utils
 """
 import pytest
+from unittest.mock import Mock
 from arviz.utils import _var_names
+from arviz import utils
 
 
 @pytest.mark.parametrize(
@@ -12,3 +14,49 @@ def test_var_names(var_names_expected):
     """Test var_name handling"""
     var_names, expected = var_names_expected
     assert _var_names(var_names) == expected
+
+
+@pytest.fixture(scope="function")
+def utils_with_numba_import_fail(monkeypatch):
+    """Patch numba in utils so when its imported it raises ImportError"""
+    failed_import = Mock()
+    failed_import.side_effect = ImportError
+
+    from arviz import utils
+    monkeypatch.setattr(utils.importlib, 'import_module', failed_import)
+    return utils
+
+
+def test_utils_fixture(utils_with_numba_import_fail):
+    """Meta test of utils fixture to ensure things are mocked out correctly"""
+    with pytest.raises(ImportError):
+        utils.importlib.import_module("numba")
+
+
+def test_conditional_jit_decorator_no_numba(utils_with_numba_import_fail):
+    """Tests to see if Numba jit code block is skipped with Import Failure
+
+    Test can be distinguished from test_conditional_jit__numba_decorator
+    by use of debugger or coverage tool
+    """
+    utils = utils_with_numba_import_fail
+
+    @utils.conditional_jit
+    def func():
+        return "Numba not used"
+
+    assert "Numba not used" == func()
+
+
+def test_conditional_jit__numba_decorator():
+    """Tests to see if Numba is used when import failure.
+
+    Test can be distinguished from test_conditional_jit_decorator_no_numba
+    by use of debugger or coverage tool
+    """
+    @utils.conditional_jit
+    def func():
+        return "Numba used"
+
+    assert "Numba used" == func()
+

--- a/arviz/tests/test_utils.py
+++ b/arviz/tests/test_utils.py
@@ -82,6 +82,8 @@ def test_conditional_jit_numba_decorator_keyword(monkeypatch):
 
     @utils.conditional_jit(keyword_argument="A keyword argument")
     def placeholder_func():
+        """This function does nothing"""
         return
 
+    # pylint: disable=comparison-with-callable
     assert placeholder_func == {"keyword_argument": "A keyword argument"}

--- a/arviz/tests/test_utils.py
+++ b/arviz/tests/test_utils.py
@@ -65,3 +65,23 @@ def test_conditional_jit_numba_decorator():
         return "Numba used"
 
     assert func() == "Numba used"
+
+
+def test_conditional_jit_numba_decorator_keyword(monkeypatch):
+    """Checks else statement and JIT keyword argument """
+    from arviz import utils
+
+    # Mock import lib to return numba with hit method which returns a function that returns kwargs
+    numba_mock = Mock()
+    monkeypatch.setattr(utils.importlib, "import_module", lambda x: numba_mock)
+
+    def jit(**kwargs):
+        return lambda x: kwargs
+
+    numba_mock.jit = jit
+
+    @utils.conditional_jit(keyword_argument="A keyword argument")
+    def placeholder_func():
+        return
+
+    assert placeholder_func == {"keyword_argument": "A keyword argument"}

--- a/arviz/tests/test_utils.py
+++ b/arviz/tests/test_utils.py
@@ -68,7 +68,7 @@ def test_conditional_jit_numba_decorator():
 
 
 def test_conditional_jit_numba_decorator_keyword(monkeypatch):
-    """Checks else statement and JIT keyword argument """
+    """Checks else statement and JIT keyword argument"""
     from arviz import utils
 
     # Mock import lib to return numba with hit method which returns a function that returns kwargs

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -24,7 +24,23 @@ def _var_names(var_names):
 
 
 def conditional_jit(function=None, **kwargs):  # noqa: D202
-    """Use numba's jit decorator if numba is installed."""
+    """Use numba's jit decorator if numba is installed.
+
+    Notes
+    -----
+        If called without arguments  then return wrapped function.
+
+        @conditional_jit
+        def my_func():
+            return
+
+        else called with arguments
+
+        @@conditional_jit(nopython=True)
+        def my_func():
+            return
+
+    """
 
     def wrapper(function):
         try:
@@ -34,6 +50,7 @@ def conditional_jit(function=None, **kwargs):  # noqa: D202
         except ImportError:
             return function
 
+    #
     if function:
         return wrapper(function)
     else:

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -23,8 +23,9 @@ def _var_names(var_names):
         return var_names
 
 
-def conditional_jit(function=None, **kwargs):
+def conditional_jit(function=None, **kwargs):  # noqa: D202
     """Use numba's jit decorator if numba is installed."""
+
     def wrapper(function):
         try:
             numba = importlib.import_module("numba")

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -22,11 +22,18 @@ def _var_names(var_names):
         return var_names
 
 
-def conditional_jit(function):
-    "use numba's jit decorator if numba is installed"
-    try:
-        from numba import jit
+def conditional_jit(function=None, **kwargs):
+    """Use numba's jit decorator if numba is installed."""
 
-        return jit(function)
-    except ImportError:
-        return function
+    def wrapper(function):
+        try:
+            from numba import jit
+
+            return jit(**kwargs)(function)
+        except ImportError:
+            return function
+
+    if function:
+        return wrapper(function)
+    else:
+        return wrapper

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -36,7 +36,7 @@ def conditional_jit(function=None, **kwargs):  # noqa: D202
 
         else called with arguments
 
-        @@conditional_jit(nopython=True)
+        @conditional_jit(nopython=True)
         def my_func():
             return
 

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -1,4 +1,5 @@
 """General utilities."""
+import importlib
 
 
 def _var_names(var_names):
@@ -24,12 +25,11 @@ def _var_names(var_names):
 
 def conditional_jit(function=None, **kwargs):
     """Use numba's jit decorator if numba is installed."""
-
     def wrapper(function):
         try:
-            from numba import jit
+            numba = importlib.import_module("numba")
+            return numba.jit(**kwargs)(function)
 
-            return jit(**kwargs)(function)
         except ImportError:
             return function
 

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -50,7 +50,6 @@ def conditional_jit(function=None, **kwargs):  # noqa: D202
         except ImportError:
             return function
 
-    #
     if function:
         return wrapper(function)
     else:

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -20,3 +20,13 @@ def _var_names(var_names):
 
     else:
         return var_names
+
+
+def conditional_jit(function):
+    "use numba's jit decorator if numba is installed"
+    try:
+        from numba import jit
+
+        return jit(function)
+    except ImportError:
+        return function

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -24,7 +24,6 @@ def _var_names(var_names):
 
 def conditional_jit(function=None, **kwargs):
     """Use numba's jit decorator if numba is installed."""
-
     def wrapper(function):
         try:
             from numba import jit

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -24,6 +24,7 @@ def _var_names(var_names):
 
 def conditional_jit(function=None, **kwargs):
     """Use numba's jit decorator if numba is installed."""
+
     def wrapper(function):
         try:
             from numba import jit

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,3 +16,4 @@ sphinx-bootstrap-theme
 sphinx-gallery
 travis-sphinx == 2.0.0
 black; python_version == '3.6'
+numba


### PR DESCRIPTION
adds the conditional_jit decorator that works only if numba is installed. I applied the decorator to speed-up _fast_kde. I guess other functions (stats, diagnostics) could benefit more from using numba.