### PR TITLE
Fix pymc3 typo

### DIFF
--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -59,7 +59,7 @@ class PyMC3Converter:
     @requires("trace")
     def posterior_to_xarray(self):
         """Convert the posterior to an xarray dataset."""
-        var_names = self.pymc3.utils.get_default_varnames(  # pylint: disable=no-member
+        var_names = self.pymc3.util.get_default_varnames(  # pylint: disable=no-member
             self.trace.varnames, include_transformed=False
         )
         data = {}


### PR DESCRIPTION
I am not sure how this worked in the past, but it looks like we definitely want `pymc3.util` (https://github.com/pymc-devs/pymc3/blob/master/pymc3/util.py) instead of `pymc3.utils` (which resolves to `pymc3.glm.utils`, and does not have `get_default_varnames`).

