### PR TITLE
Addressing issue number #470 (using plot_kde with inference data object) 

### DIFF
--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -148,7 +148,11 @@ def plot_kde(
     figsize, *_, xt_labelsize, linewidth, markersize = _scale_fig_size(figsize, textsize, 1, 1)
 
     if isinstance(values, xr.Dataset):
-        raise ValueError("Xarray dataset object detected. Use plot_posterior instead of plot_kde")
+        raise ValueError(
+            "Xarray dataset object detected. Use plot_posterior, plot_denstiy, plot_joint or plot_pair  "
+            "instead of "
+            "plot_kde"
+        )
     if isinstance(values, InferenceData):
         raise ValueError(" Inference Data object detected. Use plot_posterior instead of plot_kde")
     if values2 is None:

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -4,7 +4,8 @@ import matplotlib.pyplot as plt
 from scipy.signal import gaussian, convolve, convolve2d  # pylint: disable=no-name-in-module
 from scipy.sparse import coo_matrix
 from scipy.stats import entropy
-
+import xarray as xr
+from ..data.inference_data import InferenceData
 from ..utils import conditional_jit
 from .plot_utils import _scale_fig_size
 
@@ -146,6 +147,10 @@ def plot_kde(
 
     figsize, *_, xt_labelsize, linewidth, markersize = _scale_fig_size(figsize, textsize, 1, 1)
 
+    if isinstance(values, xr.Dataset):
+        raise ValueError("Xarray dataset object detected. Use plot_posterior instead of plot_kde")
+    if isinstance(values, InferenceData):
+        raise ValueError(" Inference Data object detected. Use plot_posterior instead of plot_kde")
     if values2 is None:
         if plot_kwargs is None:
             plot_kwargs = {}

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -149,9 +149,8 @@ def plot_kde(
 
     if isinstance(values, xr.Dataset):
         raise ValueError(
-            "Xarray dataset object detected.Use plot_posterior,plot_denstiy,plot_joint or plot_pair"
-            "instead of "
-            "plot_kde"
+            "Xarray dataset object detected.Use plot_posterior, plot_density, plot_joint"
+            "or plot_pair instead of plot_kde"
         )
     if isinstance(values, InferenceData):
         raise ValueError(" Inference Data object detected. Use plot_posterior instead of plot_kde")

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -149,10 +149,11 @@ def plot_kde(
 
     if isinstance(values, xr.Dataset):
         raise ValueError(
-            "Xarray dataset object detected. Use plot_posterior, plot_denstiy, plot_joint or plot_pair  "
+            "Xarray dataset object detected.Use plot_posterior,plot_denstiy,plot_joint or plot_pair"
             "instead of "
             "plot_kde"
         )
+        raise ValueError("Xarray dataset object detected. Use plot_posterior instead of plot_kde")
     if isinstance(values, InferenceData):
         raise ValueError(" Inference Data object detected. Use plot_posterior instead of plot_kde")
     if values2 is None:

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -153,7 +153,6 @@ def plot_kde(
             "instead of "
             "plot_kde"
         )
-        raise ValueError("Xarray dataset object detected. Use plot_posterior instead of plot_kde")
     if isinstance(values, InferenceData):
         raise ValueError(" Inference Data object detected. Use plot_posterior instead of plot_kde")
     if values2 is None:

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -358,6 +358,7 @@ def _plot_posterior_op(
             fill_kwargs={"alpha": kwargs.pop("fill_alpha", 0)},
             plot_kwargs={"linewidth": linewidth},
             ax=ax,
+            rug=True,
         )
     else:
         if bins is None:

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -358,7 +358,7 @@ def _plot_posterior_op(
             fill_kwargs={"alpha": kwargs.pop("fill_alpha", 0)},
             plot_kwargs={"linewidth": linewidth},
             ax=ax,
-            rug=True,
+            rug=False,
         )
     else:
         if bins is None:

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -6,7 +6,7 @@ from scipy.stats import gaussian_kde
 import numpy as np
 import pytest
 import pymc3 as pm
-
+import arviz as az
 
 from ..data import from_dict, from_pymc3
 from ..stats import compare, psislw
@@ -311,6 +311,14 @@ def test_plot_dist_2d_kde(continuous_model, kwargs):
 def test_plot_kde_quantiles(continuous_model, kwargs):
     axes = plot_kde(continuous_model["x"], **kwargs)
     assert axes
+
+
+def test_plot_kde_inference_data():
+    eight = az.load_arviz_data("centered_eight")
+    with pytest.raises(ValueError, match="Inference Data"):
+        plot_kde(eight)
+    with pytest.raises(ValueError, match="Xarray"):
+        plot_kde(eight.posterior)
 
 
 def test_plot_khat():

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -6,8 +6,8 @@ from scipy.stats import gaussian_kde
 import numpy as np
 import pytest
 import pymc3 as pm
-import arviz as az
 
+from ..data import load_arviz_data
 from ..data import from_dict, from_pymc3
 from ..stats import compare, psislw
 from .helpers import eight_schools_params, load_cached_models  # pylint: disable=unused-import
@@ -314,7 +314,7 @@ def test_plot_kde_quantiles(continuous_model, kwargs):
 
 
 def test_plot_kde_inference_data():
-    eight = az.load_arviz_data("centered_eight")
+    eight = load_arviz_data("centered_eight")
     with pytest.raises(ValueError, match="Inference Data"):
         plot_kde(eight)
     with pytest.raises(ValueError, match="Xarray"):

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -314,11 +314,7 @@ def test_plot_kde_quantiles(continuous_model, kwargs):
 
 
 def test_plot_kde_inference_data():
-<<<<<<< HEAD
     eight = load_arviz_data("centered_eight")
-=======
-    eight = az.load_arviz_data("centered_eight")
->>>>>>> Added the test
     with pytest.raises(ValueError, match="Inference Data"):
         plot_kde(eight)
     with pytest.raises(ValueError, match="Xarray"):

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -7,8 +7,7 @@ import numpy as np
 import pytest
 import pymc3 as pm
 
-from ..data import load_arviz_data
-from ..data import from_dict, from_pymc3
+from ..data import from_dict, from_pymc3, load_arviz_data
 from ..stats import compare, psislw
 from .helpers import eight_schools_params, load_cached_models  # pylint: disable=unused-import
 from ..plots import (
@@ -314,6 +313,10 @@ def test_plot_kde_quantiles(continuous_model, kwargs):
 
 
 def test_plot_kde_inference_data():
+    """
+    Ensure that an exception is raised when plot_kde
+    is used with an inference data or Xarray dataset object.
+    """
     eight = load_arviz_data("centered_eight")
     with pytest.raises(ValueError, match="Inference Data"):
         plot_kde(eight)

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -314,7 +314,11 @@ def test_plot_kde_quantiles(continuous_model, kwargs):
 
 
 def test_plot_kde_inference_data():
+<<<<<<< HEAD
     eight = load_arviz_data("centered_eight")
+=======
+    eight = az.load_arviz_data("centered_eight")
+>>>>>>> Added the test
     with pytest.raises(ValueError, match="Inference Data"):
         plot_kde(eight)
     with pytest.raises(ValueError, match="Xarray"):


### PR DESCRIPTION
Made the following changes:
 * Using inference data or xr.dataset with plot_kde now raises an error prompting the user to use plot_posterior instead.
 * Rug plots displayed by default for plot_posterior plots.
 * Not included the tests yet.