### PR TITLE
Added orderedDict to forestplot

### DIFF
--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -39,7 +39,7 @@ def plot_forest(
     ridgeplot_overlap=2,
     figsize=None,
 ):
-    """Forest plot to compare credible intervals from a number of distributions, generates a forest plot of 100*(credible_interval)% credible intervals from a trace or list of traces.
+    """Forest plot to compare credible intervals from a number of distributions. Generates a forest plot of 100*(credible_interval)% credible intervals from a trace or list of traces.
 
     Parameters
     ----------

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -571,4 +571,4 @@ class VarHandler:
         if self.combined:
             end_y += self.group_offset
 
-return end_y + 2 * self.group_offset
+    return end_y + 2 * self.group_offset

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -494,7 +494,7 @@ class VarHandler:
                 for _, selection, values in datum_iter:
                     label = make_label(self.var_name, selection, position="beside")
                     if label not in label_dict:
-                        label_dict[label] = {}
+                        label_dict[label] = OrderedDict()
                     if name not in label_dict[label]:
                         label_dict[label][name] = []
                     label_dict[label][name].append(values)

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -245,7 +245,10 @@ class PlotHandler:
         self.model_names = list(reversed(model_names))  # y-values are upside down
 
         if var_names is None:
-            self.var_names = list(reversed(*[OrderedDict(datum.data_vars) for datum in self.data]))
+            if len(self.data) > 1:
+                self.var_names = list(set().union(*[OrderedDict(datum.data_vars) for datum in self.data]))
+            else:
+                self.var_names = list(reversed(*[OrderedDict(datum.data_vars) for datum in self.data]))
         else:
             self.var_names = list(reversed(var_names))  # y-values are upside down
 

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -40,7 +40,7 @@ def plot_forest(
     figsize=None,
 ):
     """Forest plot to compare credible intervals from a number of distributions.
-    
+
     Generates a forest plot of 100*(credible_interval)% credible intervals from
     a trace or list of traces.
 

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -39,9 +39,8 @@ def plot_forest(
     ridgeplot_overlap=2,
     figsize=None,
 ):
-    """Forest plot to compare credible intervals from a number of distributions.
-    Generates a forest plot of 100*(credible_interval)% credible intervals from
-    a trace or list of traces.
+    """Forest plot to compare credible intervals from a number of distributions, generates a forest plot of 100*(credible_interval)% credible intervals from a trace or list of traces.
+
     Parameters
     ----------
     data : obj or list[obj]
@@ -90,6 +89,7 @@ def plot_forest(
         Overlap height for ridgeplots.
     figsize : tuple
         Figure size. If None it will be defined automatically.
+
     Returns
     -------
     gridspec : matplotlib GridSpec
@@ -298,6 +298,7 @@ class PlotHandler:
 
     def ridgeplot(self, mult, linewidth, alpha, ax):
         """Draw ridgeplot for each plotter.
+
         Parameters
         ----------
         mult : float
@@ -328,6 +329,7 @@ class PlotHandler:
         self, credible_interval, quartiles, xt_labelsize, titlesize, linewidth, markersize, ax, rope
     ):
         """Draw forestplot for each plotter.
+
         Parameters
         ----------
         credible_interval : float

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -1,5 +1,5 @@
 """Forest plot."""
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from itertools import tee
 
 import numpy as np
@@ -245,7 +245,7 @@ class PlotHandler:
         self.model_names = list(reversed(model_names))  # y-values are upside down
 
         if var_names is None:
-            self.var_names = list(set.union(*[set(datum.data_vars) for datum in self.data]))
+            self.var_names = list(reversed(*[OrderedDict(datum.data_vars) for datum in self.data]))
         else:
             self.var_names = list(reversed(var_names))  # y-values are upside down
 
@@ -484,7 +484,7 @@ class VarHandler:
             grouped_data = [datum.groupby("chain") for datum in self.data]
             skip_dims = set()
 
-        label_dict = {}
+        label_dict = OrderedDict()
         for name, grouped_datum in zip(self.model_names, grouped_data):
             for _, sub_data in grouped_datum:
                 datum_iter = xarray_var_iter(

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -40,10 +40,8 @@ def plot_forest(
     figsize=None,
 ):
     """Forest plot to compare credible intervals from a number of distributions.
-
     Generates a forest plot of 100*(credible_interval)% credible intervals from
     a trace or list of traces.
-
     Parameters
     ----------
     data : obj or list[obj]
@@ -92,18 +90,14 @@ def plot_forest(
         Overlap height for ridgeplots.
     figsize : tuple
         Figure size. If None it will be defined automatically.
-
     Returns
     -------
     gridspec : matplotlib GridSpec
-
     Examples
     --------
     Forestpĺot
-
     .. plot::
         :context: close-figs
-
         >>> import arviz as az
         >>> non_centered_data = az.load_arviz_data('non_centered_eight')
         >>> fig, axes = az.plot_forest(non_centered_data,
@@ -113,12 +107,9 @@ def plot_forest(
         >>>                            ridgeplot_overlap=3,
         >>>                            figsize=(9, 7))
         >>> axes[0].set_title('Estimated theta for 8 schools model')
-
     Ridgeplot
-
     .. plot::
         :context: close-figs
-
         >>> fig, axes = az.plot_forest(non_centered_data,
         >>>                            kind='ridgeplot',
         >>>                            var_names=['theta'],
@@ -246,9 +237,13 @@ class PlotHandler:
 
         if var_names is None:
             if len(self.data) > 1:
-                self.var_names = list(set().union(*[OrderedDict(datum.data_vars) for datum in self.data]))
+                self.var_names = list(
+                    set().union(*[OrderedDict(datum.data_vars) for datum in self.data])
+                )
             else:
-                self.var_names = list(reversed(*[OrderedDict(datum.data_vars) for datum in self.data]))
+                self.var_names = list(
+                    reversed(*[OrderedDict(datum.data_vars) for datum in self.data])
+                )
         else:
             self.var_names = list(reversed(var_names))  # y-values are upside down
 
@@ -303,7 +298,6 @@ class PlotHandler:
 
     def ridgeplot(self, mult, linewidth, alpha, ax):
         """Draw ridgeplot for each plotter.
-
         Parameters
         ----------
         mult : float
@@ -334,7 +328,6 @@ class PlotHandler:
         self, credible_interval, quartiles, xt_labelsize, titlesize, linewidth, markersize, ax, rope
     ):
         """Draw forestplot for each plotter.
-
         Parameters
         ----------
         credible_interval : float
@@ -578,4 +571,4 @@ class VarHandler:
         if self.combined:
             end_y += self.group_offset
 
-        return end_y + 2 * self.group_offset
+return end_y + 2 * self.group_offset

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -39,7 +39,10 @@ def plot_forest(
     ridgeplot_overlap=2,
     figsize=None,
 ):
-    """Forest plot to compare credible intervals from a number of distributions. Generates a forest plot of 100*(credible_interval)% credible intervals from a trace or list of traces.
+    """Forest plot to compare credible intervals from a number of distributions.
+    
+    Generates a forest plot of 100*(credible_interval)% credible intervals from
+    a trace or list of traces.
 
     Parameters
     ----------

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -571,4 +571,4 @@ class VarHandler:
         if self.combined:
             end_y += self.group_offset
 
-    return end_y + 2 * self.group_offset
+        return end_y + 2 * self.group_offset


### PR DESCRIPTION
I added OrderedDict module from collections to keep the structure of the InferenceData object. This applies to both the variable names and the dimensions within the variable names. Fixes #613