### PR TITLE
Add rankplot

### DIFF
--- a/arviz/plots/__init__.py
+++ b/arviz/plots/__init__.py
@@ -15,6 +15,7 @@ from .ppcplot import plot_ppc
 from .violinplot import plot_violin
 from .hpdplot import plot_hpd
 from .distplot import plot_dist
+from .rankplot import plot_rank
 
 
 __all__ = [
@@ -36,4 +37,5 @@ __all__ = [
     "plot_violin",
     "plot_hpd",
     "plot_dist",
+    "plot_rank",
 ]

--- a/arviz/plots/rankplot.py
+++ b/arviz/plots/rankplot.py
@@ -34,7 +34,16 @@ def _sturges_formula(dataset, mult=1):
     return int(np.ceil(mult * np.log2(dataset.draw.size)) + 1)
 
 
-def plot_rank(data, var_names=None, coords=None, bins=None, ref_line=True, figsize=None, axes=None):
+def plot_rank(
+    data,
+    var_names=None,
+    coords=None,
+    bins=None,
+    ref_line=True,
+    mean_centered=False,
+    figsize=None,
+    axes=None,
+):
 
     posterior_data = convert_to_dataset(data, group="posterior")
     if coords is not None:
@@ -64,25 +73,31 @@ def plot_rank(data, var_names=None, coords=None, bins=None, ref_line=True, figsi
         gap = all_counts.max() * 1.05
         width = bin_ary[1] - bin_ary[0]
 
-        y_ticks = []
-
         # Center the bins
         bin_ary = (bin_ary[1:] + bin_ary[:-1]) / 2
+
+        y_ticks = []
         for idx, counts in enumerate(all_counts):
             y_ticks.append(idx * gap)
-            if ref_line:
+            if ref_line and not mean_centered:
                 # Line where data is uniform
                 ax.axhline(y=y_ticks[-1] + counts.mean(), linestyle="--", color="C1")
             # fake an x-axis
-            ax.axhline(y=y_ticks[-1], color="k")
+            ax.axhline(y=y_ticks[-1], color="k", lw=1)
             ax_color = ax.get_facecolor()
+            if mean_centered:
+                heights = counts - counts.mean()
+                color = [f"C{abs(j - 1)}" for j in (heights > 0).astype(int)]
+            else:
+                heights = counts
+                color = "C0"
             ax.bar(
                 bin_ary,
-                counts,
+                heights,
                 bottom=y_ticks[-1],
                 width=width,
                 align="center",
-                color="C0",
+                color=color,
                 edgecolor=ax_color,
             )
         ax.set_xlabel("Rank (all chains)", fontsize=ax_labelsize)

--- a/arviz/plots/rankplot.py
+++ b/arviz/plots/rankplot.py
@@ -1,4 +1,5 @@
 import numpy as np
+import scipy.stats
 
 from ..data import convert_to_dataset
 from .plot_utils import (
@@ -11,13 +12,39 @@ from .plot_utils import (
 from ..utils import _var_names
 
 
-def plot_rank(data, var_names=None, coords=None, bins="auto", figsize=None, axes=None):
+def _sturges_formula(dataset, mult=1):
+    """Use Sturges' formula to determine number of bins.
+
+    See https://en.wikipedia.org/wiki/Histogram#Sturges'_formula
+    or https://doi.org/10.1080%2F01621459.1926.10502161
+
+    Parameters
+    ----------
+    dataset: xarray.DataSet
+        Must have the `draw` dimension
+
+    mult: float
+        Used to scale the number of bins up or down. Default is 1 for Sturges' formula.
+
+    Returns
+    -------
+    int
+        Number of bins to use
+    """
+    return int(np.ceil(mult * np.log2(dataset.draw.size)) + 1)
+
+
+def plot_rank(data, var_names=None, coords=None, bins=None, ref_line=True, figsize=None, axes=None):
 
     posterior_data = convert_to_dataset(data, group="posterior")
     if coords is not None:
         posterior_data = posterior_data.sel(**coords)
     var_names = _var_names(var_names, posterior_data)
     plotters = list(xarray_var_iter(posterior_data, var_names=var_names, combined=True))
+
+    if bins is None:
+        # Use double sturges' formula
+        bins = _sturges_formula(posterior_data, mult=2)
 
     if axes is None:
         rows, cols = default_grid(len(plotters))
@@ -28,28 +55,37 @@ def plot_rank(data, var_names=None, coords=None, bins="auto", figsize=None, axes
         _, axes = _create_axes_grid(len(plotters), rows, cols, figsize=figsize, squeeze=False)
 
     for ax, (var_name, selection, var_data) in zip(axes.ravel(), plotters):
-        ranks = var_data.argsort(axis=None).reshape(*var_data.shape)
+        ranks = scipy.stats.rankdata(var_data).reshape(var_data.shape)
         all_counts = []
         for row in ranks:
-            # If `bins` was auto, it gets overwritten here, and carried forward
-            # using the `range` argument makes sure the bins cover all the data
-            counts, bins = np.histogram(row, bins=bins, range=(0, ranks.size))
+            counts, bin_ary = np.histogram(row, bins=bins, range=(0, ranks.size))
             all_counts.append(counts)
         all_counts = np.array(all_counts)
         gap = all_counts.max() * 1.05
-        width = (bins[1] - bins[0]) * 0.95
+        width = bin_ary[1] - bin_ary[0]
 
         y_ticks = []
+
+        # Center the bins
+        bin_ary = (bin_ary[1:] + bin_ary[:-1]) / 2
         for idx, counts in enumerate(all_counts):
             y_ticks.append(idx * gap)
-            # Line where data is uniform
-            ax.axhline(
-                y=y_ticks[-1] + counts.sum() / bins.shape[0], linestyle="--", color="C1", zorder=-10
-            )
+            if ref_line:
+                # Line where data is uniform
+                ax.axhline(y=y_ticks[-1] + counts.mean(), linestyle="--", color="C1")
             # fake an x-axis
             ax.axhline(y=y_ticks[-1], color="k")
-            ax.bar(bins[:-1], counts, bottom=y_ticks[-1], width=width, align="edge", color="C0")
-        ax.set_xlabel("Rank (all chains)")
+            ax_color = ax.get_facecolor()
+            ax.bar(
+                bin_ary,
+                counts,
+                bottom=y_ticks[-1],
+                width=width,
+                align="center",
+                color="C0",
+                edgecolor=ax_color,
+            )
+        ax.set_xlabel("Rank (all chains)", fontsize=ax_labelsize)
         ax.set_ylabel("Chain", fontsize=ax_labelsize)
         ax.set_yticks(y_ticks)
         ax.set_yticklabels(np.arange(len(y_ticks)))

--- a/arviz/plots/rankplot.py
+++ b/arviz/plots/rankplot.py
@@ -1,0 +1,58 @@
+import numpy as np
+
+from ..data import convert_to_dataset
+from .plot_utils import (
+    _scale_fig_size,
+    xarray_var_iter,
+    default_grid,
+    _create_axes_grid,
+    make_label,
+)
+from ..utils import _var_names
+
+
+def plot_rank(data, var_names=None, coords=None, bins="auto", figsize=None, axes=None):
+
+    posterior_data = convert_to_dataset(data, group="posterior")
+    if coords is not None:
+        posterior_data = posterior_data.sel(**coords)
+    var_names = _var_names(var_names, posterior_data)
+    plotters = list(xarray_var_iter(posterior_data, var_names=var_names, combined=True))
+
+    if axes is None:
+        rows, cols = default_grid(len(plotters))
+
+        figsize, ax_labelsize, titlesize, _, _, _ = _scale_fig_size(
+            figsize, None, rows=rows, cols=cols
+        )
+        _, axes = _create_axes_grid(len(plotters), rows, cols, figsize=figsize, squeeze=False)
+
+    for ax, (var_name, selection, var_data) in zip(axes.ravel(), plotters):
+        ranks = var_data.argsort(axis=None).reshape(*var_data.shape)
+        all_counts = []
+        for row in ranks:
+            # If `bins` was auto, it gets overwritten here, and carried forward
+            # using the `range` argument makes sure the bins cover all the data
+            counts, bins = np.histogram(row, bins=bins, range=(0, ranks.size))
+            all_counts.append(counts)
+        all_counts = np.array(all_counts)
+        gap = all_counts.max() * 1.05
+        width = (bins[1] - bins[0]) * 0.95
+
+        y_ticks = []
+        for idx, counts in enumerate(all_counts):
+            y_ticks.append(idx * gap)
+            # Line where data is uniform
+            ax.axhline(
+                y=y_ticks[-1] + counts.sum() / bins.shape[0], linestyle="--", color="C1", zorder=-10
+            )
+            # fake an x-axis
+            ax.axhline(y=y_ticks[-1], color="k")
+            ax.bar(bins[:-1], counts, bottom=y_ticks[-1], width=width, align="edge", color="C0")
+        ax.set_xlabel("Rank (all chains)")
+        ax.set_ylabel("Chain", fontsize=ax_labelsize)
+        ax.set_yticks(y_ticks)
+        ax.set_yticklabels(np.arange(len(y_ticks)))
+        ax.set_title(make_label(var_name, selection), fontsize=titlesize)
+
+    return axes

--- a/arviz/plots/rankplot.py
+++ b/arviz/plots/rankplot.py
@@ -44,7 +44,80 @@ def plot_rank(
     figsize=None,
     axes=None,
 ):
+    """Plot rank order statistics of chains.
 
+    From the paper: Rank plots are histograms of the ranked posterior
+    draws (ranked over all chains) plotted separately for each chain.
+    If all of the chains are targeting the same posterior, we expect
+    the ranks in each chain to be uniform, whereas if one chain has a
+    different location or scale parameter, this will be reflected in
+    the deviation from uniformity. If rank plots of all chains look
+    similar, this indicates good mixing of the chains.
+
+    This plot was introduced by Aki Vehtari, Andrew Gelman, Daniel
+    Simpson, Bob Carpenter, Paul-Christian Burkner (2019):
+    Rank-normalization, folding, and localization: An improved R-hat
+    for assessing convergence of MCMC.
+    arXiv preprint https://arxiv.org/abs/1903.08008
+
+
+    Parameters
+    ----------
+    data : obj
+        Any object that can be converted to an az.InferenceData object
+        Refer to documentation of az.convert_to_dataset for details
+    var_names : string or list of variable names
+        Variables to be plotted
+    coords : mapping, optional
+        Coordinates of var_names to be plotted. Passed to `Dataset.sel`
+    bins : None or passed to np.histogram
+        Binning strategy used for histogram. By default uses twice the
+        result of Sturges' formula. See `np.histogram` documenation for
+        other available arguments.
+    ref_line : boolean
+        Whether to include a dashed line showing where a uniform
+        distribution would lie
+    mean_centered : boolean
+        When True, plots a histogram of deviations from the uniform
+        distribution. When False, plots a histogram of counts.
+    figsize : tuple
+        Figure size. If None it will be defined automatically.
+    ax : axes
+        Matplotlib axes. Defaults to None.
+
+    Returns
+    -------
+    ax : matplotlib axes
+
+    Examples
+    --------
+    Show a default rank plot
+
+    .. plot::
+        :context: close-figs
+
+        >>> import arviz as az
+        >>> data = az.load_arviz_data('centered_eight')
+        >>> az.plot_rank(data)
+
+    Recreate Figure 13 from the arxiv preprint
+
+    .. plot::
+        :context: close-figs
+
+        >>> import arviz as az
+        >>> data = az.load_arviz_data('centered_eight')
+        >>> az.plot_rank(data, var_names='tau')
+
+    Show a mean centered version of the plot
+
+    .. plot::
+        :context: close-figs
+
+        >>> import arviz as az
+        >>> data = az.load_arviz_data('non_centered_eight')
+        >>> az.plot_rank(data, var_names=['mu', 'tau'], mean_centered=True)
+    """
     posterior_data = convert_to_dataset(data, group="posterior")
     if coords is not None:
         posterior_data = posterior_data.sel(**coords)

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -28,7 +28,7 @@ from ..plots import (
     plot_khat,
     plot_hpd,
     plot_dist,
-    plot_rank
+    plot_rank,
 )
 
 np.random.seed(0)
@@ -615,10 +615,9 @@ def test_plot_autocorr_var_names(models, var_names):
     [
         {},
         {"var_names": "mu"},
-        {"var_names": ("mu", "tau"),
-            "coords": {"theta_dim_0": [0, 1]}},
-        {"var_names": "mu", 'ref_line': True},
-        {"var_names": "mu", 'ref_line': False},
+        {"var_names": ("mu", "tau"), "coords": {"theta_dim_0": [0, 1]}},
+        {"var_names": "mu", "ref_line": True},
+        {"var_names": "mu", "ref_line": False},
     ],
 )
 @pytest.mark.parametrize("model_fit", ["pymc3_fit", "stan_fit", "pyro_fit"])
@@ -626,6 +625,7 @@ def test_plot_rank(models, model_fit, kwargs):
     obj = getattr(models, model_fit)
     axes = plot_rank(obj, **kwargs)
     assert axes.shape
+
 
 @pytest.mark.parametrize(
     "kwargs",

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -28,6 +28,7 @@ from ..plots import (
     plot_khat,
     plot_hpd,
     plot_dist,
+    plot_rank
 )
 
 np.random.seed(0)
@@ -608,6 +609,23 @@ def test_plot_autocorr_var_names(models, var_names):
     axes = plot_autocorr(models.pymc3_fit, var_names=var_names, combined=True)
     assert axes.shape
 
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"var_names": "mu"},
+        {"var_names": ("mu", "tau"),
+            "coords": {"theta_dim_0": [0, 1]}},
+        {"var_names": "mu", 'ref_line': True},
+        {"var_names": "mu", 'ref_line': False},
+    ],
+)
+@pytest.mark.parametrize("model_fit", ["pymc3_fit", "stan_fit", "pyro_fit"])
+def test_plot_rank(models, model_fit, kwargs):
+    obj = getattr(models, model_fit)
+    axes = plot_rank(obj, **kwargs)
+    assert axes.shape
 
 @pytest.mark.parametrize(
     "kwargs",


### PR DESCRIPTION
This implements `plot_rank`, as described in #621. This still lacks tests, but wanted to get comments on some styling choices I was already making, specifically:

1. Dotted line in the background to show what a uniform histogram would look like.
2. All chains plotted in one axis
3. Using `bins='auto'` by default. In the paper, it looks like a lot of bins were chosen, but I do not understand why. You can replicate that behavior by manually passing a number of bins (see examples below).

It might make sense to also make this an optional panel in a traceplot, in which case the "artist" should get factored out.

```python
data = az.load_arviz_data('centered_eight')
az.plot_rank(data, ['mu', 'tau', 'theta'], coords={'school': ['Choate', 'Deerfield']})
```
![image](https://user-images.githubusercontent.com/2295568/54891760-fc79c880-4e84-11e9-9a45-098f751bb429.png)

```python
data = az.load_arviz_data('non_centered_eight')
az.plot_rank(data, ['mu', 'tau', 'theta'], coords={'school': ['Choate', 'Deerfield']})
```
![image](https://user-images.githubusercontent.com/2295568/54891775-0ac7e480-4e85-11e9-921a-e96c9f11786c.png)

```python
data = az.load_arviz_data('centered_eight')
az.plot_rank(data, var_names='tau', bins=50, figsize=(10, 7));
```
![image](https://user-images.githubusercontent.com/2295568/54891819-45ca1800-4e85-11e9-8c32-f14375b022e3.png)
