### PR TITLE
Maintain order of variables in xarray_var_iter

### DIFF
--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -260,7 +260,7 @@ def xarray_var_iter(data, var_names=None, combined=False, skip_dims=None, revers
     for var_name in var_names:
         if var_name in data:
             new_dims = [dim for dim in data[var_name].dims if dim not in skip_dims]
-            vals = [set(data[var_name][dim].values) for dim in new_dims]
+            vals = [np.unique(data[var_name][dim].values) for dim in new_dims]
             dims = [{k: v for k, v in zip(new_dims, prod)} for prod in product(*vals)]
             if reverse_selections:
                 dims = reversed(dims)

--- a/arviz/tests/test_plot_utils.py
+++ b/arviz/tests/test_plot_utils.py
@@ -55,10 +55,10 @@ def test_dataset_to_numpy_combined(sample_dataset):
     assert (data[var_names.index("tau")] == tau.reshape(1, 6)).all()
 
 
-def test_xarray_var_iter_ordering(sample_dataset):  # pylint: disable=invalid-name
+def test_xarray_var_iter_ordering():
     """Assert that coordinate names stay the provided order"""
     coords = list("abcd")
-    data = from_dict(
+    data = from_dict(  # pylint: disable=no-member
         {"x": np.random.randn(1, 100, len(coords))},
         coords={"in_order": coords},
         dims={"x": ["in_order"]},

--- a/arviz/tests/test_plot_utils.py
+++ b/arviz/tests/test_plot_utils.py
@@ -3,6 +3,7 @@ import numpy as np
 import xarray as xr
 import pytest
 
+from ..data import from_dict
 from ..plots.plot_utils import make_2d, xarray_to_ndarray, xarray_var_iter, get_bins, get_coords
 
 
@@ -52,6 +53,19 @@ def test_dataset_to_numpy_combined(sample_dataset):
     assert len(var_names) == 2
     assert (data[var_names.index("mu")] == mu.reshape(1, 6)).all()
     assert (data[var_names.index("tau")] == tau.reshape(1, 6)).all()
+
+
+def test_xarray_var_iter_ordering(sample_dataset):  # pylint: disable=invalid-name
+    """Assert that coordinate names stay the provided order"""
+    coords = list("abcd")
+    data = from_dict(
+        {"x": np.random.randn(1, 100, len(coords))},
+        coords={"in_order": coords},
+        dims={"x": ["in_order"]},
+    ).posterior
+
+    coord_names = [sel["in_order"] for _, sel, _ in xarray_var_iter(data)]
+    assert coord_names == coords
 
 
 def test_xarray_var_iter_ordering_combined(sample_dataset):  # pylint: disable=invalid-name


### PR DESCRIPTION
Fixes #554. My local environment is a little broken, so I want to make sure unittests pass while I write a test for this case. This works on the examples from the issue, though.

```
data = az.from_pymc3(trace=trace, coords={'schools': list('abcdefgh')}, dims={'theta': ['schools']})
az.plot_forest(data, var_names='theta')
```

![image](https://user-images.githubusercontent.com/2295568/51539766-d2733e00-1e22-11e9-9c05-9646eedf8c25.png)
