### PR TITLE
Pair plot fixes and kde extra options. Fixes #602

### DIFF
--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -28,6 +28,7 @@ def plot_kde(
     rug_kwargs=None,
     contour_kwargs=None,
     contourf_kwargs=None,
+    pcolormesh_kwargs=None,
     ax=None,
     legend=True,
 ):
@@ -234,6 +235,8 @@ def plot_kde(
         contour_kwargs.setdefault("colors", "0.5")
         if contourf_kwargs is None:
             contourf_kwargs = {}
+        if pcolormesh_kwargs is None:
+            pcolormesh_kwargs = {}
 
         gridsize = (128, 128) if contour else (256, 256)
 

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -72,7 +72,11 @@ def plot_kde(
         Use `space` keyword (float) to control the position of the rugplot. The larger this number
         the lower the rugplot.
     contour_kwargs : dict
-        Keywords passed to the contourplot. Ignored for 1D KDE.
+        Keywords passed to ax.contour. Ignored for 1D KDE.
+    contourf_kwargs : dict
+        Keywords passed to ax.contourf. Ignored for 1D KDE.
+    pcolormesh_kwargs : dict
+        Keywords passed to ax.pcolormesh. Ignored for 1D KDE.
     ax : matplotlib axes
     legend : bool
         Add legend to the figure. By default True.
@@ -242,13 +246,12 @@ def plot_kde(
         ax.set_ylim(ymin, ymax)
         if contour:
             qcfs = ax.contourf(x_x, y_y, density, antialiased=True, **contourf_kwargs)
-            if not fill_last:
-                qcfs.collections[0].set_alpha(0)
             qcs = ax.contour(x_x, y_y, density, **contour_kwargs)
             if not fill_last:
+                qcfs.collections[0].set_alpha(0)
                 qcs.collections[0].set_alpha(0)
         else:
-            ax.pcolormesh(x_x, y_y, density)
+            ax.pcolormesh(x_x, y_y, density, **pcolormesh_kwargs)
 
     return ax
 

--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 from matplotlib.ticker import NullFormatter
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
-from ..data import convert_to_dataset
+from ..data import convert_to_dataset, convert_to_inference_data
 from .kdeplot import plot_kde
 from .plot_utils import _scale_fig_size, xarray_to_ndarray, get_coords
 from ..utils import _var_names
@@ -134,6 +134,7 @@ def plot_pair(
     divergences_kwargs.setdefault("lw", 0)
 
     # Get posterior draws and combine chains
+    data = convert_to_inference_data(data)
     posterior_data = convert_to_dataset(data, group="posterior")
     var_names = _var_names(var_names, posterior_data)
     flat_var_names, _posterior = xarray_to_ndarray(
@@ -142,8 +143,8 @@ def plot_pair(
 
     # Get diverging draws and combine chains
     if divergences:
-        divergent_data = convert_to_dataset(data, group="sample_stats")
-        if hasattr(divergent_data, "diverging"):
+        if hasattr(data, "sample_stats") and hasattr(data.sample_stats, "diverging"):
+            divergent_data = convert_to_dataset(data, group="sample_stats")
             _, diverging_mask = xarray_to_ndarray(
                 divergent_data, var_names=("diverging",), combined=True
             )

--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -1,4 +1,5 @@
 """Plot a scatter or hexbin of sampled parameters."""
+import warnings
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.ticker import NullFormatter
@@ -142,10 +143,19 @@ def plot_pair(
     # Get diverging draws and combine chains
     if divergences:
         divergent_data = convert_to_dataset(data, group="sample_stats")
-        _, diverging_mask = xarray_to_ndarray(
-            divergent_data, var_names=("diverging",), combined=True
-        )
-        diverging_mask = np.squeeze(diverging_mask)
+        if hasattr(divergent_data, "diverging"):
+            _, diverging_mask = xarray_to_ndarray(
+                divergent_data, var_names=("diverging",), combined=True
+            )
+            diverging_mask = np.squeeze(diverging_mask)
+        else:
+            divergences = False
+            warnings.warn(
+                "diverging field not found in sample stats. "
+                "Plotting without divergences, make sure divergences data is present "
+                "or set divergences=False",
+                SyntaxWarning
+            )
 
     if gridsize == "auto":
         gridsize = int(len(_posterior[0]) ** 0.35)

--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -154,7 +154,7 @@ def plot_pair(
                 "diverging field not found in sample stats. "
                 "Plotting without divergences, make sure divergences data is present "
                 "or set divergences=False",
-                SyntaxWarning
+                SyntaxWarning,
             )
 
     if gridsize == "auto":

--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -152,8 +152,9 @@ def plot_pair(
         else:
             divergences = False
             warnings.warn(
-                "diverging field not found in sample stats. "
-                "Plotting without divergences, make sure divergences data is present "
+                "Divergences data not found, plotting without divergences. "
+                "Make sure the sample method provides divergences data and "
+                "that it is present in the `diverging` field of `sample_stats` "
                 "or set divergences=False",
                 SyntaxWarning,
             )

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -272,7 +272,13 @@ def test_plot_joint_bad(models, model_fit):
     [
         {"plot_kwargs": {"linestyle": "-"}},
         {"contour": True, "fill_last": False},
+        {
+            "contour": True,
+            "contourf_kwargs": {"cmap": "plasma"},
+            "contour_kwargs": {"linewidths": 1},
+        },
         {"contour": False},
+        {"contour": False, "pcolormesh_kwargs": {"cmap": "plasma"}},
     ],
 )
 def test_plot_kde(continuous_model, kwargs):
@@ -280,7 +286,15 @@ def test_plot_kde(continuous_model, kwargs):
     assert axes
 
 
-@pytest.mark.parametrize("kwargs", [{"cumulative": True}, {"rug": True}])
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"cumulative": True},
+        {"cumulative": True, "plot_kwargs": {"linestyle": "--"}},
+        {"rug": True},
+        {"rug": True, "rug_kwargs": {"alpha": 0.2}},
+    ],
+)
 def test_plot_kde_cumulative(continuous_model, kwargs):
     axes = plot_kde(continuous_model["x"], quantiles=[0.25, 0.5, 0.75], **kwargs)
     assert axes
@@ -385,6 +399,18 @@ def test_plot_pair_bad(models, model_fit):
         plot_pair(obj, kind="bad_kind")
     with pytest.raises(Exception):
         plot_pair(obj, var_names=["mu"])
+
+
+@pytest.mark.parametrize("has_stats", [True, False])
+def test_plot_pair_divergences_warning(has_stats):
+    data = load_arviz_data("centered_eight")
+    if has_stats:
+        data.sample_stats = data.sample_stats.rename({"diverging": "diverging_missing"})
+    else:
+        data = data.posterior
+    with pytest.warns(SyntaxWarning):
+        ax = plot_pair(data, divergences=True)
+    assert np.all(ax)
 
 
 @pytest.mark.parametrize("kind", ["density", "cumulative", "scatter"])

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -401,12 +401,14 @@ def test_plot_pair_bad(models, model_fit):
         plot_pair(obj, var_names=["mu"])
 
 
-@pytest.mark.parametrize("has_stats", [True, False])
-def test_plot_pair_divergences_warning(has_stats):
+@pytest.mark.parametrize("has_sample_stats", [True, False])
+def test_plot_pair_divergences_warning(has_sample_stats):
     data = load_arviz_data("centered_eight")
-    if has_stats:
+    if has_sample_stats:
+        # sample_stats present, diverging field missing
         data.sample_stats = data.sample_stats.rename({"diverging": "diverging_missing"})
     else:
+        # sample_stats missing
         data = data.posterior
     with pytest.warns(SyntaxWarning):
         ax = plot_pair(data, divergences=True)


### PR DESCRIPTION
It should fix the issue with missing divergence data (I choose to use a `warnings.warn` instead of logging following #620) and added kwarg arguments for contourf and pcolormesh in `plot_kde`. 