### PR TITLE
Remove trailing commata in `arviz/data/io_dict.py`

### DIFF
--- a/arviz/data/io_dict.py
+++ b/arviz/data/io_dict.py
@@ -24,7 +24,7 @@ class DictConverter:
         sample_stats_prior=None,
         observed_data=None,
         coords=None,
-        dims=None,
+        dims=None
     ):
         self.posterior = posterior
         self.posterior_predictive = posterior_predictive
@@ -146,7 +146,7 @@ def from_dict(
     sample_stats_prior=None,
     observed_data=None,
     coords=None,
-    dims=None,
+    dims=None
 ):
     """Convert Dictionary data into an InferenceData object.
 


### PR DESCRIPTION
See also #539 .
Trailing commata in combination with keyword-only function definitions are only supported in Python >= 3.6 and thus break support for Python3.5.
As pointed out in #539, this is a problem introduced in `black` and subject to an issue there as well.

This PR removes trailing commas in `arviz/data/io_dict.py` manually. After these changes, `python -c "import arviz"` works without error.