### PR TITLE
Fix docker python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,19 @@ matrix:
   include:
   - name: "Python 3.6 Unit Test"
     python: 3.6
-    env: PYSTAN_VERSION=latest PYRO_VERSION=latest NAME="UNIT"
+    env: PYTHON_VERSION=3.6 PYSTAN_VERSION=latest PYRO_VERSION=latest NAME="UNIT"
   - name: "Python 3.6 Unit Test - PyStan=preview Pyro=0.2.1"
     python: 3.6
-    env: PYSTAN_VERSION=preview PYRO_VERSION=0.2.1 NAME="UNIT"
+    env: PYTHON_VERSION=3.6 PYSTAN_VERSION=preview PYRO_VERSION=0.2.1 NAME="UNIT"
   - name: "Python 3.5 Unit Test"
     python: 3.5
-    env: PYSTAN_VERSION=latest PYRO_VERSION=latest NAME="UNIT"
+    env: PYTHON_VERSION=3.5 PYSTAN_VERSION=latest PYRO_VERSION=latest NAME="UNIT"
   - name: "Python 3.6 Lint"
     python: 3.6
-    env: PYSTAN_VERSION=latest PYRO_VERSION=latest NAME="LINT"
+    env: PYTHON_VERSION=3.6 PYSTAN_VERSION=latest PYRO_VERSION=latest NAME="LINT"
   - name: "Python 3.6 Sphinx"
     python: 3.6
-    env: PYSTAN_VERSION=latest PYRO_VERSION=latest NAME="SPHINX"
+    env: PYTHON_VERSION=3.6 PYSTAN_VERSION=latest PYRO_VERSION=latest NAME="SPHINX"
 
 addons:
   apt:

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -506,8 +506,9 @@ class TestEmceeNetCDFUtils:
             from_emcee(data.obj, arg_names=["not", "enough"])
 
     def test_ln_funcs_for_infinity(self):
-        assert np.isinf(emcee_lnprior([1000, 10000, 1_000_000]))
-        assert np.isinf(emcee_lnprob([1000, 10000, 1_000_000], 0, 0, 0))
+        # after dropping Python 3.5 support use underscore 1_000_000
+        assert np.isinf(emcee_lnprior([1000, 10000, 1000000]))
+        assert np.isinf(emcee_lnprob([1000, 10000, 1000000], 0, 0, 0))
 
 
 class TestIONetCDFUtils:


### PR DESCRIPTION
We didn't have python arg set-up. (`PYTHON_VERSION=3.6 `)

Which meant that this code was executed

```
# if no python specified, use Travis version, or else 3.6
PYTHON_VERSION=${PYTHON_VERSION:-${TRAVIS_PYTHON_VERSION:-3.6}}
```