### PR TITLE
Vectorize effective sample size

### DIFF
--- a/arviz/stats/diagnostics.py
+++ b/arviz/stats/diagnostics.py
@@ -97,9 +97,9 @@ def _get_ess(sample_array):
 
     # Geyer's initial monotone sequence
     # here we split out the initial value and take the accumulated min of the remaining sequence
-    P_t = np.concatenate([P_t[..., :1],
-                          np.minimum.accumulate(P_t[..., 1:].clip(min=0), axis=-1)],
-                         axis=-1)
+    P_t = np.concatenate(
+        [P_t[..., :1], np.minimum.accumulate(P_t[..., 1:].clip(min=0), axis=-1)], axis=-1
+    )
 
     ess = np.floor((n_chain * n_draws) / (-1.0 + 2.0 * np.sum(P_t, axis=-1)))
     return ess
@@ -122,7 +122,7 @@ def autocorr(x):
     y = x - x.mean(axis=-1, keepdims=True)
     len_y = y.shape[-1]
     result = fftconvolve(y, y[..., ::-1], axes=-1)
-    acorr = result[..., result.shape[-1] // 2:]
+    acorr = result[..., result.shape[-1] // 2 :]
     acorr /= np.arange(len_y, 0, -1)
     acorr /= acorr[..., :1]
     return acorr

--- a/arviz/stats/diagnostics.py
+++ b/arviz/stats/diagnostics.py
@@ -73,6 +73,7 @@ def _get_ess(sample_array):
 
     It is required that the last two dimensions are chain dimension and draw dimension.
     """
+    # pylint: disable=no-member
     if sample_array.ndim == 1:
         sample_array = sample_array[None, ...]
     n_chain, n_draws = sample_array.shape[-2], sample_array.shape[-1]
@@ -93,15 +94,16 @@ def _get_ess(sample_array):
     rho_hat_t = 1.0 - (mean_var - acov.mean(axis=-2)) / var_plus
     rho_hat_t[..., 0] = 1.0  # correlation at lag 0 is 1
     # take sum of even index and odd index from the sequence
-    P_t = rho_hat_t[..., :-1:2] + rho_hat_t[..., 1::2]
+    p_t = rho_hat_t[..., :-1:2] + rho_hat_t[..., 1::2]
 
     # Geyer's initial monotone sequence
     # here we split out the initial value and take the accumulated min of the remaining sequence
-    P_t = np.concatenate(
-        [P_t[..., :1], np.minimum.accumulate(P_t[..., 1:].clip(min=0), axis=-1)], axis=-1
+    p_t = np.concatenate(
+        [p_t[..., :1], np.minimum.accumulate(p_t[..., 1:].clip(min=0), axis=-1)],
+        axis=-1
     )
 
-    ess = np.floor((n_chain * n_draws) / (-1.0 + 2.0 * np.sum(P_t, axis=-1)))
+    ess = np.floor((n_chain * n_draws) / (-1.0 + 2.0 * np.sum(p_t, axis=-1)))
     return ess
 
 

--- a/arviz/stats/diagnostics.py
+++ b/arviz/stats/diagnostics.py
@@ -118,7 +118,6 @@ def autocorr(x):
     y = x - x.mean(axis=-1, keepdims=True)
     len_y = y.shape[-1]
     result = fftconvolve(y, y[..., ::-1], axes=-1)
-    print(result)
     acorr = result[..., result.shape[-1] // 2 :]
     acorr /= np.arange(len_y, 0, -1)
     acorr /= acorr[..., :1]

--- a/arviz/stats/diagnostics.py
+++ b/arviz/stats/diagnostics.py
@@ -69,8 +69,9 @@ def _ess_ufunc(ary):
 
 
 def _get_ess(sample_array):
-    """Compute the effective sample size for a ND array with the last two dimensions are chain
-    dimension and draw dimension.
+    """Compute the effective sample size for a ND array.
+
+    It is required that the last two dimensions are chain dimension and draw dimension.
     """
     if sample_array.ndim == 1:
         sample_array = sample_array[None, ...]
@@ -97,8 +98,8 @@ def _get_ess(sample_array):
     # Geyer's initial monotone sequence
     # here we split out the initial value and take the accumulated min of the remaining sequence
     P_t = np.concatenate([P_t[..., :1],
-                          np.minimum.accumulate(P_t[..., 1:].clip(min=0), axis=-1)
-                         ], axis=-1)
+                          np.minimum.accumulate(P_t[..., 1:].clip(min=0), axis=-1)],
+                         axis=-1)
 
     ess = np.floor((n_chain * n_draws) / (-1.0 + 2.0 * np.sum(P_t, axis=-1)))
     return ess
@@ -121,7 +122,7 @@ def autocorr(x):
     y = x - x.mean(axis=-1, keepdims=True)
     len_y = y.shape[-1]
     result = fftconvolve(y, y[..., ::-1], axes=-1)
-    acorr = result[..., result.shape[-1] // 2 :]
+    acorr = result[..., result.shape[-1] // 2:]
     acorr /= np.arange(len_y, 0, -1)
     acorr /= acorr[..., :1]
     return acorr

--- a/arviz/stats/diagnostics.py
+++ b/arviz/stats/diagnostics.py
@@ -99,8 +99,7 @@ def _get_ess(sample_array):
     # Geyer's initial monotone sequence
     # here we split out the initial value and take the accumulated min of the remaining sequence
     p_t = np.concatenate(
-        [p_t[..., :1], np.minimum.accumulate(p_t[..., 1:].clip(min=0), axis=-1)],
-        axis=-1
+        [p_t[..., :1], np.minimum.accumulate(p_t[..., 1:].clip(min=0), axis=-1)], axis=-1
     )
 
     ess = np.floor((n_chain * n_draws) / (-1.0 + 2.0 * np.sum(p_t, axis=-1)))

--- a/arviz/stats/diagnostics.py
+++ b/arviz/stats/diagnostics.py
@@ -137,7 +137,7 @@ def _autocov(x):
     acov: Numpy array same size as the input array
     """
     acorr = autocorr(x)
-    varx = np.var(x, axis=-1, ddof=1, keepdims=True) * (x.shape[-1] - 1) / x.shape[-1]
+    varx = np.var(x, axis=-1, keepdims=True)
     acov = acorr * varx
     return acov
 

--- a/arviz/tests/test_diagnostics.py
+++ b/arviz/tests/test_diagnostics.py
@@ -44,14 +44,6 @@ class TestDiagnostics:
         assert ess_hat > 100
         assert ess_hat < 800
 
-    def test_effective_sample_size_bad_shape(self):
-        with pytest.raises(TypeError):
-            effective_sample_size(np.random.randn(3))
-
-    def test_effective_sample_size_bad_chains(self):
-        with pytest.raises(TypeError):
-            effective_sample_size(np.random.randn(1, 3))
-
     @pytest.mark.parametrize("var_names", (None, "mu", ["mu", "tau"]))
     def test_effective_sample_size_dataset(self, data, var_names):
         ess_hat = effective_sample_size(data, var_names=var_names)


### PR DESCRIPTION
This PR vectorizes effective sample size in all dimensions: variable dimensions, chain dimension, draw dimension. In addition, I think that we don't need multi-chains to be able to compute this value, so I also remove that restriction in this PR (the same thing happens for `split-R-hat`: we can vectorize and don't need multi-chains to be able to compute its value (but I would like to defer the discussion about it to another PR).

Test on `centered_eight` posterior, this PR gives nearly identical result to the current one:
```
    mu       float64 192.0
    theta    (school) float64 377.0 372.0 418.0 301.0 290.0 397.0 347.0 359.0
    tau      float64 130.0
```
```
    mu       float64 192.0
    theta    (school) float64 377.0 372.0 418.0 300.0 290.0 397.0 347.0 359.0
    tau      float64 130.0
```
The difference 301 vs 300 comes from the inconsistent behaviour of `acov_t` vs the remaining `acov[:, t]` values in the current implementation.

By the way, thanks for making this awesome library!