### PR TITLE
az.concat and __add__ - Simple group level addition

### DIFF
--- a/arviz/data/__init__.py
+++ b/arviz/data/__init__.py
@@ -1,5 +1,5 @@
 """Code for loading and manipulating data structures."""
-from .inference_data import InferenceData
+from .inference_data import InferenceData, concat
 from .io_netcdf import from_netcdf, to_netcdf, load_data, save_data
 from .datasets import load_arviz_data, list_datasets, clear_data_home
 from .base import numpy_to_data_array, dict_to_dataset
@@ -14,6 +14,7 @@ from .io_tfp import from_tfp
 
 __all__ = [
     "InferenceData",
+    "concat",
     "load_arviz_data",
     "list_datasets",
     "clear_data_home",

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -119,14 +119,17 @@ def concat(*args, copy=True, inplace=False):
     """
     if len(args) == 0:
         return InferenceData()
-    if len(args) == 1 and isinstance(args, Sequence):
+    if len(args) == 1 and isinstance(args[0], Sequence):
         args = args[0]
     elif len(args) == 1:
         if isinstance(args[0], InferenceData):
             if inplace:
-                return args[0]
+                return None
             else:
-                return deepcopy(args[0])
+                if copy:
+                    return deepcopy(args[0])
+                else:
+                    return args[0]
 
     # assert that all args are InferenceData
     for i, arg in enumerate(args):

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -117,10 +117,10 @@ def concat(*args, copy=True, inplace=False):
         A new InferenceData object by default.
         When `inplace==True` merge args to first arg and return `None`
     """
-    if len(args) == 1 and isinstance(args, Sequence):
-        args = args[0]
     if len(args) == 0:
         return InferenceData()
+    if len(args) == 1 and isinstance(args, Sequence):
+        args = args[0]
     elif len(args) == 1:
         if isinstance(args[0], InferenceData):
             if inplace:

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -232,11 +232,12 @@ def test_concat_edgecases(copy, inplace, sequence):
         new_idata = concat(idata, copy=copy, inplace=inplace)
     if inplace:
         assert new_idata is None
+        mew_idata = idata
     else:
         assert new_idata is not None
-    assert hasattr(idata, "posterior")
-    assert hasattr(idata.posterior, "A")
-    assert hasattr(idata.posterior, "B")
+    assert hasattr(new_idata, "posterior")
+    assert hasattr(new_idata.posterior, "A")
+    assert hasattr(new_idata.posterior, "B")
     if copy:
         assert id(new_idata.posterior) != id(idata.posterior)
     else:

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -213,7 +213,7 @@ def test_concat(copy, inplace, sequence):
     assert hasattr(new_idata.observed_data, "F")
     if copy:
         if inplace:
-            assert id(new_idata.posterior) != original_idata1_posterior_id
+            assert id(new_idata.posterior) == original_idata1_posterior_id
         else:
             assert id(new_idata.posterior) != id(idata1.posterior)
         assert id(new_idata.prior) != id(idata2.prior)

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -240,7 +240,7 @@ def test_concat_copy_True():
     assert hasattr(new_idata.prior, "C")
     assert hasattr(new_idata.prior, "D")
     assert id(new_idata.posterior) != id(idata1.posterior)
-    assert id(new_idata.prior) != id(idata1.prior)
+    assert id(new_idata.prior) != id(idata2.prior)
 
 
 def test_concat_copy_False():
@@ -257,7 +257,7 @@ def test_concat_copy_False():
     assert hasattr(new_idata.prior, "C")
     assert hasattr(new_idata.prior, "D")
     assert id(new_idata.posterior) == id(idata1.posterior)
-    assert id(new_idata.prior) == id(idata1.prior)
+    assert id(new_idata.prior) == id(idata2.prior)
 
 
 def test_concat_sequency_inplace():

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -188,6 +188,8 @@ def test_concat(copy, inplace, sequence):
     idata1 = from_dict(
         posterior={"A": np.random.randn(2, 10, 2), "B": np.random.randn(2, 10, 5, 2)}
     )
+    if copy and inplace:
+        original_idata1_posterior_id = id(idata1.posterior)
     idata2 = from_dict(prior={"C": np.random.randn(2, 10, 2), "D": np.random.randn(2, 10, 5, 2)})
     idata3 = from_dict(observed_data={"E": np.random.randn(100), "F": np.random.randn(2, 100)})
     # basic case
@@ -210,7 +212,10 @@ def test_concat(copy, inplace, sequence):
     assert hasattr(new_idata.observed_data, "E")
     assert hasattr(new_idata.observed_data, "F")
     if copy:
-        assert id(new_idata.posterior) != id(idata1.posterior)
+        if inplace:
+            assert id(new_idata.posterior) != original_idata1_posterior_id
+        else:
+            assert id(new_idata.posterior) != id(idata1.posterior)
         assert id(new_idata.prior) != id(idata2.prior)
         assert id(new_idata.observed_data) != id(idata3.observed_data)
     else:
@@ -238,7 +243,7 @@ def test_concat_edgecases(copy, inplace, sequence):
     assert hasattr(new_idata, "posterior")
     assert hasattr(new_idata.posterior, "A")
     assert hasattr(new_idata.posterior, "B")
-    if copy:
+    if copy and not inplace:
         assert id(new_idata.posterior) != id(idata.posterior)
     else:
         assert id(new_idata.posterior) == id(idata.posterior)

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -275,6 +275,25 @@ def test_concat_sequency_inplace():
     assert hasattr(idata1.prior, "D")
 
 
+def test_concat_edgecases():
+    idata1 = from_dict(
+        posterior={"A": np.random.randn(2, 10, 2), "B": np.random.randn(2, 10, 5, 2)}
+    )
+    idata2 = from_dict(prior={"C": np.random.randn(2, 10, 2), "D": np.random.randn(2, 10, 5, 2)})
+    empty = concat()
+    assert empty is not None
+    new_idata = concat(idata1)
+    assert new_idata is not None
+    assert hasattr(idata1, "posterior")
+    assert hasattr(idata1.posterior, "A")
+    assert hasattr(idata1.posterior, "B")
+    new_idata2 = concat(idata2, inplace=True)
+    assert new_idata2 is None
+    assert hasattr(idata2, "prior")
+    assert hasattr(idata2.prior, "C")
+    assert hasattr(idata2.prior, "D")
+
+
 def test_concat_bad():
     with pytest.raises(TypeError):
         concat("hello", "hello")

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -237,7 +237,7 @@ def test_concat_edgecases(copy, inplace, sequence):
         new_idata = concat(idata, copy=copy, inplace=inplace)
     if inplace:
         assert new_idata is None
-        mew_idata = idata
+        new_idata = idata
     else:
         assert new_idata is not None
     assert hasattr(new_idata, "posterior")

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -181,123 +181,74 @@ def test_addition():
     assert hasattr(new_idata.prior, "D")
 
 
-def test_concat():
+@pytest.mark.parametrize("copy", [True, False])
+@pytest.mark.parametrize("inplace", [True, False])
+@pytest.mark.parametrize("sequence", [True, False])
+def test_concat(copy, inplace, sequence):
     idata1 = from_dict(
         posterior={"A": np.random.randn(2, 10, 2), "B": np.random.randn(2, 10, 5, 2)}
     )
     idata2 = from_dict(prior={"C": np.random.randn(2, 10, 2), "D": np.random.randn(2, 10, 5, 2)})
-    new_idata = concat(idata1, idata2)
+    idata3 = from_dict(observed_data={"E": np.random.randn(100), "F": np.random.randn(2, 100)})
+    # basic case
+    assert concat(idata1, idata2, copy=True, inplace=False) is not None
+    if sequence:
+        new_idata = concat((idata1, idata2, idata3), copy=copy, inplace=inplace)
+    else:
+        new_idata = concat(idata1, idata2, idata3, copy=copy, inplace=inplace)
+    if inplace:
+        assert new_idata is None
+        new_idata = idata1
     assert new_idata is not None
     assert hasattr(new_idata, "posterior")
     assert hasattr(new_idata, "prior")
+    assert hasattr(new_idata, "observed_data")
     assert hasattr(new_idata.posterior, "A")
     assert hasattr(new_idata.posterior, "B")
     assert hasattr(new_idata.prior, "C")
     assert hasattr(new_idata.prior, "D")
+    assert hasattr(new_idata.observed_data, "E")
+    assert hasattr(new_idata.observed_data, "F")
+    if copy:
+        assert id(new_idata.posterior) != id(idata1.posterior)
+        assert id(new_idata.prior) != id(idata2.prior)
+        assert id(new_idata.observed_data) != id(idata3.observed_data)
+    else:
+        assert id(new_idata.posterior) == id(idata1.posterior)
+        assert id(new_idata.prior) == id(idata2.prior)
+        assert id(new_idata.observed_data) == id(idata3.observed_data)
 
 
-def test_concat_inplace():
-    idata1 = from_dict(
-        posterior={"A": np.random.randn(2, 10, 2), "B": np.random.randn(2, 10, 5, 2)}
-    )
-    idata2 = from_dict(prior={"C": np.random.randn(2, 10, 2), "D": np.random.randn(2, 10, 5, 2)})
-    new_idata = concat(idata1, idata2, inplace=True)
-    assert new_idata is None
-    assert hasattr(idata1, "posterior")
-    assert hasattr(idata1, "prior")
-    assert hasattr(idata1.posterior, "A")
-    assert hasattr(idata1.posterior, "B")
-    assert hasattr(idata1.prior, "C")
-    assert hasattr(idata1.prior, "D")
-
-
-def test_concat_sequency():
-    idata1 = from_dict(
-        posterior={"A": np.random.randn(2, 10, 2), "B": np.random.randn(2, 10, 5, 2)}
-    )
-    idata2 = from_dict(prior={"C": np.random.randn(2, 10, 2), "D": np.random.randn(2, 10, 5, 2)})
-    new_idata = concat((idata1, idata2))
-    assert new_idata is not None
-    assert hasattr(new_idata, "posterior")
-    assert hasattr(new_idata, "prior")
-    assert hasattr(new_idata.posterior, "A")
-    assert hasattr(new_idata.posterior, "B")
-    assert hasattr(new_idata.prior, "C")
-    assert hasattr(new_idata.prior, "D")
-
-
-def test_concat_copy_True():
-    idata1 = from_dict(
-        posterior={"A": np.random.randn(2, 10, 2), "B": np.random.randn(2, 10, 5, 2)}
-    )
-    idata2 = from_dict(prior={"C": np.random.randn(2, 10, 2), "D": np.random.randn(2, 10, 5, 2)})
-    new_idata = concat(idata1, idata2, copy=True)
-    assert new_idata is not None
-    assert hasattr(new_idata, "posterior")
-    assert hasattr(new_idata, "prior")
-    assert hasattr(new_idata.posterior, "A")
-    assert hasattr(new_idata.posterior, "B")
-    assert hasattr(new_idata.prior, "C")
-    assert hasattr(new_idata.prior, "D")
-    assert id(new_idata.posterior) != id(idata1.posterior)
-    assert id(new_idata.prior) != id(idata2.prior)
-
-
-def test_concat_copy_False():
-    idata1 = from_dict(
-        posterior={"A": np.random.randn(2, 10, 2), "B": np.random.randn(2, 10, 5, 2)}
-    )
-    idata2 = from_dict(prior={"C": np.random.randn(2, 10, 2), "D": np.random.randn(2, 10, 5, 2)})
-    new_idata = concat(idata1, idata2, copy=False)
-    assert new_idata is not None
-    assert hasattr(new_idata, "posterior")
-    assert hasattr(new_idata, "prior")
-    assert hasattr(new_idata.posterior, "A")
-    assert hasattr(new_idata.posterior, "B")
-    assert hasattr(new_idata.prior, "C")
-    assert hasattr(new_idata.prior, "D")
-    assert id(new_idata.posterior) == id(idata1.posterior)
-    assert id(new_idata.prior) == id(idata2.prior)
-
-
-def test_concat_sequency_inplace():
-    idata1 = from_dict(
-        posterior={"A": np.random.randn(2, 10, 2), "B": np.random.randn(2, 10, 5, 2)}
-    )
-    idata2 = from_dict(prior={"C": np.random.randn(2, 10, 2), "D": np.random.randn(2, 10, 5, 2)})
-    new_idata = concat((idata1, idata2), inplace=True)
-    assert new_idata is None
-    assert hasattr(idata1, "posterior")
-    assert hasattr(idata1, "prior")
-    assert hasattr(idata1.posterior, "A")
-    assert hasattr(idata1.posterior, "B")
-    assert hasattr(idata1.prior, "C")
-    assert hasattr(idata1.prior, "D")
-
-
-def test_concat_edgecases():
-    idata1 = from_dict(
-        posterior={"A": np.random.randn(2, 10, 2), "B": np.random.randn(2, 10, 5, 2)}
-    )
-    idata2 = from_dict(prior={"C": np.random.randn(2, 10, 2), "D": np.random.randn(2, 10, 5, 2)})
+@pytest.mark.parametrize("copy", [True, False])
+@pytest.mark.parametrize("inplace", [True, False])
+@pytest.mark.parametrize("sequence", [True, False])
+def test_concat_edgecases(copy, inplace, sequence):
+    idata = from_dict(posterior={"A": np.random.randn(2, 10, 2), "B": np.random.randn(2, 10, 5, 2)})
     empty = concat()
     assert empty is not None
-    new_idata = concat(idata1)
-    assert new_idata is not None
-    assert hasattr(idata1, "posterior")
-    assert hasattr(idata1.posterior, "A")
-    assert hasattr(idata1.posterior, "B")
-    new_idata2 = concat(idata2, inplace=True)
-    assert new_idata2 is None
-    assert hasattr(idata2, "prior")
-    assert hasattr(idata2.prior, "C")
-    assert hasattr(idata2.prior, "D")
+    if sequence:
+        new_idata = concat([idata], copy=copy, inplace=inplace)
+    else:
+        new_idata = concat(idata, copy=copy, inplace=inplace)
+    if inplace:
+        assert new_idata is None
+    else:
+        assert new_idata is not None
+    assert hasattr(idata, "posterior")
+    assert hasattr(idata.posterior, "A")
+    assert hasattr(idata.posterior, "B")
+    if copy:
+        assert id(new_idata.posterior) != id(idata.posterior)
+    else:
+        assert id(new_idata.posterior) == id(idata.posterior)
 
 
 def test_concat_bad():
     with pytest.raises(TypeError):
         concat("hello", "hello")
     idata = from_dict(posterior={"A": np.random.randn(2, 10, 2), "B": np.random.randn(2, 10, 5, 2)})
+    with pytest.raises(TypeError):
+        concat(idata, np.array([1, 2, 3, 4, 5]))
     with pytest.raises(NotImplementedError):
         concat(idata, idata)
 


### PR DESCRIPTION
This PR implements a simple group-level addition for InferenceData objects. The addition is only supported with unique groups

### Data groups

    A._groups == ["posterior", "posterior_predictive"]
    B._groups == ["prior", "prior_predictive"]
    X._groups == ["prior"]

### New object

        C = A + B
        C = az.concat(A, B)
        C = az.concat((A, B))
    C._groups ==["posterior", "posterior_predictive", "prior", "prior_predictive"]

### Edit first object

    az.concat(A, B, inplace=True)
    A._groups ==["posterior", "posterior_predictive", "prior", "prior_predictive"]
        
### Exceptions

    A + "hello" --> TypeError
    B + X --> NotImplementedError

### New object vs reference

If `copy=True` function will `deepcopy` groups to a new location (this means that if `inplace=True` then first object's groups are not touched). Otherwise, a reference is passed to a new group.