### PR TITLE
Feature/summary unpack order

### DIFF
--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -1,5 +1,6 @@
 """Statistical functions in ArviZ."""
 import warnings
+from collections import OrderedDict
 from collections.abc import Sequence
 
 import numpy as np
@@ -794,7 +795,7 @@ def summary(
         for var_name, values in joined.data_vars.items():
             if len(values.shape[1:]):
                 metric = list(values.metric.values)
-                data_dict = {}
+                data_dict = OrderedDict()
                 for idx in np.ndindex(values.shape[1:] if order == "C" else values.shape[1:][::-1]):
                     if order == "F":
                         idx = tuple(idx[::-1])

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -797,17 +797,18 @@ def summary(
                 data_dict = {}
                 for idx in np.ndindex(values.shape[1:] if order == "C" else values.shape[1:][::-1]):
                     if order == "F":
-                        idx = list(idx)[::-1]
+                        idx = tuple(idx[::-1])
                     ser = pd.Series(values[(Ellipsis, *idx)].values, index=metric)
                     key = "{}[{}]".format(var_name, ",".join(map(str, idx)))
                     data_dict[key] = ser
                 df = pd.DataFrame.from_dict(data_dict, orient="index")
+                df = df.loc[list(data_dict.keys())]
             else:
                 df = values.to_dataframe()
                 df.index = list(df.index)
                 df = df.T
             dfs.append(df)
-        summary_df = pd.concat(dfs)
+        summary_df = pd.concat(dfs, sort=False)
     elif fmt.lower() == "long":
         df = joined.to_dataframe().reset_index().set_index("metric")
         df.index = list(df.index)

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -795,8 +795,8 @@ def summary(
             if len(values.shape[1:]):
                 metric = list(values.metric.values)
                 data_dict = {}
-                for idx in np.ndindex(values.shape[1:] if order else values.shape[1:][::-1]):
-                    if not order:
+                for idx in np.ndindex(values.shape[1:] if order == "C" else values.shape[1:][::-1]):
+                    if order == "F":
                         idx = list(idx)[::-1]
                     ser = pd.Series(values[(Ellipsis, *idx)].values, index=metric)
                     key = "{}[{}]".format(var_name, ",".join(map(str, idx)))

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -121,13 +121,13 @@ def test_summary_unpack_order(order):
     az_summary = summary(data, order=order, fmt="wide")
     assert az_summary is not None
     if order != "F":
-        first_index = 3
-        second_index = 5
-        third_index = 4
-    else:
         first_index = 4
         second_index = 5
         third_index = 3
+    else:
+        first_index = 3
+        second_index = 5
+        third_index = 4
     column_order = []
     for idx1 in range(first_index):
         for idx2 in range(second_index):

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -7,7 +7,7 @@ from scipy.special import logsumexp
 from scipy.stats import linregress
 
 
-from ..data import load_arviz_data
+from ..data import load_arviz_data, from_dict
 from ..stats import bfmi, compare, hpd, loo, r2_score, waic, psislw, summary
 from ..stats.stats import _gpinv, _mc_error, _logsumexp
 
@@ -117,7 +117,7 @@ def test_summary_fmt(centered_eight, fmt):
 
 @pytest.mark.parametrize("order", ["C", "F"])
 def test_summary_unpack_order(order):
-    data = az.from_dict({"a": np.random.randn(4, 100, 4, 5, 3)})
+    data = from_dict({"a": np.random.randn(4, 100, 4, 5, 3)})
     az_summary = summary(data, order=order, fmt="wide")
     assert az_summary is not None
     if order != "F":
@@ -133,9 +133,9 @@ def test_summary_unpack_order(order):
         for idx2 in range(second_index):
             for idx3 in range(third_index):
                 if order != "F":
-                    column_order.append("{}[{},{},{}]".format(idx1, idx2, idx3))
+                    column_order.append("a[{},{},{}]".format(idx1, idx2, idx3))
                 else:
-                    column_order.append("{}[{},{},{}]".format(idx3, idx2, idx1))
+                    column_order.append("a[{},{},{}]".format(idx3, idx2, idx1))
     for col1, col2 in zip(list(az_summary.index), column_order):
         assert col1 == col2
 

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -116,8 +116,28 @@ def test_summary_fmt(centered_eight, fmt):
 
 
 @pytest.mark.parametrize("order", ["C", "F"])
-def test_summary_unpack_order(centered_eight, order):
-    assert summary(centered_eight, order=order) is not None
+def test_summary_unpack_order(order):
+    data = az.from_dict({"a": np.random.randn(4, 100, 4, 5, 3)})
+    az_summary = summary(data, order=order, fmt="wide")
+    assert az_summary is not None
+    if order != "F":
+        first_index = 3
+        second_index = 5
+        third_index = 4
+    else:
+        first_index = 4
+        second_index = 5
+        third_index = 3
+    column_order = []
+    for idx1 in range(first_index):
+        for idx2 in range(second_index):
+            for idx3 in range(third_index):
+                if order != "F":
+                    column_order.append("{}[{},{},{}]".format(idx1, idx2, idx3))
+                else:
+                    column_order.append("{}[{},{},{}]".format(idx3, idx2, idx1))
+    for col1, col2 in zip(list(az_summary.index), column_order):
+        assert col1 == col2
 
 
 def test_summary_stat_func(centered_eight):
@@ -138,18 +158,16 @@ def test_summary_nan(centered_eight):
     )
 
 
-def test_summary_bad_fmt(centered_eight):
+@pytest.mark.parametrize("fmt", [1, "bad_fmt"])
+def test_summary_bad_fmt(centered_eight, fmt):
     with pytest.raises(TypeError):
-        summary(centered_eight, fmt=1)
-    with pytest.raises(TypeError):
-        summary(centered_eight, fmt="bad_fmt")
+        summary(centered_eight, fmt=fmt)
 
 
-def test_summary_bad_unpack_order(centered_eight):
+@pytest.mark.parametrize("order", [1, "bad_order"])
+def test_summary_bad_unpack_order(centered_eight, order):
     with pytest.raises(TypeError):
-        summary(centered_eight, order=1)
-    with pytest.raises(TypeError):
-        summary(centered_eight, order="bad_order")
+        summary(centered_eight, order=order)
 
 
 def test_waic(centered_eight):

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -115,6 +115,11 @@ def test_summary_fmt(centered_eight, fmt):
     assert summary(centered_eight, fmt=fmt) is not None
 
 
+@pytest.mark.parametrize("order", ["C", "F"])
+def test_summary_unpack_order(centered_eight, order):
+    assert summary(centered_eight, order=order) is not None
+
+
 def test_summary_stat_func(centered_eight):
     assert summary(centered_eight, stat_funcs=[np.var]) is not None
 
@@ -135,7 +140,16 @@ def test_summary_nan(centered_eight):
 
 def test_summary_bad_fmt(centered_eight):
     with pytest.raises(TypeError):
+        summary(centered_eight, fmt=1)
+    with pytest.raises(TypeError):
         summary(centered_eight, fmt="bad_fmt")
+
+
+def test_summary_bad_unpack_order(centered_eight):
+    with pytest.raises(TypeError):
+        summary(centered_eight, order=1)
+    with pytest.raises(TypeError):
+        summary(centered_eight, order="bad_order")
 
 
 def test_waic(centered_eight):


### PR DESCRIPTION
Have the opportunity to unpack nD objects (n > 1) against either C-order (iterate last dimension first) or F-order (iterate first dimension first).

Implemented only for "wide" format.