### PR TITLE
Fix nan handling and fix n_eff to ess

### DIFF
--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -29,7 +29,7 @@ def plot_forest(
     credible_interval=0.94,
     rope=None,
     quartiles=True,
-    eff_n=False,
+    ess=False,
     r_hat=False,
     colors="cycle",
     textsize=None,
@@ -71,7 +71,7 @@ def plot_forest(
         Defaults to True
     r_hat : bool, optional
         Flag for plotting Split R-hat statistics. Requires 2 or more chains. Defaults to False
-    eff_n : bool, optional
+    ess : bool, optional
         Flag for plotting the effective sample size. Requires 2 or more chains. Defaults to False
     colors : list or string, optional
         list with valid matplotlib colors, one color per model. Alternative a string can be passed.
@@ -101,7 +101,7 @@ def plot_forest(
 
     ncols, width_ratios = 1, [3]
 
-    if eff_n:
+    if ess:
         ncols += 1
         width_ratios.append(1)
 
@@ -156,7 +156,7 @@ def plot_forest(
         )
 
     idx = 1
-    if eff_n:
+    if ess:
         plot_handler.plot_neff(axes[idx], xt_labelsize, titlesize, markersize)
         idx += 1
 
@@ -362,10 +362,10 @@ class PlotHandler:
     def plot_neff(self, ax, xt_labelsize, titlesize, markersize):
         """Draw effective n for each plotter."""
         for plotter in self.plotters.values():
-            for y, eff_n, color in plotter.eff_n():
-                if eff_n is not None:
+            for y, ess, color in plotter.ess():
+                if ess is not None:
                     ax.plot(
-                        eff_n,
+                        ess,
                         y,
                         "o",
                         color=color,
@@ -374,7 +374,7 @@ class PlotHandler:
                         markeredgecolor="k",
                     )
         ax.set_xlim(left=0)
-        ax.set_title("eff_n", fontsize=titlesize, wrap=True)
+        ax.set_title("ess", fontsize=titlesize, wrap=True)
         ax.tick_params(labelsize=xt_labelsize)
         return ax
 
@@ -518,7 +518,7 @@ class VarHandler:
             y = y * np.ones_like(x)
             yield x, y, mult * pdf / scaling + y, color
 
-    def eff_n(self):
+    def ess(self):
         """Get effective n data for the variable."""
         _, y_vals, values, colors = self.labels_ticks_and_vals()
         for y, value, color in zip(y_vals, values, colors):

--- a/arviz/stats/diagnostics.py
+++ b/arviz/stats/diagnostics.py
@@ -116,7 +116,11 @@ def _get_ess(sample_array):
             rho_hat_t[t + 1] = (rho_hat_t[t - 1] + rho_hat_t[t]) / 2.0
             rho_hat_t[t + 2] = rho_hat_t[t + 1]
         t += 2
-    ess = int((n_chain * n_draws) / (-1.0 + 2.0 * np.sum(rho_hat_t)))
+    ess = (
+        int((n_chain * n_draws) / (-1.0 + 2.0 * np.sum(rho_hat_t)))
+        if not np.any(np.isnan(rho_hat_t))
+        else np.nan
+    )
     return ess
 
 

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -382,11 +382,9 @@ def loo(data, pointwise=False, reff=None):
         if n_chains == 1:
             reff = 1.0
         else:
-            eff_n = effective_sample_size(posterior)
+            ess = effective_sample_size(posterior)
             # this mean is over all data variables
-            reff = (
-                np.hstack([eff_n[v].values.flatten() for v in eff_n.data_vars]).mean() / n_samples
-            )
+            reff = np.hstack([ess[v].values.flatten() for v in ess.data_vars]).mean() / n_samples
 
     log_weights, pareto_shape = psislw(-log_likelihood, reff)
     log_weights += log_likelihood
@@ -647,7 +645,7 @@ def summary(
     -------
     pandas.DataFrame
         With summary statistics for each variable. Defaults statistics are: `mean`, `sd`,
-        `hpd_3%`, `hpd_97%`, `mc_error`, `eff_n` and `r_hat`. `eff_n` and `r_hat` are only computed
+        `hpd_3%`, `hpd_97%`, `mc_error`, `ess` and `r_hat`. `ess` and `r_hat` are only computed
         for traces with 2 or more chains.
 
     Examples
@@ -655,7 +653,7 @@ def summary(
     .. code:: ipython
 
         >>> az.summary(trace, ['mu'])
-               mean    sd  mc_error  hpd_3  hpd_97  eff_n  r_hat
+               mean    sd  mc_error  hpd_3  hpd_97  ess  r_hat
         mu[0]  0.10  0.06      0.00  -0.02    0.23  487.0  1.00
         mu[1] -0.04  0.06      0.00  -0.17    0.08  379.0  1.00
 
@@ -775,7 +773,7 @@ def summary(
 
     if len(posterior.chain) > 1:
         metrics.append(effective_sample_size(posterior, var_names=var_names))
-        metric_names.append("eff_n")
+        metric_names.append("ess")
 
         metrics.append(rhat(posterior, var_names=var_names))
         metric_names.append("r_hat")

--- a/arviz/tests/test_diagnostics.py
+++ b/arviz/tests/test_diagnostics.py
@@ -40,9 +40,9 @@ class TestDiagnostics:
             rhat(np.random.randn(3))
 
     def test_effective_sample_size_array(self):
-        eff_n_hat = effective_sample_size(np.random.randn(4, 100))
-        assert eff_n_hat > 100
-        assert eff_n_hat < 800
+        ess_hat = effective_sample_size(np.random.randn(4, 100))
+        assert ess_hat > 100
+        assert ess_hat < 800
 
     def test_effective_sample_size_bad_shape(self):
         with pytest.raises(TypeError):
@@ -54,8 +54,8 @@ class TestDiagnostics:
 
     @pytest.mark.parametrize("var_names", (None, "mu", ["mu", "tau"]))
     def test_effective_sample_size_dataset(self, data, var_names):
-        eff_n_hat = effective_sample_size(data, var_names=var_names)
-        assert eff_n_hat.mu > 100  # This might break if the data is regenerated
+        ess_hat = effective_sample_size(data, var_names=var_names)
+        assert ess_hat.mu > 100  # This might break if the data is regenerated
 
     def test_geweke(self):
         first = 0.1

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -168,9 +168,9 @@ def test_plot_trace_discrete(discrete_model):
         ({"var_names": "mu"}, 1),
         ({"var_names": "mu", "rope": (-1, 1)}, 1),
         ({"r_hat": True, "quartiles": False}, 2),
-        ({"var_names": ["mu"], "colors": "C0", "eff_n": True, "combined": True}, 2),
-        ({"kind": "ridgeplot", "r_hat": True, "eff_n": True}, 3),
-        ({"kind": "ridgeplot", "r_hat": True, "eff_n": True, "ridgeplot_alpha": 0}, 3),
+        ({"var_names": ["mu"], "colors": "C0", "ess": True, "combined": True}, 2),
+        ({"kind": "ridgeplot", "r_hat": True, "ess": True}, 3),
+        ({"kind": "ridgeplot", "r_hat": True, "ess": True, "ridgeplot_alpha": 0}, 3),
         (
             {
                 "var_names": ["mu", "tau"],

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -119,6 +119,20 @@ def test_summary_stat_func(centered_eight):
     assert summary(centered_eight, stat_funcs=[np.var]) is not None
 
 
+def test_summary_nan(centered_eight):
+    centered_eight = deepcopy(centered_eight)
+    centered_eight.posterior.theta[:, :, 0] = np.nan
+    summary_xarray = summary(centered_eight)
+    assert summary_xarray is not None
+    assert summary_xarray.loc["theta[0]"].isnull().all()
+    assert (
+        summary_xarray.loc[[ix for ix in summary_xarray.index if ix != "theta[0]"]]
+        .notnull()
+        .all()
+        .all()
+    )
+
+
 def test_summary_bad_fmt(centered_eight):
     with pytest.raises(TypeError):
         summary(centered_eight, fmt="bad_fmt")


### PR DESCRIPTION
This PR makes ess to return float if NaN is seen.

Until there exists a way to return integer dtype with NaN, this is the best option.

Let's follow how xarray evolves with this issue. https://github.com/pydata/xarray/issues/1194

Also I noticed that there was many `n_eff` left so I changed them to ess.