### PR TITLE
Increase loo-results and select scale

### DIFF
--- a/arviz/plots/compareplot.py
+++ b/arviz/plots/compareplot.py
@@ -12,7 +12,7 @@ def plot_compare(
     figsize=None,
     textsize=None,
     plot_kwargs=None,
-    ax=None,
+    ax=None
 ):
     """
     Summary plot for model comparison.
@@ -143,7 +143,7 @@ def plot_compare(
 
     if insample_dev:
         ax.plot(
-            comp_df[information_criterion] - (2 * comp_df["p" + information_criterion]),
+            comp_df[information_criterion] - (2 * comp_df["p_" + information_criterion]),
             yticks_pos[::2],
             color=plot_kwargs.get("color_insample_dev", "k"),
             marker=plot_kwargs.get("marker_insample_dev", "o"),
@@ -158,7 +158,12 @@ def plot_compare(
         lw=linewidth,
     )
 
-    ax.set_xlabel("Deviance", fontsize=ax_labelsize)
+    scale_col = information_criterion + "_scale"
+    if scale_col in comp_df:
+        scale = comp_df[scale_col].iloc[0].capitalize()
+    else:
+        scale = "Deviance"
+    ax.set_xlabel(scale, fontsize=ax_labelsize)
     ax.set_yticklabels(yticks_labels)
     ax.set_ylim(-1 + step, 0 - step)
     ax.tick_params(labelsize=xt_labelsize)

--- a/arviz/plots/compareplot.py
+++ b/arviz/plots/compareplot.py
@@ -12,7 +12,7 @@ def plot_compare(
     figsize=None,
     textsize=None,
     plot_kwargs=None,
-    ax=None
+    ax=None,
 ):
     """
     Summary plot for model comparison.

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -125,7 +125,7 @@ def compare(
         ic_func = waic
         df_comp = pd.DataFrame(
             index=names,
-            columns=["waic", "pwaic", "dwaic", "weight", "se", "dse", "warning", "waic_scale"],
+            columns=["waic", "p_waic", "d_waic", "weight", "se", "dse", "warning", "waic_scale"],
         )
         scale_col = "waic_scale"
 
@@ -133,7 +133,7 @@ def compare(
         ic_func = loo
         df_comp = pd.DataFrame(
             index=names,
-            columns=["loo", "ploo", "dloo", "weight", "se", "dse", "warning", "loo_scale"],
+            columns=["loo", "p_loo", "d_loo", "weight", "se", "dse", "warning", "loo_scale"],
         )
         scale_col = "loo_scale"
 
@@ -398,14 +398,14 @@ def loo(data, pointwise=False, reff=None, scale="deviance"):
 
     Returns
     -------
-    DataFrame with the following columns:
+    pandas.Series with the following columns:
     loo: approximated Leave-one-out cross-validation
     loo_se: standard error of loo
     p_loo: effective number of parameters
     shape_warn: 1 if the estimated shape parameter of
         Pareto distribution is greater than 0.7 for one or more samples
     loo_i: array of pointwise predictive accuracy, only if pointwise True
-    kss: array of Pareto tail indices
+    pareto_k: array of Pareto shape values, only if pointwise True
     loo_scale: scale of the loo results
     """
     inference_data = convert_to_inference_data(data)
@@ -470,7 +470,7 @@ def loo(data, pointwise=False, reff=None, scale="deviance"):
             )
         return pd.Series(
             data=[loo_lppd, loo_lppd_se, p_loo, warn_mg, loo_lppd_i, pareto_shape, scale],
-            index=["loo", "loo_se", "p_loo", "warning", "loo_i", "kss", "loo_scale"],
+            index=["loo", "loo_se", "p_loo", "warning", "loo_i", "pareto_k", "loo_scale"],
         )
 
     else:

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -437,12 +437,12 @@ def loo(data, pointwise=False, reff=None, scale="deviance"):
                           """
             )
         return pd.DataFrame(
-            [[loo_lppd, loo_lppd_se, p_loo, warn_mg, loo_lppd_i]],
-            columns=["loo", "loo_se", "p_loo", "warning", "loo_i"],
+            [[loo_lppd, loo_lppd_se, p_loo, warn_mg, loo_lppd_i, scale]],
+            columns=["loo", "loo_se", "p_loo", "warning", "loo_i", "scale"],
         )
     else:
         return pd.DataFrame(
-            [[loo_lppd, loo_lppd_se, p_loo, warn_mg]], columns=["loo", "loo_se", "p_loo", "warning"]
+            [[loo_lppd, loo_lppd_se, p_loo, scale, warn_mg]], columns=["loo", "loo_se", "p_loo", "scale", "warning"]
         )
 
 
@@ -455,7 +455,7 @@ def psislw(log_weights, reff=1.0):
     log_weights : array
         Array of size (n_samples, n_observations)
     reff : float
-        relative MCMC efficiency, `effective_n / n`
+        relative MCMC efficiency, `ess / n`
 
     Returns
     -------

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -221,7 +221,10 @@ def compare(
         min_ic_i_val = ics[ic_i].iloc[0]
         for idx, val in enumerate(ics.index):
             res = ics.loc[val]
-            diff = res[ic_i] - min_ic_i_val
+            if scale_value < 0:
+                diff = res[ic_i] - min_ic_i_val
+            else:
+                diff = min_ic_i_val - res[ic_i]
             d_ic = np.sum(diff)
             d_std_err = np.sqrt(len(diff) * np.var(diff))
             std_err = ses.loc[val]

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -82,7 +82,7 @@ def compare(
 
         - `deviance` : (default) -2 * (log-score)
         - `log` : 1 * log-score (after Vehtari et al. (2017))
-        - `neglog` : -1 * (log-score)
+        - `negative_log` : -1 * (log-score)
 
     Returns
     -------
@@ -151,7 +151,7 @@ def compare(
 
     if scale.lower() == "log":
         scale_value = 1
-    elif scale.lower() == "neglog":
+    elif scale.lower() == "negative_log":
         scale_value = -1
     else:
         scale_value = -2
@@ -395,7 +395,7 @@ def loo(data, pointwise=False, reff=None, scale="deviance"):
 
         - `deviance` : (default) -2 * (log-score)
         - `log` : 1 * log-score (after Vehtari et al. (2017))
-        - `neglog` : -1 * (log-score)
+        - `negative_log` : -1 * (log-score)
 
     Returns
     -------
@@ -427,10 +427,10 @@ def loo(data, pointwise=False, reff=None, scale="deviance"):
         scale_value = -2
     elif scale.lower() == "log":
         scale_value = 1
-    elif scale.lower() == "neglog":
+    elif scale.lower() == "negative_log":
         scale_value = -1
     else:
-        raise TypeError('Valid scale values are "deviance", "log", "neglog"')
+        raise TypeError('Valid scale values are "deviance", "log", "negative_log"')
 
     if reff is None:
         n_chains = len(posterior.chain)
@@ -944,7 +944,7 @@ def waic(data, pointwise=False, scale="deviance"):
 
         - `deviance` : (default) -2 * (log-score)
         - `log` : 1 * log-score
-        - `neglog` : -1 * (log-score)
+        - `negative_log` : -1 * (log-score)
 
     Returns
     -------
@@ -971,10 +971,10 @@ def waic(data, pointwise=False, scale="deviance"):
         scale_value = -2
     elif scale.lower() == "log":
         scale_value = 1
-    elif scale.lower() == "neglog":
+    elif scale.lower() == "negative_log":
         scale_value = -1
     else:
-        raise TypeError('Valid scale values are "deviance", "log", "neglog"')
+        raise TypeError('Valid scale values are "deviance", "log", "negative_log"')
 
     n_samples = log_likelihood.chain.size * log_likelihood.draw.size
     new_shape = (n_samples,) + log_likelihood.shape[2:]

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -90,7 +90,7 @@ def compare(
     models are passed to this function. The columns are:
     IC : Information Criteria (WAIC or LOO).
         Smaller IC indicates higher out-of-sample predictive fit ("better" model). Default WAIC.
-        If `scale` is `log` higher IC indicates higher out-of-sample predictive fit ("better" model).
+        If `scale == log` higher IC indicates higher out-of-sample predictive fit ("better" model).
     pIC : Estimated effective number of parameters.
     dIC : Relative difference between each IC (WAIC or LOO)
     and the lowest IC (WAIC or LOO).

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -106,6 +106,7 @@ def compare(
         It's always 0 for the top-ranked model.
     warning : A value of 1 indicates that the computation of the IC may not be reliable. This could
         be indication of WAIC/LOO starting to fail see http://arxiv.org/abs/1507.04544 for details.
+    scale : Scale used for the IC.
     """
     names = list(dataset_dict.keys())
 

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -460,7 +460,7 @@ def loo(data, pointwise=False, reff=None, scale="deviance"):
     loo_lppd_se = (len(loo_lppd_i) * np.var(loo_lppd_i)) ** 0.5
 
     lppd = np.sum(_logsumexp(log_likelihood, axis=0, b_inv=log_likelihood.shape[0]))
-    p_loo = lppd - loo_lppd/scale_value
+    p_loo = lppd - loo_lppd / scale_value
 
     if pointwise:
         if np.equal(loo_lppd, loo_lppd_i).all():
@@ -470,15 +470,15 @@ def loo(data, pointwise=False, reff=None, scale="deviance"):
                           """
             )
         return pd.Series(
-                    data=[loo_lppd, loo_lppd_se, p_loo, warn_mg, loo_lppd_i, pareto_shape, scale],
-                    index=["loo", "loo_se", "p_loo", "warning", "loo_i", "kss", "loo_scale"],
-                )
+            data=[loo_lppd, loo_lppd_se, p_loo, warn_mg, loo_lppd_i, pareto_shape, scale],
+            index=["loo", "loo_se", "p_loo", "warning", "loo_i", "kss", "loo_scale"],
+        )
 
     else:
         return pd.Series(
-                    data=[loo_lppd, loo_lppd_se, p_loo, warn_mg, scale],
-                    index=["loo", "loo_se", "p_loo", "warning", "loo_scale"]
-                )
+            data=[loo_lppd, loo_lppd_se, p_loo, warn_mg, scale],
+            index=["loo", "loo_se", "p_loo", "warning", "loo_scale"],
+        )
 
 
 def psislw(log_weights, reff=1.0):
@@ -535,7 +535,7 @@ def psislw(log_weights, reff=1.0):
             if k >= k_min:
                 # no smoothing if short tail or GPD fit failed
                 # compute ordered statistic for the fit
-                sti = np.arange(0.5, tail_len)/tail_len
+                sti = np.arange(0.5, tail_len) / tail_len
                 smoothed_tail = _gpinv(sti, k, sigma)
                 smoothed_tail = np.log(  # pylint: disable=assignment-from-no-return
                     smoothed_tail + expxcutoff

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 """Statistical functions in ArviZ."""
 import warnings
 from collections.abc import Sequence

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -640,6 +640,17 @@ def test_plot_compare(models, kwargs):
     assert axes
 
 
+def test_plot_compare_manual(models):
+    """Test compare plot without scale column"""
+    # Pymc3 models create loglikelihood on InferenceData automatically
+    model_compare = compare({"Pymc3": models.pymc3_fit, "Pymc3_Again": models.pymc3_fit})
+
+    # remove "scale" column
+    del model_compare["waic_scale"]
+    axes = plot_compare(model_compare)
+    assert axes
+
+
 def test_plot_compare_no_ic(models):
     """Check exception is raised if model_compare doesn't contain a valid information criterion"""
     model_compare = compare({"Pymc3": models.pymc3_fit, "Pymc3_Again": models.pymc3_fit})

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -159,7 +159,7 @@ def test_waic_bad(centered_eight):
 
 
 def test_waic_bad_scale(centered_eight):
-    """Test widely available information criterion calculation"""
+    """Test widely available information criterion calculation with bad scale."""
     with pytest.raises(TypeError):
         waic(centered_eight, scale="bad_value")
 
@@ -188,6 +188,7 @@ def test_loo_one_chain(centered_eight):
 
 @pytest.mark.parametrize("scale", ["deviance", "log", "negative_log"])
 def test_loo_pointwise(centered_eight, scale):
+    """Test pointwise loo with different scales."""
     loo_results = loo(centered_eight, scale=scale, pointwise=True)
     assert loo_results is not None
     assert hasattr(loo_results, "loo_scale")
@@ -206,6 +207,7 @@ def test_loo_bad(centered_eight):
 
 
 def test_loo_bad_scale(centered_eight):
+    """Test loo with bad scale value."""
     with pytest.raises(TypeError):
         loo(centered_eight, scale="bad_scale")
 

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -76,7 +76,7 @@ def test_compare_unknown_ic_and_method(centered_eight, non_centered_eight):
 
 @pytest.mark.parametrize("ic", ["waic", "loo"])
 @pytest.mark.parametrize("method", ["stacking", "BB-pseudo-BMA", "pseudo-BMA"])
-@pytest.mark.parametrize("scale", ["deviance", "log", "neglog"])
+@pytest.mark.parametrize("scale", ["deviance", "log", "negative_log"])
 def test_compare_different(centered_eight, non_centered_eight, ic, method, scale):
     model_dict = {"centered": centered_eight, "non_centered": non_centered_eight}
     weight = compare(model_dict, ic=ic, method=method, scale=scale)["weight"]
@@ -139,7 +139,7 @@ def test_summary_bad_fmt(centered_eight):
         summary(centered_eight, fmt="bad_fmt")
 
 
-@pytest.mark.parametrize("scale", ["deviance", "log", "neglog"])
+@pytest.mark.parametrize("scale", ["deviance", "log", "negative_log"])
 def test_waic(centered_eight, scale):
     """Test widely available information criterion calculation"""
     assert waic(centered_eight, scale=scale) is not None
@@ -186,7 +186,7 @@ def test_loo_one_chain(centered_eight):
     assert loo(centered_eight) is not None
 
 
-@pytest.mark.parametrize("scale", ["deviance", "log", "neglog"])
+@pytest.mark.parametrize("scale", ["deviance", "log", "negative_log"])
 def test_loo_pointwise(centered_eight, scale):
     loo_results = loo(centered_eight, scale=scale, pointwise=True)
     assert loo_results is not None


### PR DESCRIPTION
This PR gives three options for scaling

- `deviation` (default) = -2
- `log` (following Vehtari et al.) = 1
- `neglog` = -1

This also adds `loo_scale`/`waic_scale` column for the results.

I also added `kss` if user wants elementwise results. This makes it easier to use `kss`.