### PR TITLE
negate variable names

### DIFF
--- a/arviz/plots/autocorrplot.py
+++ b/arviz/plots/autocorrplot.py
@@ -77,7 +77,7 @@ def plot_autocorr(data, var_names=None, max_lag=100, combined=False, figsize=Non
         >>> az.plot_autocorr(data, var_names=['mu', 'tau'], max_lag=200, combined=True)
     """
     data = convert_to_dataset(data, group="posterior")
-    var_names = _var_names(var_names)
+    var_names = _var_names(var_names, data)
 
     plotters = list(xarray_var_iter(data, var_names, combined))
     length_plotters = len(plotters)

--- a/arviz/plots/densityplot.py
+++ b/arviz/plots/densityplot.py
@@ -132,12 +132,12 @@ def plot_density(
 
         >>> az.plot_density([centered, non_centered], var_names=["mu"], bw=.9)
     """
-    var_names = _var_names(var_names)
-
     if not isinstance(data, (list, tuple)):
         datasets = [convert_to_dataset(data, group=group)]
     else:
-        datasets = [convert_to_dataset(d, group=group) for d in data]
+        datasets = [convert_to_dataset(datum, group=group) for datum in data]
+
+    var_names = _var_names(var_names, datasets)
 
     if point_estimate not in ("mean", "median", None):
         raise ValueError(

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -97,7 +97,12 @@ def plot_forest(
     -------
     gridspec : matplotlib GridSpec
     """
-    var_names = _var_names(var_names)
+    if not isinstance(data, (list, tuple)):
+        data = [data]
+
+    datasets = [convert_to_dataset(datum) for datum in reversed(data)]
+
+    var_names = _var_names(var_names, datasets)
 
     ncols, width_ratios = 1, [3]
 
@@ -110,7 +115,7 @@ def plot_forest(
         width_ratios.append(1)
 
     plot_handler = PlotHandler(
-        data, var_names=var_names, model_names=model_names, combined=combined, colors=colors
+        datasets, var_names=var_names, model_names=model_names, combined=combined, colors=colors
     )
 
     if figsize is None:
@@ -195,12 +200,8 @@ class PlotHandler:
 
     # pylint: disable=inconsistent-return-statements
 
-    def __init__(self, data, var_names, model_names, combined, colors):
-        if not isinstance(data, (list, tuple)):
-            data = [data]
-
-        # y-values upside down
-        self.data = [convert_to_dataset(datum, group="posterior") for datum in reversed(data)]
+    def __init__(self, datasets, var_names, model_names, combined, colors):
+        self.data = datasets
 
         if model_names is None:
             if len(self.data) > 1:

--- a/arviz/plots/jointplot.py
+++ b/arviz/plots/jointplot.py
@@ -4,6 +4,7 @@ import matplotlib.pyplot as plt
 from ..data import convert_to_dataset
 from .kdeplot import plot_kde
 from .plot_utils import _scale_fig_size, get_bins, xarray_var_iter, make_label, get_coords
+from ..utils import _var_names
 
 
 def plot_joint(
@@ -66,6 +67,8 @@ def plot_joint(
 
     if coords is None:
         coords = {}
+
+    var_names = _var_names(var_names, data)
 
     plotters = list(xarray_var_iter(get_coords(data, coords), var_names=var_names, combined=True))
 

--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -69,8 +69,6 @@ def plot_pair(
     -------
     ax : matplotlib axes
     """
-    var_names = _var_names(var_names)
-
     valid_kinds = ["scatter", "kde", "hexbin"]
     if kind not in valid_kinds:
         raise ValueError(
@@ -97,6 +95,7 @@ def plot_pair(
 
     # Get posterior draws and combine chains
     posterior_data = convert_to_dataset(data, group="posterior")
+    var_names = _var_names(var_names, posterior_data)
     flat_var_names, _posterior = xarray_to_ndarray(
         get_coords(posterior_data, coords), var_names=var_names, combined=True
     )

--- a/arviz/plots/parallelplot.py
+++ b/arviz/plots/parallelplot.py
@@ -55,8 +55,6 @@ def plot_parallel(
     -------
     ax : matplotlib axes
     """
-    var_names = _var_names(var_names)
-
     if coords is None:
         coords = {}
 
@@ -67,6 +65,7 @@ def plot_parallel(
 
     # Get posterior draws and combine chains
     posterior_data = convert_to_dataset(data, group="posterior")
+    var_names = _var_names(var_names, posterior_data)
     var_names, _posterior = xarray_to_ndarray(
         get_coords(posterior_data, coords), var_names=var_names, combined=True
     )

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -144,9 +144,8 @@ def plot_posterior(
 
         >>> az.plot_posterior(data, var_names=['mu'], credible_interval=.75)
     """
-    var_names = _var_names(var_names)
-
     data = convert_to_dataset(data, group="posterior")
+    var_names = _var_names(var_names, data)
 
     if coords is None:
         coords = {}

--- a/arviz/plots/ppcplot.py
+++ b/arviz/plots/ppcplot.py
@@ -188,7 +188,7 @@ def plot_ppc(
 
     if var_names is None:
         var_names = observed.data_vars
-    var_names = _var_names(var_names)
+    var_names = _var_names(var_names, observed)
     pp_var_names = [data_pairs.get(var, var) for var in var_names]
 
     if flatten_pp is None and flatten is None:

--- a/arviz/plots/traceplot.py
+++ b/arviz/plots/traceplot.py
@@ -96,7 +96,7 @@ def plot_trace(
             divergences = False
 
     data = convert_to_dataset(data, group="posterior")
-    var_names = _var_names(var_names)
+    var_names = _var_names(var_names, data)
 
     if coords is None:
         coords = {}

--- a/arviz/plots/violinplot.py
+++ b/arviz/plots/violinplot.py
@@ -63,7 +63,7 @@ def plot_violin(
     ax : matplotlib axes
     """
     data = convert_to_dataset(data, group="posterior")
-    var_names = _var_names(var_names)
+    var_names = _var_names(var_names, data)
 
     plotters = list(xarray_var_iter(data, var_names=var_names, combined=True))
 

--- a/arviz/stats/diagnostics.py
+++ b/arviz/stats/diagnostics.py
@@ -54,8 +54,8 @@ def effective_sample_size(data, *, var_names=None):
     if isinstance(data, np.ndarray):
         return _get_ess(data)
 
-    var_names = _var_names(var_names)
     dataset = convert_to_dataset(data, group="posterior")
+    var_names = _var_names(var_names, dataset)
 
     dataset = dataset if var_names is None else dataset[var_names]
     return xr.apply_ufunc(_ess_ufunc, dataset, input_core_dims=(("chain", "draw"),))
@@ -205,8 +205,9 @@ def rhat(data, var_names=None):
     """
     if isinstance(data, np.ndarray):
         return _get_split_rhat(data)
-    var_names = _var_names(var_names)
+
     dataset = convert_to_dataset(data, group="posterior")
+    var_names = _var_names(var_names, dataset)
 
     dataset = dataset if var_names is None else dataset[var_names]
     return xr.apply_ufunc(_rhat_ufunc, dataset, input_core_dims=(("chain", "draw"),))

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -676,7 +676,7 @@ def summary(
         mu[1]  0.07 -0.16 -0.04  0.06
     """
     posterior = convert_to_dataset(data, group="posterior")
-    var_names = _var_names(var_names)
+    var_names = _var_names(var_names, posterior)
     posterior = posterior if var_names is None else posterior[var_names]
 
     fmt_group = ("wide", "long", "xarray")

--- a/arviz/tests/test_utils.py
+++ b/arviz/tests/test_utils.py
@@ -24,10 +24,10 @@ def data():
         (["~mu"], ["theta", "tau"]),
     ],
 )
-def test_var_names(var_names_expected):
+def test_var_names(var_names_expected, data):
     """Test var_name handling"""
     var_names, expected = var_names_expected
-    assert _var_names(var_names, data()) == expected
+    assert _var_names(var_names, data) == expected
 
 
 @pytest.fixture(scope="function")

--- a/arviz/tests/test_utils.py
+++ b/arviz/tests/test_utils.py
@@ -5,15 +5,29 @@ Tests for arviz.utils.
 from unittest.mock import Mock
 import pytest
 from ..utils import _var_names
+from ..data import load_arviz_data
+
+
+@pytest.fixture(scope="session")
+def data():
+    centered_eight = load_arviz_data("centered_eight")
+    return centered_eight.posterior
 
 
 @pytest.mark.parametrize(
-    "var_names_expected", [("mu", ["mu"]), (None, None), (["mu", "tau"], ["mu", "tau"])]
+    "var_names_expected",
+    [
+        ("mu", ["mu"]),
+        (None, None),
+        (["mu", "tau"], ["mu", "tau"]),
+        ("~mu", ["theta", "tau"]),
+        (["~mu"], ["theta", "tau"]),
+    ],
 )
 def test_var_names(var_names_expected):
     """Test var_name handling"""
     var_names, expected = var_names_expected
-    assert _var_names(var_names) == expected
+    assert _var_names(var_names, data()) == expected
 
 
 @pytest.fixture(scope="function")

--- a/arviz/tests/test_utils.py
+++ b/arviz/tests/test_utils.py
@@ -1,7 +1,7 @@
 """
 Tests for arviz.utils.
 """
-# pylint: disable=redefined-outer-name
+# pylint: disable=redefined-outer-name, no-member
 from unittest.mock import Mock
 import pytest
 from ..utils import _var_names

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -2,25 +2,37 @@
 import importlib
 
 
-def _var_names(var_names):
+def _var_names(var_names, data):
     """Handle var_names input across arviz.
-
     Parameters
     ----------
     var_names: str, list, or None
-
+    data : xarray.Dataset
+        Posterior data in an xarray
     Returns
     -------
     var_name: list or None
     """
-    if var_names is None:
-        return None
+    if var_names is not None:
 
-    elif isinstance(var_names, str):
-        return [var_names]
+        if isinstance(var_names, str):
+            var_names = [var_names]
 
-    else:
-        return var_names
+        if isinstance(data, (list, tuple)):
+            all_vars = []
+            for dataset in data:
+                dataset_vars = list(dataset.data_vars)
+                for var in dataset_vars:
+                    if var not in all_vars:
+                        all_vars.append(var)
+        else:
+            all_vars = list(data.data_vars)
+
+        exclude_vars = [i[1:] for i in var_names if i.startswith("~")]
+        if exclude_vars:
+            var_names = [i for i in all_vars if i not in exclude_vars]
+
+    return var_names
 
 
 def conditional_jit(function=None, **kwargs):  # noqa: D202

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -4,6 +4,7 @@ import importlib
 
 def _var_names(var_names, data):
     """Handle var_names input across arviz.
+
     Parameters
     ----------
     var_names: str, list, or None
@@ -28,7 +29,8 @@ def _var_names(var_names, data):
         else:
             all_vars = list(data.data_vars)
 
-        exclude_vars = [i[1:] for i in var_names if i.startswith("~")]
+        exclude_vars = [i[1:] for i in var_names if i.startswith("~") and i not in all_vars]
+
         if exclude_vars:
             var_names = [i for i in all_vars if i not in exclude_vars]
 

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -1,5 +1,6 @@
 """General utilities."""
 import importlib
+import warnings
 
 
 def _var_names(var_names, data):
@@ -29,10 +30,21 @@ def _var_names(var_names, data):
         else:
             all_vars = list(data.data_vars)
 
-        exclude_vars = [i[1:] for i in var_names if i.startswith("~") and i not in all_vars]
+        excluded_vars = [i[1:] for i in var_names if i.startswith("~") and i not in all_vars]
 
-        if exclude_vars:
-            var_names = [i for i in all_vars if i not in exclude_vars]
+        all_vars_tilde = [i for i in all_vars if i.startswith("~")]
+
+        if all_vars_tilde:
+            warnings.warn(
+                """ArviZ treats '~' as a negation character for variable selection.
+                   Your model has variables names starting with '~', {0}. Please double check
+                   your results to ensure all variables are included""".format(
+                    ", ".join(all_vars_tilde)
+                )
+            )
+
+        if excluded_vars:
+            var_names = [i for i in all_vars if i not in excluded_vars]
 
     return var_names
 


### PR DESCRIPTION
This allow to pass a variable to `var_names` and get all the variables except the one that was passed.

Thus if `data` is a model with variables names ['mu', 'theta', 'tau']

```python
az.plot_joint(data, var_names=['~theta']);
```

returns

![lala](https://user-images.githubusercontent.com/1338958/51861421-eafbc080-231a-11e9-937f-797d8a653e4f.png)

One caveat is that variables names are then no allowed to starts with `~`. 

