### PR TITLE
Fix to plot ordering

### DIFF
--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -242,6 +242,25 @@ def xarray_var_iter(data, var_names=None, combined=False, skip_dims=None, revers
         The string is the variable name, the dictionary are coordinate names to values,
         and the array are the values of the variable at those coordinates.
     """
+
+    def ordered_unique(l):
+        """Remove duplicates from list while conserving order
+        Required arguments:
+            l: Iterable
+        Returns:
+            First occurences in order
+        """
+    
+        def purge_duplicates(l):
+            seen = set() # for faster lookups than lists
+            for x in l:
+                if x in seen:
+                    continue
+                seen.add(x)
+                yield x
+    
+        return np.array(list(purge_duplicates(l)))
+    
     if skip_dims is None:
         skip_dims = set()
 
@@ -260,7 +279,7 @@ def xarray_var_iter(data, var_names=None, combined=False, skip_dims=None, revers
     for var_name in var_names:
         if var_name in data:
             new_dims = [dim for dim in data[var_name].dims if dim not in skip_dims]
-            vals = [np.unique(data[var_name][dim].values) for dim in new_dims]
+            vals = [ordered_unique(data[var_name][dim].values) for dim in new_dims]
             dims = [{k: v for k, v in zip(new_dims, prod)} for prod in product(*vals)]
             if reverse_selections:
                 dims = reversed(dims)

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -243,23 +243,13 @@ def xarray_var_iter(data, var_names=None, combined=False, skip_dims=None, revers
         and the array are the values of the variable at those coordinates.
     """
 
-    def ordered_unique(l):
-        """Remove duplicates from list while conserving order
-        Required arguments:
-            l: Iterable
-        Returns:
-            First occurences in order
-        """
+    def purge_duplicates(l):
+        _list = []
+        for item in l:
+            if item not in _list:
+                _list.append(item)
+        return _list
     
-        def purge_duplicates(l):
-            seen = set() # for faster lookups than lists
-            for x in l:
-                if x in seen:
-                    continue
-                seen.add(x)
-                yield x
-    
-        return np.array(list(purge_duplicates(l)))
     
     if skip_dims is None:
         skip_dims = set()
@@ -279,7 +269,7 @@ def xarray_var_iter(data, var_names=None, combined=False, skip_dims=None, revers
     for var_name in var_names:
         if var_name in data:
             new_dims = [dim for dim in data[var_name].dims if dim not in skip_dims]
-            vals = [ordered_unique(data[var_name][dim].values) for dim in new_dims]
+            vals = [purge_duplicates(data[var_name][dim].values) for dim in new_dims]
             dims = [{k: v for k, v in zip(new_dims, prod)} for prod in product(*vals)]
             if reverse_selections:
                 dims = reversed(dims)

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -213,6 +213,25 @@ def make_label(var_name, selection, position="below"):
     return "{}{}{}".format(var_name, sep, sel)
 
 
+def purge_duplicates(l):
+    """Remove duplicates from list while preserving order.
+
+    Parameters
+    ----------
+    l: Iterable
+
+    Returns
+    -------
+    list
+        List of first occurences in order
+    """
+    _list = []
+    for item in l:
+        if item not in _list:
+            _list.append(item)
+    return _list
+
+
 def xarray_var_iter(data, var_names=None, combined=False, skip_dims=None, reverse_selections=False):
     """Convert xarray data to an iterator over vectors.
 
@@ -242,15 +261,6 @@ def xarray_var_iter(data, var_names=None, combined=False, skip_dims=None, revers
         The string is the variable name, the dictionary are coordinate names to values,
         and the array are the values of the variable at those coordinates.
     """
-
-    def purge_duplicates(l):
-        _list = []
-        for item in l:
-            if item not in _list:
-                _list.append(item)
-        return _list
-    
-    
     if skip_dims is None:
         skip_dims = set()
 

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -213,12 +213,12 @@ def make_label(var_name, selection, position="below"):
     return "{}{}{}".format(var_name, sep, sel)
 
 
-def purge_duplicates(l):
+def purge_duplicates(list_in):
     """Remove duplicates from list while preserving order.
 
     Parameters
     ----------
-    l: Iterable
+    list_in: Iterable
 
     Returns
     -------
@@ -226,7 +226,7 @@ def purge_duplicates(l):
         List of first occurences in order
     """
     _list = []
-    for item in l:
+    for item in list_in:
         if item not in _list:
             _list.append(item)
     return _list

--- a/arviz/tests/test_plot_utils.py
+++ b/arviz/tests/test_plot_utils.py
@@ -57,7 +57,7 @@ def test_dataset_to_numpy_combined(sample_dataset):
 
 def test_xarray_var_iter_ordering():
     """Assert that coordinate names stay the provided order"""
-    coords = list("abcd")
+    coords = list("dcba")
     data = from_dict(  # pylint: disable=no-member
         {"x": np.random.randn(1, 100, len(coords))},
         coords={"in_order": coords},


### PR DESCRIPTION
Previously the order returned was always alphabetical due to use of np.unique(). Now the order of the provided coords are respected.