### PR TITLE
kde warning and empty plot

### DIFF
--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -1,4 +1,5 @@
 """One-dimensional kernel density estimate plots."""
+import warnings
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy.signal import gaussian, convolve, convolve2d  # pylint: disable=no-name-in-module
@@ -154,6 +155,7 @@ def plot_kde(
         )
     if isinstance(values, InferenceData):
         raise ValueError(" Inference Data object detected. Use plot_posterior instead of plot_kde")
+
     if values2 is None:
         if plot_kwargs is None:
             plot_kwargs = {}
@@ -275,6 +277,10 @@ def _fast_kde(x, cumulative=False, bw=4.5, xmin=None, xmax=None):
     """
     x = np.asarray(x, dtype=float)
     x = x[np.isfinite(x)]
+    if x.size == 0:
+        warnings.warn("kde plot failed, you may want to check your data")
+        return np.array([np.nan]), np.nan, np.nan
+
     len_x = len(x)
     n_points = 200 if (xmin or xmax) is None else 500
 
@@ -289,6 +295,10 @@ def _fast_kde(x, cumulative=False, bw=4.5, xmin=None, xmax=None):
     std_x = entropy(x - xmin) * bw
 
     n_bins = min(int(len_x ** (1 / 3) * std_x * 2), n_points)
+    if n_bins < 2:
+        warnings.warn("kde plot failed, you may want to check your data")
+        return np.array([np.nan]), np.nan, np.nan
+
     d_x = (xmax - xmin) / (n_bins - 1)
     grid = _histogram(x, n_bins, range_hist=(xmin, xmax))
 


### PR DESCRIPTION
Currently `plot_kde` fails if all the elements of the input array are `nan` or `inf` or exactly the same number, or for very short array (less than 3 or so). Functions like `plot_trace` will fail for those cases too, and only variables before the failing point will be plotted.

With this PR if `plot_kde` fails (at least for the cases mentioned before.) we get an empty plot and a warning message.