### PR TITLE
Helper method for tests

### DIFF
--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -38,33 +38,33 @@ def eight_schools_params():
     }
 
 
-def check_multiple_attrs(objs, attrs, parent=None):
-    """Perform multiple hasattr checks.
+def check_multiple_attrs(test_dict, parent):
+    """Perform multiple hasattr checks on InferenceData objects. It is thought to first check
+    if the parent object contains a given dataset, and then (if present) check the attributes
+    of the dataset.
 
     Args
     ----
-    objs: iterable
-        Iterable containing the objects whose attributes should be checked
-    attrs: iterable
-        Iterable containing the names of the attributes to be checked.
-    parent: obj
-        Parent object of the objs, if present, check the attributes of parent.<obj>
+    test_dict: dict
+        Its structure should be `{dataset1_name: [var1, var2], dataset2_name: [var]}`
+    parent: InferenceData
+        InferenceData object on which to check the attributes.
 
     Returns
     -------
     list
-        List containing the tuples (obj, attr) that failed
+        List containing the failed checks. It will contain either the dataset_name or a
+        tuple (dataset_name, var) for all non present attributes.
     """
     failed_attrs = []
-    if parent:
-        for check_obj, check_attr in zip(objs, attrs):
-            check_obj = getattr(parent, check_obj) if check_obj else parent
-            if not hasattr(check_obj, check_attr):
-                failed_attrs.append((check_obj, check_attr))
-    else:
-        for check_obj, check_attr in zip(objs, attrs):
-            if not hasattr(check_obj, check_attr):
-                failed_attrs.append((check_obj, check_attr))
+    for dataset_name, attributes in test_dict.items():
+        if hasattr(parent, dataset_name):
+            dataset = getattr(parent, dataset_name)
+            for attribute in attributes:
+                if not hasattr(dataset, attribute):
+                    failed_attrs.append((dataset_name, attribute))
+        else:
+            failed_attrs.append(dataset_name)
     return failed_attrs
 
 

--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -38,6 +38,36 @@ def eight_schools_params():
     }
 
 
+def check_multiple_attrs(objs, attrs, parent=None):
+    """Perform multiple hasattr checks.
+
+    Args
+    ----
+    objs: iterable
+        Iterable containing the objects whose attributes should be checked
+    attrs: iterable
+        Iterable containing the names of the attributes to be checked.
+    parent: obj
+        Parent object of the objs, if present, check the attributes of parent.<obj>
+
+    Returns
+    -------
+    list
+        List containing the tuples (obj, attr) that failed
+    """
+    failed_attrs = []
+    if parent:
+        for check_obj, check_attr in zip(objs, attrs):
+            check_obj = getattr(parent, check_obj) if check_obj else parent
+            if not hasattr(check_obj, check_attr):
+                failed_attrs.append((check_obj, check_attr))
+    else:
+        for check_obj, check_attr in zip(objs, attrs):
+            if not hasattr(check_obj, check_attr):
+                failed_attrs.append((check_obj, check_attr))
+    return failed_attrs
+
+
 def emcee_version():
     """Check emcee version.
 

--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -39,9 +39,10 @@ def eight_schools_params():
 
 
 def check_multiple_attrs(test_dict, parent):
-    """Perform multiple hasattr checks on InferenceData objects. It is thought to first check
-    if the parent object contains a given dataset, and then (if present) check the attributes
-    of the dataset.
+    """Perform multiple hasattr checks on InferenceData objects.
+
+    It is thought to first check if the parent object contains a given dataset,
+    and then (if present) check the attributes of the dataset.
 
     Args
     ----

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -525,7 +525,7 @@ class TestDictIONetCDFUtils:
             "posterior_predictive": [],
             "prior_predictive": [],
             "sample_stats_prior": [],
-            "observed_data": [],
+            "observed_data": ["J", "y", "sigma"],
         }
         fails = check_multiple_attrs(test_dict, inference_data)
         assert not fails
@@ -760,7 +760,7 @@ class TestPyMC3NetCDFUtils:
             pm.Normal("y2", x, 1, observed=y2_data)
             trace = pm.sample(100, chains=2)
         inference_data = from_pymc3(trace=trace)
-        test_dict = {"posterior": ["x"], "observed_data": ["y1", "y2"]}
+        test_dict = {"posterior": ["x"], "observed_data": ["y1", "y2"], "sample_stats": ["lp"]}
         fails = check_multiple_attrs(test_dict, inference_data)
         assert not fails
         assert not hasattr(inference_data.sample_stats, "log_likelihood")
@@ -942,7 +942,7 @@ class TestPyStanNetCDFUtils:
             model = StanModel(model_code=model_code)
             fit = model.sampling(iter=10, chains=2, check_hmc_diagnostics=False)
             posterior = from_pystan(posterior=fit)
-            test_dict = {"posterior": ["y", "z"]}
+            test_dict = {"posterior": ["y"], "sample_stats": ["lp"]}
             fails = check_multiple_attrs(test_dict, posterior)
             assert not fails
 
@@ -1316,12 +1316,12 @@ class TestCmdStanNetCDFUtils:
                 dims={"x": ["rand"]},
             )
             test_dict = {
-                "posterior": [],
-                "prior": [],
-                "prior_predictive": [],
-                "sample_stats": [],
-                "sample_stats_prior": [],
-                "posterior_predictive": [],
+                "posterior": ["x", "y", "Z"],
+                "prior": ["x", "y", "Z"],
+                "prior_predictive": ["x", "y", "Z"],
+                "sample_stats": ["lp"],
+                "sample_stats_prior": ["lp"],
+                "posterior_predictive": ["x", "y", "Z"],
             }
             fails = check_multiple_attrs(test_dict, inference_data)
             assert not fails
@@ -1357,7 +1357,7 @@ class TestCmdStanNetCDFUtils:
                 "prior": ["mu", "tau", "theta_tilde", "theta"],
                 "sample_stats": ["log_likelihood"],
                 "observed_data": ["y"],
-                "sample_stats_prior": [],
+                "sample_stats_prior": ["lp"],
             }
             fails = check_multiple_attrs(test_dict, inference_data)
             assert not fails

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -179,7 +179,7 @@ def test_addition():
     assert new_idata is not None
     test_dict = {"posterior": ["A", "B"], "prior": ["C", "D"]}
     fails = check_multiple_attrs(test_dict, new_idata)
-    assert len(fails) == 0
+    assert not fails
 
 
 @pytest.mark.parametrize("copy", [True, False])
@@ -203,15 +203,9 @@ def test_concat(copy, inplace, sequence):
         assert new_idata is None
         new_idata = idata1
     assert new_idata is not None
-    assert hasattr(new_idata, "posterior")
-    assert hasattr(new_idata, "prior")
-    assert hasattr(new_idata, "observed_data")
-    assert hasattr(new_idata.posterior, "A")
-    assert hasattr(new_idata.posterior, "B")
-    assert hasattr(new_idata.prior, "C")
-    assert hasattr(new_idata.prior, "D")
-    assert hasattr(new_idata.observed_data, "E")
-    assert hasattr(new_idata.observed_data, "F")
+    test_dict = {"posterior": ["A", "B"], "prior": ["C", "D"], "observed_data": ["E", "F"]}
+    fails = check_multiple_attrs(test_dict, new_idata)
+    assert not fails
     if copy:
         if inplace:
             assert id(new_idata.posterior) == original_idata1_posterior_id
@@ -241,9 +235,9 @@ def test_concat_edgecases(copy, inplace, sequence):
         new_idata = idata
     else:
         assert new_idata is not None
-    assert hasattr(new_idata, "posterior")
-    assert hasattr(new_idata.posterior, "A")
-    assert hasattr(new_idata.posterior, "B")
+    test_dict = {"posterior": ["A", "B"]}
+    fails = check_multiple_attrs(test_dict, new_idata)
+    assert not fails
     if copy and not inplace:
         assert id(new_idata.posterior) != id(idata.posterior)
     else:
@@ -524,13 +518,17 @@ class TestDictIONetCDFUtils:
 
     def test_inference_data(self, data, eight_schools_params):
         inference_data = self.get_inference_data(data, eight_schools_params)
-        assert hasattr(inference_data, "posterior")
-        assert hasattr(inference_data, "posterior_predictive")
-        assert hasattr(inference_data, "sample_stats")
-        assert hasattr(inference_data, "prior")
-        assert hasattr(inference_data, "prior_predictive")
-        assert hasattr(inference_data, "sample_stats_prior")
-        assert hasattr(inference_data, "observed_data")
+        test_dict = {
+            "posterior": [],
+            "prior": [],
+            "sample_stats": [],
+            "posterior_predictive": [],
+            "prior_predictive": [],
+            "sample_stats_prior": [],
+            "observed_data": [],
+        }
+        fails = check_multiple_attrs(test_dict, inference_data)
+        assert not fails
         self.check_var_names_coords_dims(inference_data.posterior)
         self.check_var_names_coords_dims(inference_data.posterior_predictive)
         self.check_var_names_coords_dims(inference_data.sample_stats)
@@ -598,18 +596,16 @@ class TestEmceeNetCDFUtils:
 
     def test_inference_data(self, data):
         inference_data = self.get_inference_data(data)
-        assert hasattr(inference_data, "posterior")
-        assert hasattr(inference_data.posterior, "ln(f)")
-        assert hasattr(inference_data.posterior, "b")
-        assert hasattr(inference_data.posterior, "m")
+        test_dict = {"posterior": ["ln(f)", "b", "m"]}
+        fails = check_multiple_attrs(test_dict, inference_data)
+        assert not fails
 
     @needs_emcee3
     def test_inference_data_reader(self):
         inference_data = self.get_inference_data_reader()
-        assert hasattr(inference_data, "posterior")
-        assert hasattr(inference_data.posterior, "ln(f)")
-        assert hasattr(inference_data.posterior, "b")
-        assert hasattr(inference_data.posterior, "m")
+        test_dict = {"posterior": ["ln(f)", "b", "m"]}
+        fails = check_multiple_attrs(test_dict, inference_data)
+        assert not fails
 
     def test_verify_var_names(self, data):
         with pytest.raises(ValueError):
@@ -751,11 +747,9 @@ class TestPyMC3NetCDFUtils:
         y_missing, = model.missing_values
         assert y_missing.tag.test_value.shape == (2,)
         inference_data = from_pymc3(trace=trace)
-        assert hasattr(inference_data, "posterior")
-        assert hasattr(inference_data.posterior, "x")
-        assert hasattr(inference_data.observed_data, "y")
-        assert hasattr(inference_data, "sample_stats")
-        assert hasattr(inference_data.sample_stats, "log_likelihood")
+        test_dict = {"posterior": ["x"], "observed_data": ["y"], "sample_stats": ["log_likelihood"]}
+        fails = check_multiple_attrs(test_dict, inference_data)
+        assert not fails
 
     def test_multiple_observed_rv(self):
         y1_data = np.random.randn(10)
@@ -766,11 +760,9 @@ class TestPyMC3NetCDFUtils:
             pm.Normal("y2", x, 1, observed=y2_data)
             trace = pm.sample(100, chains=2)
         inference_data = from_pymc3(trace=trace)
-        assert hasattr(inference_data, "posterior")
-        assert hasattr(inference_data.posterior, "x")
-        assert hasattr(inference_data.observed_data, "y1")
-        assert hasattr(inference_data.observed_data, "y2")
-        assert hasattr(inference_data, "sample_stats")
+        test_dict = {"posterior": ["x"], "observed_data": ["y1", "y2"]}
+        fails = check_multiple_attrs(test_dict, inference_data)
+        assert not fails
         assert not hasattr(inference_data.sample_stats, "log_likelihood")
 
 
@@ -873,9 +865,9 @@ class TestPyStanNetCDFUtils:
 
     def test_sampler_stats(self, data, eight_schools_params):
         inference_data = self.get_inference_data(data, eight_schools_params)
-        assert hasattr(inference_data, "sample_stats")
-        assert hasattr(inference_data.sample_stats, "lp")
-        assert hasattr(inference_data.sample_stats, "diverging")
+        test_dict = {"sample_stats": ["lp", "diverging"]}
+        fails = check_multiple_attrs(test_dict, inference_data)
+        assert not fails
 
     def test_inference_data(self, data, eight_schools_params):
         inference_data1 = self.get_inference_data(data, eight_schools_params)
@@ -883,25 +875,38 @@ class TestPyStanNetCDFUtils:
         inference_data3 = self.get_inference_data3(data, eight_schools_params)
         inference_data4 = self.get_inference_data4(data)
         # inference_data 1
-        assert hasattr(inference_data1.sample_stats, "log_likelihood")
-        assert hasattr(inference_data1.posterior, "theta")
-        assert hasattr(inference_data1.prior, "theta")
-        assert hasattr(inference_data1.observed_data, "y")
+        test_dict = {
+            "posterior": ["theta"],
+            "observed_data": ["y"],
+            "sample_stats": ["log_likelihood"],
+            "prior": ["theta"],
+        }
+        fails = check_multiple_attrs(test_dict, inference_data1)
+        assert not fails
         # inference_data 2
-        assert hasattr(inference_data2.posterior_predictive, "y_hat")
-        assert hasattr(inference_data2.prior_predictive, "y_hat")
-        assert hasattr(inference_data2.sample_stats, "lp")
-        assert hasattr(inference_data2.sample_stats_prior, "lp")
-        assert hasattr(inference_data2.observed_data, "y")
+        test_dict = {
+            "posterior_predictive": ["y_hat"],
+            "observed_data": ["y"],
+            "sample_stats_prior": ["lp"],
+            "sample_stats": ["lp"],
+            "prior_predictive": ["y_hat"],
+        }
+        fails = check_multiple_attrs(test_dict, inference_data2)
+        assert not fails
         # inference_data 3
-        assert hasattr(inference_data3.posterior_predictive, "y_hat")
-        assert hasattr(inference_data3.prior_predictive, "y_hat")
-        assert hasattr(inference_data3.sample_stats, "lp")
-        assert hasattr(inference_data3.sample_stats_prior, "lp")
-        assert hasattr(inference_data3.observed_data, "y")
+        test_dict = {
+            "posterior_predictive": ["y_hat"],
+            "observed_data": ["y"],
+            "sample_stats_prior": ["lp"],
+            "sample_stats": ["lp"],
+            "prior_predictive": ["y_hat"],
+        }
+        fails = check_multiple_attrs(test_dict, inference_data3)
+        assert not fails
         # inference_data 4
-        assert hasattr(inference_data4.posterior, "theta")
-        assert hasattr(inference_data4.prior, "theta")
+        test_dict = {"posterior": ["theta"], "prior": ["theta"]}
+        fails = check_multiple_attrs(test_dict, inference_data4)
+        assert not fails
 
     def test_invalid_fit(self, data):
         if pystan_version() == 2:
@@ -937,9 +942,9 @@ class TestPyStanNetCDFUtils:
             model = StanModel(model_code=model_code)
             fit = model.sampling(iter=10, chains=2, check_hmc_diagnostics=False)
             posterior = from_pystan(posterior=fit)
-            assert hasattr(posterior, "posterior")
-            assert hasattr(posterior.posterior, "y")
-            assert not hasattr(posterior.posterior, "z")
+            test_dict = {"posterior": ["y", "z"]}
+            fails = check_multiple_attrs(test_dict, posterior)
+            assert not fails
 
     def test_get_draws(self, data):
         fit = data.obj
@@ -1051,14 +1056,13 @@ class TestTfpNetCDFUtils:
 
     def test_inference_data(self, data, eight_schools_params):
         inference_data = self.get_inference_data(data, eight_schools_params)
-        assert hasattr(inference_data, "posterior")
-        assert hasattr(inference_data.posterior, "mu")
-        assert hasattr(inference_data.posterior, "tau")
-        assert hasattr(inference_data.posterior, "eta")
-        assert hasattr(inference_data, "observed_data")
-        assert hasattr(inference_data.observed_data, "obs")
-        assert hasattr(inference_data, "posterior_predictive")
-        assert hasattr(inference_data.posterior_predictive, "obs")
+        test_dict = {
+            "posterior": ["mu", "tau", "eta"],
+            "observed_data": ["obs"],
+            "posterior_predictive": ["obs"],
+        }
+        fails = check_multiple_attrs(test_dict, inference_data)
+        assert not fails
 
     def test_inference_data2(self, data):
         inference_data = self.get_inference_data2(data)
@@ -1066,26 +1070,23 @@ class TestTfpNetCDFUtils:
 
     def test_inference_data3(self, data, eight_schools_params):
         inference_data = self.get_inference_data3(data, eight_schools_params)
-        assert hasattr(inference_data, "posterior")
-        assert hasattr(inference_data.posterior, "mu")
-        assert hasattr(inference_data.posterior, "tau")
-        assert hasattr(inference_data.posterior, "eta")
-        assert hasattr(inference_data, "observed_data")
-        assert hasattr(inference_data.observed_data, "obs")
-        assert hasattr(inference_data, "posterior_predictive")
-        assert hasattr(inference_data.posterior_predictive, "obs")
+        test_dict = {
+            "posterior": ["mu", "tau", "eta"],
+            "observed_data": ["obs"],
+            "posterior_predictive": ["obs"],
+        }
+        fails = check_multiple_attrs(test_dict, inference_data)
+        assert not fails
 
     def test_inference_data4(self, data, eight_schools_params):
         inference_data = self.get_inference_data4(data, eight_schools_params)
-        assert hasattr(inference_data, "posterior")
-        assert hasattr(inference_data.posterior, "mu")
-        assert hasattr(inference_data.posterior, "tau")
-        assert hasattr(inference_data.posterior, "eta")
-        assert hasattr(inference_data.posterior, "avg_effect")
-        assert hasattr(inference_data, "observed_data")
-        assert hasattr(inference_data.observed_data, "obs")
-        assert hasattr(inference_data, "posterior_predictive")
-        assert hasattr(inference_data.posterior_predictive, "obs")
+        test_dict = {
+            "posterior": ["mu", "tau", "eta", "avg_effect"],
+            "observed_data": ["obs"],
+            "posterior_predictive": ["obs"],
+        }
+        fails = check_multiple_attrs(test_dict, inference_data)
+        assert not fails
 
 
 class TestCmdStanNetCDFUtils:
@@ -1165,10 +1166,9 @@ class TestCmdStanNetCDFUtils:
             if "eight" in key or "missing" in key:
                 continue
             inference_data = self.get_inference_data(path)
-            assert hasattr(inference_data, "posterior")
-            assert hasattr(inference_data.posterior, "y")
-            assert hasattr(inference_data.posterior, "x")
-            assert hasattr(inference_data.posterior, "Z")
+            test_dict = {"posterior": ["x", "y", "Z"]}
+            fails = check_multiple_attrs(test_dict, inference_data)
+            assert not fails
             assert inference_data.posterior["y"].shape == (4, 100)
             assert inference_data.posterior["x"].shape == (4, 100, 3)
             assert inference_data.posterior["Z"].shape == (4, 100, 4, 6)
@@ -1215,11 +1215,16 @@ class TestCmdStanNetCDFUtils:
                     "eta": ["school"],
                 },
             )
-            assert hasattr(inference_data, "posterior")
-            assert hasattr(inference_data, "sample_stats")
-            assert hasattr(inference_data.sample_stats, "log_likelihood")
-            assert hasattr(inference_data, "posterior_predictive")
-            assert hasattr(inference_data, "observed_data")
+            test_dict = {
+                "posterior": ["mu", "tau", "theta_tilde", "theta"],
+                "prior": ["mu", "tau", "theta_tilde", "theta"],
+                "prior_predictive": ["y_hat"],
+                "sample_stats": ["log_likelihood"],
+                "observed_data": ["y"],
+                "posterior_predictive": ["y_hat"],
+            }
+            fails = check_multiple_attrs(test_dict, inference_data)
+            assert not fails
 
     def test_inference_data_input_types2(self, paths, observed_data_paths):
         """Check input types (change, see earlier)
@@ -1247,11 +1252,16 @@ class TestCmdStanNetCDFUtils:
                     "eta": ["school"],
                 },
             )
-            assert hasattr(inference_data, "posterior")
-            assert hasattr(inference_data, "sample_stats")
-            assert hasattr(inference_data.sample_stats, "log_likelihood")
-            assert hasattr(inference_data, "posterior_predictive")
-            assert hasattr(inference_data, "observed_data")
+            test_dict = {
+                "posterior": ["mu", "tau", "theta_tilde", "theta"],
+                "prior": ["mu", "tau", "theta_tilde", "theta"],
+                "prior_predictive": ["y_hat"],
+                "sample_stats": ["log_likelihood"],
+                "observed_data": ["y"],
+                "posterior_predictive": ["y_hat"],
+            }
+            fails = check_multiple_attrs(test_dict, inference_data)
+            assert not fails
 
     def test_inference_data_input_types3(self, paths, observed_data_paths):
         """Check input types (change, see earlier)
@@ -1275,11 +1285,16 @@ class TestCmdStanNetCDFUtils:
                 coords={"school": np.arange(8), "log_lik_dim_0": np.arange(8)},
                 dims={"theta": ["school"], "y": ["school"], "y_hat": ["school"], "eta": ["school"]},
             )
-            assert hasattr(inference_data, "posterior")
-            assert hasattr(inference_data, "sample_stats")
-            assert hasattr(inference_data.sample_stats, "log_likelihood")
-            assert hasattr(inference_data, "posterior_predictive")
-            assert hasattr(inference_data, "observed_data")
+            test_dict = {
+                "posterior": ["mu", "tau", "theta_tilde", "theta"],
+                "prior": ["mu", "tau", "theta_tilde", "theta"],
+                "prior_predictive": ["y_hat"],
+                "sample_stats": ["log_likelihood"],
+                "observed_data": ["y"],
+                "posterior_predictive": ["y_hat"],
+            }
+            fails = check_multiple_attrs(test_dict, inference_data)
+            assert not fails
 
     def test_inference_data_input_types4(self, paths):
         """Check input types (change, see earlier)
@@ -1300,12 +1315,16 @@ class TestCmdStanNetCDFUtils:
                 coords={"rand": np.arange(3)},
                 dims={"x": ["rand"]},
             )
-            assert hasattr(inference_data, "posterior")
-            assert hasattr(inference_data, "sample_stats")
-            assert hasattr(inference_data, "posterior_predictive")
-            assert hasattr(inference_data, "prior")
-            assert hasattr(inference_data, "sample_stats_prior")
-            assert hasattr(inference_data, "prior_predictive")
+            test_dict = {
+                "posterior": [],
+                "prior": [],
+                "prior_predictive": [],
+                "sample_stats": [],
+                "sample_stats_prior": [],
+                "posterior_predictive": [],
+            }
+            fails = check_multiple_attrs(test_dict, inference_data)
+            assert not fails
 
     def test_inference_data_input_types5(self, paths, observed_data_paths):
         """Check input types (change, see earlier)
@@ -1333,10 +1352,15 @@ class TestCmdStanNetCDFUtils:
                     "eta": ["school"],
                 },
             )
-            assert hasattr(inference_data, "posterior")
-            assert hasattr(inference_data, "sample_stats")
-            assert hasattr(inference_data.sample_stats, "log_likelihood")
-            assert hasattr(inference_data, "observed_data")
+            test_dict = {
+                "posterior": ["mu", "tau", "theta_tilde", "theta"],
+                "prior": ["mu", "tau", "theta_tilde", "theta"],
+                "sample_stats": ["log_likelihood"],
+                "observed_data": ["y"],
+                "sample_stats_prior": [],
+            }
+            fails = check_multiple_attrs(test_dict, inference_data)
+            assert not fails
 
     def test_inference_data_bad_csv(self, paths):
         """Check ValueError for csv with missing headers"""

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -33,6 +33,7 @@ from ..data.base import generate_dims_coords, make_attrs
 from ..data.io_pystan import get_draws, get_draws_stan3  # pylint: disable=unused-import
 from ..data.datasets import REMOTE_DATASETS, LOCAL_DATASETS, RemoteFileMetadata
 from .helpers import (  # pylint: disable=unused-import
+    check_multiple_attrs,
     _emcee_lnprior as emcee_lnprior,
     _emcee_lnprob as emcee_lnprob,
     needs_emcee3,
@@ -176,12 +177,10 @@ def test_addition():
     idata2 = from_dict(prior={"C": np.random.randn(2, 10, 2), "D": np.random.randn(2, 10, 5, 2)})
     new_idata = idata1 + idata2
     assert new_idata is not None
-    assert hasattr(new_idata, "posterior")
-    assert hasattr(new_idata, "prior")
-    assert hasattr(new_idata.posterior, "A")
-    assert hasattr(new_idata.posterior, "B")
-    assert hasattr(new_idata.prior, "C")
-    assert hasattr(new_idata.prior, "D")
+    objs = (None, None, "posterior", "posterior", "prior", "prior")
+    attrs = ("posterior", "prior", "A", "B", "C", "D")
+    fails = check_multiple_attrs(objs, attrs, parent=new_idata)
+    assert len(fails) == 0
 
 
 @pytest.mark.parametrize("copy", [True, False])

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -177,9 +177,8 @@ def test_addition():
     idata2 = from_dict(prior={"C": np.random.randn(2, 10, 2), "D": np.random.randn(2, 10, 5, 2)})
     new_idata = idata1 + idata2
     assert new_idata is not None
-    objs = (None, None, "posterior", "posterior", "prior", "prior")
-    attrs = ("posterior", "prior", "A", "B", "C", "D")
-    fails = check_multiple_attrs(objs, attrs, parent=new_idata)
+    test_dict = {"posterior": ["A", "B"], "prior": ["C", "D"]}
+    fails = check_multiple_attrs(test_dict, new_idata)
     assert len(fails) == 0
 
 


### PR DESCRIPTION
In order to adress Issue #390 I started creating a function that performs multiple `hasattr` checks and returns a list of tuples containing `(object, attribute)` for the failed tests, as proposed. I have included an extra argument `parent` to account for the fact that most of the checks are on the same object and/or on childs of the same object. 

I have replaced one of the multiple checks instances for a call to this helper function, to show its possible usage. I have used `assert len(failed_checks) == 0` instead of `assert failed_checks == []` because its message when failing is much more clear to me:

**`len == 0` message**

    E  AssertionError: assert 2 == 0
    E    +  where 2 = len([(<xarray.Dataset>\nDimensions:  (A_dim_0: 2, B_dim_0: 5, B_dim_1: 2, chain: 2, draw: 10)\nCoordinates:\n  * chain    (ch... draw, D_dim_0, D_dim_1) float64 0.7048 0.64 ... 0.1206\nAttributes:\n    created_at:  2019-03-21T00:14:24.493919, 'Ci')])

**`list == []` message**

    E  AssertionError: assert [(<xarray.Dat...585079, 'Ci')] == []
    E    Left contains more items, first extra item: (<xarray.Dataset>\nDimensions:  (A_dim_0: 2, B_dim_0: 5, B_dim_1: 2, chain: 2, draw: 10)\nCoordinates:\n  * chain    (cha...draw, B_dim_0, B_dim_1) float64 -0.2893 -0.418 ... 1.061\nAttributes:\n    created_at:  2019-03-21T00:14:39.583937, 'Ai')

At this level of verbosity none of the options shows clearly which checks failed, but the first option shows clearly how many of them failed.