### PR TITLE
Update Docker instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,22 +182,24 @@ tools:
 ## Developing in Docker
 
 We have provided a Dockerfile which helps for isolating build problems, and local development.
-Install [Docker](https://www.docker.com/) for your operating system, clone this repo, then
-run `./scripts/container.sh --build` (you may need root privileges). This should start a local docker image called `arviz`. 
-The repo will be running the code from your local copy of `arviz`, so it is good for development.
+Install [Docker](https://www.docker.com/) for your operating system, clone this repo. Docker will generate an environment with your local copy of `arviz` with all the packages in Dockerfile.
 
-Afterwards, you can start a container form the image with `docker run -it -p 8888:8888 arviz`, which will open an interactive bash shell. This can be used to run code inside the docker, with the packages listed in the Dockerfile. For instance, to open a terminal, type `jupyter notebook --ip 0.0.0.0 --no-browser --allow-root` inside the docker container. This will output something similar to `http://(<docker container id> or <ip>):8888/?token=<token id>`, and can be accessed at `http://localhost:8888/?token=<token id>`.
+### Testing in Docker
+Testing the code using docker consists of executing the same file 3 times (you may need root privileges to run it). First run `./scripts/container.sh --build`. This starts a local docker image called `arviz`. Then run `./scripts/container.sh --clear-cache` and eventually, run the tests in a container with the built image with `./scripts/container.sh --test`. This should be quite close to how the tests run on TravisCI.
 
-Or to run the tests instead, type `pytest -v arviz/tests/ --cov=arviz/` also inside the docker container.
+### Using the Docker image interactively
+Once the Docker image is built with `./scripts/container.sh --build`, interactive containers can also be run. 
 
-This should be quite close to how the tests run on TravisCI.
+To start a bash shell inside Docker, run:
 
-If the container was started without opening the browser, you
-need the notebook instances token to work with the notebook. This token can be
-accessed with
+    $ docker run -it arviz bash
 
-```
-docker exec -it arviz jupyter notebook list
-```
+To start a jupyter notebook, there are two steps, first run:
+
+    $ docker run --name jupyter-dock -it -d -p 8888:8888 arviz
+    $ docker exec -it jupyter-dock pip install jupyter
+    $ docker exec -it jupyter-dock jupyter notebook --ip 0.0.0.0 --no-browser --allow-root
+
+This will output something similar to `http://(<docker container id> or <ip>):8888/?token=<token id>`, and can be accessed at `http://localhost:8888/?token=<token id>`.
 
 #### This guide was derived from the [scikit-learn guide to contributing](https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,7 +185,8 @@ We have provided a Dockerfile which helps for isolating build problems, and loca
 Install [Docker](https://www.docker.com/) for your operating system, clone this repo. Docker will generate an environment with your local copy of `arviz` with all the packages in Dockerfile.
 
 ### Testing in Docker
-Testing the code using docker consists of executing the same file 3 times (you may need root privileges to run it). First run `./scripts/container.sh --build`. This starts a local docker image called `arviz`. Then run `./scripts/container.sh --clear-cache` and eventually run the tests with `./scripts/container.sh --test`. This should be quite close to how the tests run on TravisCI.
+Testing the code using docker consists of executing the same file 3 times (you may need root privileges to run it). 
+First run `./scripts/container.sh --clear-cache`. Then run `./scripts/container.sh --build`. This starts a local docker image called `arviz`. Finally run the tests with `./scripts/container.sh --test`. This should be quite close to how the tests run on TravisCI.
 
 ### Using the Docker image interactively
 Once the Docker image is built with `./scripts/container.sh --build`, interactive containers can also be run. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,7 +185,7 @@ We have provided a Dockerfile which helps for isolating build problems, and loca
 Install [Docker](https://www.docker.com/) for your operating system, clone this repo. Docker will generate an environment with your local copy of `arviz` with all the packages in Dockerfile.
 
 ### Testing in Docker
-Testing the code using docker consists of executing the same file 3 times (you may need root privileges to run it). First run `./scripts/container.sh --build`. This starts a local docker image called `arviz`. Then run `./scripts/container.sh --clear-cache` and eventually, run the tests in a container with the built image with `./scripts/container.sh --test`. This should be quite close to how the tests run on TravisCI.
+Testing the code using docker consists of executing the same file 3 times (you may need root privileges to run it). First run `./scripts/container.sh --build`. This starts a local docker image called `arviz`. Then run `./scripts/container.sh --clear-cache` and eventually run the tests with `./scripts/container.sh --test`. This should be quite close to how the tests run on TravisCI.
 
 ### Using the Docker image interactively
 Once the Docker image is built with `./scripts/container.sh --build`, interactive containers can also be run. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,19 +183,12 @@ tools:
 
 We have provided a Dockerfile which helps for isolating build problems, and local development.
 Install [Docker](https://www.docker.com/) for your operating system, clone this repo, then
-run `./scripts/start_container.sh`. This should start a local docker container called `arviz`,
-as well as a [`jupyter`](http://jupyter.org/) notebook server running on port 8888. The
-notebook should be opened in your browser automatically (you can disable this by passing
-`--no-browser`). The repo will be running the code from your local copy of `arviz`,
-so it is good for development.
+run `./scripts/container.sh --build` (you may need root privileges). This should start a local docker image called `arviz`. 
+The repo will be running the code from your local copy of `arviz`, so it is good for development.
 
-You may also use it to run the test suite, with
+Afterwards, you can start a container form the image with `docker run -it -p 8888:8888 arviz`, which will open an interactive bash shell. This can be used to run code inside the docker, with the packages listed in the Dockerfile. For instance, to open a terminal, type `jupyter notebook --ip 0.0.0.0 --no-browser --allow-root` inside the docker container. This will output something similar to `http://(<docker container id> or <ip>):8888/?token=<token id>`, and can be accessed at `http://localhost:8888/?token=<token id>`.
 
-```bash
-$  docker exec -it arviz  bash # logon to the container
-$  cd ~/arviz
-$  . ./scripts/test.sh # takes a while!
-```
+Or to run the tests instead, type `pytest -v arviz/tests/ --cov=arviz/` also inside the docker container.
 
 This should be quite close to how the tests run on TravisCI.
 


### PR DESCRIPTION
I am no docker expert, but as I am trying to develop and test arviz using it, I think it will be useful to update the instructions with the things I have had to do different from what is written. 

I updated some filenames which were incorrect, and some basic instructions on how to run a notebook. `jupyter` is not installed by default in the docker image, therefore one of the steps is installing it, however, the docker image could also be modified.

Related to #421.


