### PR TITLE
PyStan 0-based indexing vs 1-based indexing

### DIFF
--- a/arviz/data/io_pystan.py
+++ b/arviz/data/io_pystan.py
@@ -357,8 +357,8 @@ def get_draws(fit, variables=None, ignore=None):
     if any(fit.sim["dims_oi"]):
         # choose variable with lowest number of dims > 1
         par_idx = min((dim, i) for i, dim in enumerate(fit.sim["dims_oi"]) if dim)[1]
-        offset = sum(map(np.product, fit.sim["dims_oi"][:par_idx]))
-        par_offset = np.product(fit.sim["dims_oi"][par_idx])
+        offset = int(sum(map(np.product, fit.sim["dims_oi"][:par_idx])))
+        par_offset = int(np.product(fit.sim["dims_oi"][par_idx]))
         par_keys = fit.sim["fnames_oi"][offset : offset + par_offset]
         shift = len(par_keys)
         for item in par_keys:

--- a/arviz/data/io_pystan.py
+++ b/arviz/data/io_pystan.py
@@ -352,6 +352,25 @@ def get_draws(fit, variables=None, ignore=None):
     ndraws = [s - w for s, w in zip(fit.sim["n_save"], fit.sim["warmup2"])]
     nchain = len(fit.sim["samples"])
 
+    # check if the values are in 0-based (<=2.17) or 1-based indexing (>=2.18)
+    shift = 1
+    if any(fit.sim["dims_oi"]):
+        # choose variable with lowest number of dims > 1
+        par_idx = min((dim, i) for i, dim in enumerate(fit.sim["dims_oi"]) if dim)[1]
+        offset = sum(map(np.product, fit.sim["dims_oi"][:par_idx]))
+        par_offset = np.product(fit.sim["dims_oi"][par_idx])
+        par_keys = fit.sim["fnames_oi"][offset : offset + par_offset]
+        shift = len(par_keys)
+        for item in par_keys:
+            _, shape = item.replace("]", "").split("[")
+            shape_idx_min = min(int(shape_value) for shape_value in shape.split(","))
+            if shape_idx_min < shift:
+                shift = shape_idx_min
+        # If shift is higher than 1, this will probably mean that Stan
+        # has implemented sparse structure (saves only non-zero parts),
+        # but let's hope that dims are still corresponding the full shape
+        shift = min(shift, 1)
+
     var_keys = OrderedDict((var, []) for var in fit.sim["pars_oi"])
     for key in fit.sim["fnames_oi"]:
         var, *tails = key.split("[")
@@ -359,7 +378,7 @@ def get_draws(fit, variables=None, ignore=None):
         for tail in tails:
             loc = []
             for i in tail[:-1].split(","):
-                loc.append(int(i) - 1)
+                loc.append(int(i) - shift)
         var_keys[var].append((key, loc))
 
     shapes = dict(zip(fit.sim["pars_oi"], fit.sim["dims_oi"]))
@@ -446,11 +465,7 @@ def get_draws_stan3(fit, model=None, variables=None, ignore=None):
         dtype = dtypes.get(var)
 
         # in future fix the correct number of draws if fit.save_warmup is True
-        new_shape = (
-            *fit.dims[fit.param_names.index(var)],
-            -1,
-            fit.num_chains,
-        )  # pylint: disable=protected-access
+        new_shape = (*fit.dims[fit.param_names.index(var)], -1, fit.num_chains)
         values = fit._draws[fit._parameter_indexes(var), :]  # pylint: disable=protected-access
         values = values.reshape(new_shape, order="F")
         values = np.moveaxis(values, [-2, -1], [1, 0])

--- a/arviz/data/io_pystan.py
+++ b/arviz/data/io_pystan.py
@@ -369,7 +369,7 @@ def get_draws(fit, variables=None, ignore=None):
         # If shift is higher than 1, this will probably mean that Stan
         # has implemented sparse structure (saves only non-zero parts),
         # but let's hope that dims are still corresponding the full shape
-        shift = min(shift, 1)
+        shift = int(min(shift, 1))
 
     var_keys = OrderedDict((var, []) for var in fit.sim["pars_oi"])
     for key in fit.sim["fnames_oi"]:

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -958,6 +958,7 @@ class TestPyStanNetCDFUtils:
                         key = name + "[{}]".format(",".join(shape))
                     new_chains[key] = values.copy()
                 setattr(holder, "chains", new_chains)
+            fit.sim["fnames_oi"] = list(fit.sim["samples"][0].chains.keys())
         idata = from_pystan(posterior=fit)
         assert idata is not None
         for (par,) in fit.sim["pars_oi"]:

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -962,6 +962,8 @@ class TestPyStanNetCDFUtils:
         idata = from_pystan(posterior=fit)
         assert idata is not None
         for par in fit.sim["pars_oi"]:
+            if par == "lp__":
+                continue
             assert hasattr(idata.posterior, par)
 
 

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -941,6 +941,7 @@ class TestPyStanNetCDFUtils:
             draws = get_draws_stan3(fit, variables=["theta", "theta"])
             assert draws.get("theta") is not None
 
+    @pytest.mark.skipif(pystan_version() != 2, reason="PyStan 2.x required")
     def test_index_order(self, data, eight_schools_params):
         """Test 0-indexed data."""
         import pystan
@@ -955,13 +956,12 @@ class TestPyStanNetCDFUtils:
                         name, *shape = key.replace("]", "").split("[")
                         shape = [str(int(item) - 1) for items in shape for item in items.split(",")]
                         key = name + "[{}]".format(",".join(shape))
-                    new_chains[key] = values
+                    new_chains[key] = values.copy()
                 setattr(holder, "chains", new_chains)
         idata = from_pystan(posterior=fit)
         assert idata is not None
-        for par, dim in zip(fit.sim["pars_oi"], fit.sim["dims_oi"]):
-            if dim:
-                assert idata.posterior[par]
+        for (par,) in fit.sim["pars_oi"]:
+            assert hasattr(idata.posterior, par)
 
 
 class TestTfpNetCDFUtils:

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -947,14 +947,14 @@ class TestPyStanNetCDFUtils:
         if pystan.__version__ >= "2.18":
             # make 1-indexed to 0-indexed
             for i, holder in enumerate(fit.sim["samples"]):
-            new_chains = OrderedDict()
-            for key, values in holder.chains.items():
-                if "[" in key:
-                    name, *shape = key.replace("]", "").split("[")
-                    shape = [str(int(item)-1) for items in shape for item in items.split(",")]
-                    key = name + "[{}]".format(",".join(shape))
-                new_chains[key] = values
-            setattr(holder, "chains", new_chains)
+                new_chains = OrderedDict()
+                for key, values in holder.chains.items():
+                    if "[" in key:
+                        name, *shape = key.replace("]", "").split("[")
+                        shape = [str(int(item)-1) for items in shape for item in items.split(",")]
+                        key = name + "[{}]".format(",".join(shape))
+                    new_chains[key] = values
+                setattr(holder, "chains", new_chains)
         idata = from_pystan(posterior=fit)
         assert idata is not None
         for par, dim in zip(fit.sim["pars_oi"], fit.sim["dims_oi"]):

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -946,7 +946,7 @@ class TestPyStanNetCDFUtils:
         fit = deepcopy(data.obj)
         if pystan.__version__ >= "2.18":
             # make 1-indexed to 0-indexed
-            for i, holder in enumerate(fit.sim["samples"]):
+            for holder in fit.sim["samples"]:
                 new_chains = OrderedDict()
                 for key, values in holder.chains.items():
                     if "[" in key:

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -959,7 +959,7 @@ class TestPyStanNetCDFUtils:
         assert idata is not None
         for par, dim in zip(fit.sim["pars_oi"], fit.sim["dims_oi"]):
             if dim:
-                assert idata.posterior[par][]
+                assert idata.posterior[par]
 
 
 class TestTfpNetCDFUtils:

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -942,11 +942,11 @@ class TestPyStanNetCDFUtils:
             draws = get_draws_stan3(fit, variables=["theta", "theta"])
             assert draws.get("theta") is not None
 
-    def test_index_order(self, data):
+    def test_index_order(self, data, eight_schools_params):
         """Test 0-indexed data."""
         import pystan
 
-        fit = deepcopy(data.obj)
+        fit = data.model.sampling(data=eight_schools_params)
         if pystan.__version__ >= "2.18":
             # make 1-indexed to 0-indexed
             for holder in fit.sim["samples"]:

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -951,7 +951,7 @@ class TestPyStanNetCDFUtils:
                 for key, values in holder.chains.items():
                     if "[" in key:
                         name, *shape = key.replace("]", "").split("[")
-                        shape = [str(int(item)-1) for items in shape for item in items.split(",")]
+                        shape = [str(int(item) - 1) for items in shape for item in items.split(",")]
                         key = name + "[{}]".format(",".join(shape))
                     new_chains[key] = values
                 setattr(holder, "chains", new_chains)

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -961,7 +961,7 @@ class TestPyStanNetCDFUtils:
             fit.sim["fnames_oi"] = list(fit.sim["samples"][0].chains.keys())
         idata = from_pystan(posterior=fit)
         assert idata is not None
-        for (par,) in fit.sim["pars_oi"]:
+        for par in fit.sim["pars_oi"]:
             assert hasattr(idata.posterior, par)
 
 

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -1,6 +1,7 @@
 # pylint: disable=no-member, invalid-name, redefined-outer-name
 # pylint: disable=too-many-lines
 from collections import namedtuple, OrderedDict
+from copy import deepcopy
 import os
 from urllib.parse import urlunsplit
 
@@ -943,6 +944,8 @@ class TestPyStanNetCDFUtils:
 
     def test_index_order(self, data):
         """Test 0-indexed data."""
+        import pystan
+
         fit = deepcopy(data.obj)
         if pystan.__version__ >= "2.18":
             # make 1-indexed to 0-indexed

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -967,7 +967,7 @@ class TestPyStanNetCDFUtils:
             par, *shape = fpar.replace("]", "").split("[")
             assert hasattr(idata.posterior, par)
             if shape:
-                shape = list(map(int, shape))
+                shape = [slice(None), slice(None)] + list(map(int, shape))
                 assert idata.posterior[par][tuple(shape)].values.mean() == float(j)
             else:
                 assert idata.posterior[par].values.mean() == float(j)

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -1,7 +1,6 @@
 # pylint: disable=no-member, invalid-name, redefined-outer-name
 # pylint: disable=too-many-lines
 from collections import namedtuple, OrderedDict
-from copy import deepcopy
 import os
 from urllib.parse import urlunsplit
 


### PR DESCRIPTION
Fixes bug where PyStan<=2.17 was unpacking in wrong locations due to the difference between PyStan 2.18 and 2.17.