### PR TITLE
fix kde scaling

### DIFF
--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -182,7 +182,7 @@ def plot_kde(
         if cumulative:
             density_q = density
         else:
-            density_q = np.cumsum(density)
+            density_q = density.cumsum() / density.sum()
         fill_func = ax.fill_between
         fill_x, fill_y = x, density
         if rotated:
@@ -274,17 +274,20 @@ def _fast_kde(x, cumulative=False, bw=4.5, xmin=None, xmax=None):
     x = np.asarray(x, dtype=float)
     x = x[np.isfinite(x)]
     len_x = len(x)
+    n_points = 200 if (xmin or xmax) is None else 500
+
     if xmin is None:
         xmin = np.min(x)
     if xmax is None:
         xmax = np.max(x)
 
-    assert np.min(x) <= xmin
-    assert np.max(x) >= xmax
+    assert np.min(x) >= xmin
+    assert np.max(x) <= xmax
 
     std_x = entropy(x - xmin) * bw
 
-    n_bins = min(int(len_x ** (1 / 3) * std_x * 2), 200)
+    n_bins = min(int(len_x ** (1 / 3) * std_x * 2), n_points)
+    d_x = (xmax - xmin) / (n_bins - 1)
     grid = _histogram(x, n_bins, range=(xmin, xmax))
 
     scotts_factor = len_x ** (-0.2)
@@ -294,11 +297,12 @@ def _fast_kde(x, cumulative=False, bw=4.5, xmin=None, xmax=None):
     npad = min(n_bins, 2 * kern_nx)
     grid = np.concatenate([grid[npad:0:-1], grid, grid[n_bins : n_bins - npad : -1]])
     density = convolve(grid, kernel, mode="same", method="direct")[npad : npad + n_bins]
+    norm_factor = len_x * d_x * (2 * np.pi * std_x ** 2 * scotts_factor ** 2) ** 0.5
 
-    density /= np.sum(density)
+    density /= norm_factor
 
     if cumulative:
-        density = np.cumsum(density)
+        density = density.cumsum() / density.sum()
 
     return density, xmin, xmax
 

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -27,8 +27,6 @@ def plot_kde(
     contour_kwargs=None,
     ax=None,
     legend=True,
-    xmin=None,
-    xmax=None,
 ):
     """1D or 2D KDE plot taking into account boundary conditions.
 
@@ -75,10 +73,6 @@ def plot_kde(
     ax : matplotlib axes
     legend : bool
         Add legend to the figure. By default True.
-    xmin : float
-        Manually set lower limit for 1D KDE.
-    xmax : float
-        Manually set upper limit for 1D KDE.
 
     Returns
     -------
@@ -173,7 +167,7 @@ def plot_kde(
         plot_kwargs.setdefault("linewidth", linewidth)
         rug_kwargs.setdefault("markersize", 2 * markersize)
 
-        density, lower, upper = _fast_kde(values, cumulative, bw, xmin=xmin, xmax=xmax)
+        density, lower, upper = _fast_kde(values, cumulative, bw)
 
         rug_space = max(density) * rug_kwargs.pop("space")
 
@@ -288,7 +282,7 @@ def _fast_kde(x, cumulative=False, bw=4.5, xmin=None, xmax=None):
 
     n_bins = min(int(len_x ** (1 / 3) * std_x * 2), n_points)
     d_x = (xmax - xmin) / (n_bins - 1)
-    grid = _histogram(x, n_bins, range=(xmin, xmax))
+    grid = _histogram(x, n_bins, range_hist=(xmin, xmax))
 
     scotts_factor = len_x ** (-0.2)
     kern_nx = int(scotts_factor * 2 * np.pi * std_x)
@@ -308,8 +302,8 @@ def _fast_kde(x, cumulative=False, bw=4.5, xmin=None, xmax=None):
 
 
 @conditional_jit
-def _histogram(x, n_bins, range=None):
-    grid, _ = np.histogram(x, bins=n_bins, range=range)
+def _histogram(x, n_bins, range_hist=None):
+    grid, _ = np.histogram(x, bins=n_bins, range=range_hist)
     return grid
 
 


### PR DESCRIPTION
This fixes #581. Also add tests and add `xmin` and `xmax` arguments to `_fast_kde`. After internal discussion we decided not to add xmin-xmax arguments to `plot_kde`. 