### PR TITLE
Force numpy 1.15 until pymc3 is fixed.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib>=3.0
-numpy
+numpy==1.15
 scipy
 pandas
 xarray


### PR DESCRIPTION
Numpy 1.16 breaks Theano / PyMC3