### PR TITLE
Add rankplot to docs

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -26,6 +26,7 @@ Plots
     plot_parallel
     plot_posterior
     plot_ppc
+    plot_rank
     plot_trace
 
 .. _stats_api:

--- a/examples/plot_rank.py
+++ b/examples/plot_rank.py
@@ -1,0 +1,13 @@
+"""
+Rank plot
+=========
+
+_thumb: .1, .8
+"""
+import arviz as az
+
+az.style.use('arviz-darkgrid')
+
+data = az.load_arviz_data('centered_eight')
+az.plot_rank(data, var_names=('tau', 'mu'))
+


### PR DESCRIPTION
This adds an example, and also adds it to the api docs (which includes inline examples).