### PR TITLE
implement from_cmdstanpy

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -324,7 +324,7 @@ ignore-docstrings=yes
 ignore-imports=no
 
 # Minimum lines number of a similarity.
-min-similarity-lines=15
+min-similarity-lines=50
 
 
 [TYPECHECK]

--- a/arviz/data/__init__.py
+++ b/arviz/data/__init__.py
@@ -5,6 +5,7 @@ from .datasets import load_arviz_data, list_datasets, clear_data_home
 from .base import numpy_to_data_array, dict_to_dataset
 from .converters import convert_to_dataset, convert_to_inference_data
 from .io_cmdstan import from_cmdstan
+from .io_cmdstanpy import from_cmdstanpy
 from .io_dict import from_dict
 from .io_pymc3 import from_pymc3
 from .io_pystan import from_pystan
@@ -26,6 +27,7 @@ __all__ = [
     "from_pystan",
     "from_emcee",
     "from_cmdstan",
+    "from_cmdstanpy",
     "from_dict",
     "from_pyro",
     "from_tfp",

--- a/arviz/data/converters.py
+++ b/arviz/data/converters.py
@@ -66,26 +66,15 @@ def convert_to_inference_data(obj, *, group="posterior", coords=None, dims=None,
             return from_cmdstan(**kwargs)
         else:
             return InferenceData.from_netcdf(obj)
-    elif obj.__class__.__name__ == "StanFit4Model":  # ugly, but doesn't make PyStan a requirement
+    elif obj.__class__.__name__ in {"StanFit4Model", "stan.fit", "PosteriorSample"}:
         if group == "sample_stats":
             kwargs["posterior"] = kwargs.pop(group)
         elif group == "sample_stats_prior":
             kwargs["prior"] = kwargs.pop(group)
-        return from_pystan(**kwargs)
-    elif obj.__class__.__module__ == "stan.fit":  # ugly, but doesn't make PyStan3 a requirement
-        if group == "sample_stats":
-            kwargs["posterior"] = kwargs.pop(group)
-        elif group == "sample_stats_prior":
-            kwargs["prior"] = kwargs.pop(group)
-        return from_pystan(**kwargs)
-    elif (
-        obj.__class__.__name__ == "PosteriorSample"
-    ):  # ugly, but doesn't make CmdStanPy a requirement
-        if group == "sample_stats":
-            kwargs["posterior"] = kwargs.pop(group)
-        elif group == "sample_stats_prior":
-            kwargs["prior"] = kwargs.pop(group)
-        return from_cmdstanpy(**kwargs)
+        if obj.__class__.__name__ == "PosteriorSample":
+            return from_cmdstanpy(**kwargs)
+        else:  # pystan or pystan3
+            return from_pystan(**kwargs)
     elif obj.__class__.__name__ == "MultiTrace":  # ugly, but doesn't make PyMC3 a requirement
         return from_pymc3(trace=kwargs.pop(group), **kwargs)
     elif obj.__class__.__name__ == "EnsembleSampler":  # ugly, but doesn't make emcee a requirement

--- a/arviz/data/converters.py
+++ b/arviz/data/converters.py
@@ -4,6 +4,8 @@ import xarray as xr
 
 from .inference_data import InferenceData
 from .base import dict_to_dataset
+from .io_cmdstan import from_cmdstan
+from .io_cmdstanpy import from_cmdstanpy
 from .io_emcee import from_emcee
 from .io_pymc3 import from_pymc3
 from .io_pyro import from_pyro
@@ -22,8 +24,10 @@ def convert_to_inference_data(obj, *, group="posterior", coords=None, dims=None,
     obj : dict, str, np.ndarray, xr.Dataset, pystan fit, pymc3 trace
         A supported object to convert to InferenceData:
             | InferenceData: returns unchanged
-            | str: Attempts to load the netcdf dataset from disk
+            | str: Attempts to load the cmdstan csv or netcdf dataset from disk
             | pystan fit: Automatically extracts data
+            | cmdstanpy fit: Automatically extracts data
+            | cmdstan csv-list: Automatically extracts data
             | pymc3 trace: Automatically extracts data
             | emcee sampler: Automatically extracts data
             | pyro MCMC: Automatically extracts data
@@ -46,29 +50,64 @@ def convert_to_inference_data(obj, *, group="posterior", coords=None, dims=None,
     -------
     InferenceData
     """
+
+    kwargs[group] = obj
+    kwargs["coords"] = coords
+    kwargs["dims"] = dims
+
     # Cases that convert to InferenceData
     if isinstance(obj, InferenceData):
         return obj
     elif isinstance(obj, str):
-        return InferenceData.from_netcdf(obj)
+        if obj.endswith(".csv"):
+            if group == "sample_stats":
+                kwargs["posterior"] = kwargs.pop(group)
+            elif group == "sample_stats_prior":
+                kwargs["prior"] = kwargs.pop(group)
+            return from_cmdstan(**kwargs)
+        else:
+            return InferenceData.from_netcdf(obj)
     elif obj.__class__.__name__ == "StanFit4Model":  # ugly, but doesn't make PyStan a requirement
-        return from_pystan(posterior=obj, coords=coords, dims=dims, **kwargs)
+        if group == "sample_stats":
+            kwargs["posterior"] = kwargs.pop(group)
+        elif group == "sample_stats_prior":
+            kwargs["prior"] = kwargs.pop(group)
+        return from_pystan(**kwargs)
     elif obj.__class__.__module__ == "stan.fit":  # ugly, but doesn't make PyStan3 a requirement
-        return from_pystan(posterior=obj, coords=coords, dims=dims, **kwargs)
+        if group == "sample_stats":
+            kwargs["posterior"] = kwargs.pop(group)
+        elif group == "sample_stats_prior":
+            kwargs["prior"] = kwargs.pop(group)
+        return from_pystan(**kwargs)
+    elif (
+        obj.__class__.__name__ == "PosteriorSample"
+    ):  # ugly, but doesn't make CmdStanPy a requirement
+        if group == "sample_stats":
+            kwargs["posterior"] = kwargs.pop(group)
+        elif group == "sample_stats_prior":
+            kwargs["prior"] = kwargs.pop(group)
+        return from_cmdstanpy(**kwargs)
     elif obj.__class__.__name__ == "MultiTrace":  # ugly, but doesn't make PyMC3 a requirement
-        return from_pymc3(trace=obj, coords=coords, dims=dims, **kwargs)
+        return from_pymc3(trace=kwargs.pop(group), **kwargs)
     elif obj.__class__.__name__ == "EnsembleSampler":  # ugly, but doesn't make emcee a requirement
-        return from_emcee(obj, coords=coords, dims=dims, **kwargs)
+        return from_emcee(sampler=kwargs.pop(group), **kwargs)
     elif obj.__class__.__name__ == "MCMC" and obj.__class__.__module__.startswith("pyro"):
-        return from_pyro(obj, coords=coords, dims=dims, **kwargs)
+        return from_pyro(posterior=kwargs.pop(group), **kwargs)
 
     # Cases that convert to xarray
     if isinstance(obj, xr.Dataset):
         dataset = obj
     elif isinstance(obj, dict):
-        dataset = dict_to_dataset(obj, coords=coords, dims=dims)
+        dataset = dict_to_dataset(**kwargs)
     elif isinstance(obj, np.ndarray):
-        dataset = dict_to_dataset({"x": obj}, coords=coords, dims=dims)
+        kwargs[group] = {"x": kwargs.pop(group)}
+        dataset = dict_to_dataset(**kwargs)
+    elif isinstance(obj, (list, tuple)) and isinstance(obj[0], str) and obj[0].endswith(".csv"):
+        if group == "sample_stats":
+            kwargs["posterior"] = kwargs.pop(group)
+        elif group == "sample_stats_prior":
+            kwargs["prior"] = kwargs.pop(group)
+        return from_cmdstan(**kwargs)
     else:
         allowable_types = (
             "xarray dataset",
@@ -77,6 +116,10 @@ def convert_to_inference_data(obj, *, group="posterior", coords=None, dims=None,
             "numpy array",
             "pystan fit",
             "pymc3 trace",
+            "emcee fit",
+            "pyro mcmc fit",
+            "cmdstan fit csv",
+            "cmdstanpy fit",
         )
         raise ValueError(
             "Can only convert {} to InferenceData, not {}".format(

--- a/arviz/data/converters.py
+++ b/arviz/data/converters.py
@@ -97,10 +97,9 @@ def convert_to_inference_data(obj, *, group="posterior", coords=None, dims=None,
     if isinstance(obj, xr.Dataset):
         dataset = obj
     elif isinstance(obj, dict):
-        dataset = dict_to_dataset(**kwargs)
+        dataset = dict_to_dataset(obj, coords=coords, dims=dims)
     elif isinstance(obj, np.ndarray):
-        kwargs[group] = {"x": kwargs.pop(group)}
-        dataset = dict_to_dataset(**kwargs)
+        dataset = dict_to_dataset({"x": obj}, coords=coords, dims=dims)
     elif isinstance(obj, (list, tuple)) and isinstance(obj[0], str) and obj[0].endswith(".csv"):
         if group == "sample_stats":
             kwargs["posterior"] = kwargs.pop(group)

--- a/arviz/data/converters.py
+++ b/arviz/data/converters.py
@@ -66,7 +66,10 @@ def convert_to_inference_data(obj, *, group="posterior", coords=None, dims=None,
             return from_cmdstan(**kwargs)
         else:
             return InferenceData.from_netcdf(obj)
-    elif obj.__class__.__name__ in {"StanFit4Model", "stan.fit", "PosteriorSample"}:
+    elif (
+        obj.__class__.__name__ in {"StanFit4Model", "PosteriorSample"}
+        or obj.__class__.__module__ == "stan.fit"
+    ):
         if group == "sample_stats":
             kwargs["posterior"] = kwargs.pop(group)
         elif group == "sample_stats_prior":

--- a/arviz/data/converters.py
+++ b/arviz/data/converters.py
@@ -50,7 +50,6 @@ def convert_to_inference_data(obj, *, group="posterior", coords=None, dims=None,
     -------
     InferenceData
     """
-
     kwargs[group] = obj
     kwargs["coords"] = coords
     kwargs["dims"] = dims

--- a/arviz/data/io_cmdstan.py
+++ b/arviz/data/io_cmdstan.py
@@ -1,4 +1,3 @@
-# pylint: disable=duplicate-code
 """CmdStan-specific conversion code."""
 from collections import defaultdict
 from copy import deepcopy

--- a/arviz/data/io_cmdstan.py
+++ b/arviz/data/io_cmdstan.py
@@ -1,3 +1,4 @@
+# pylint: disable=duplicate-code
 """CmdStan-specific conversion code."""
 from collections import defaultdict
 from copy import deepcopy

--- a/arviz/data/io_cmdstanpy.py
+++ b/arviz/data/io_cmdstanpy.py
@@ -130,11 +130,7 @@ class CmdStanPyConverter:
 
         if isinstance(posterior_predictive, str):
             posterior_predictive = [posterior_predictive]
-        valid_cols = [
-            col
-            for col in columns
-            if col.split(".")[0] in set(posterior_predictive)
-        ]
+        valid_cols = [col for col in columns if col.split(".")[0] in set(posterior_predictive)]
         data = _unpack_frame(self.posterior.sample, columns, valid_cols)
         return dict_to_dataset(data, library=self.cmdstanpy, coords=self.coords, dims=self.dims)
 
@@ -152,11 +148,8 @@ class CmdStanPyConverter:
             prior_predictive = [col for col in columns if prior_predictive == col.split(".")[0]]
         else:
             prior_predictive = [
-                col
-                for col in columns
-                if col.split(".")[0] in set(prior_predictive)
+                col for col in columns if col.split(".")[0] in set(prior_predictive)
             ]
-
 
         valid_cols = [col for col in columns if col not in set(prior_predictive)]
         data = _unpack_frame(self.posterior.sample, columns, valid_cols)
@@ -190,9 +183,7 @@ class CmdStanPyConverter:
 
         if isinstance(prior_predictive, str):
             prior_predictive = [prior_predictive]
-        valid_cols = [
-            col for col in columns if col.split(".")[0] in set(prior_predictive)
-        ]
+        valid_cols = [col for col in columns if col.split(".")[0] in set(prior_predictive)]
         data = _unpack_frame(self.prior.sample, columns, valid_cols)
         return dict_to_dataset(data, library=self.cmdstanpy, coords=self.coords, dims=self.dims)
 

--- a/arviz/data/io_cmdstanpy.py
+++ b/arviz/data/io_cmdstanpy.py
@@ -1,4 +1,3 @@
-# pylint: disable=duplicate-code
 """CmdStan-specific conversion code."""
 from collections import defaultdict
 from copy import deepcopy

--- a/arviz/data/io_cmdstanpy.py
+++ b/arviz/data/io_cmdstanpy.py
@@ -1,0 +1,326 @@
+"""CmdStan-specific conversion code."""
+from collections import defaultdict
+from copy import deepcopy
+import logging
+import re
+
+
+import numpy as np
+import xarray as xr
+
+from .inference_data import InferenceData
+from .base import requires, dict_to_dataset, generate_dims_coords, make_attrs
+
+
+_log = logging.getLogger(__name__)
+
+
+class CmdStanPyConverter:
+    """Encapsulate CmdStanPy specific logic."""
+
+    # pylint: disable=too-many-instance-attributes
+
+    def __init__(
+        self,
+        *,
+        posterior=None,
+        posterior_predictive=None,
+        prior=None,
+        prior_predictive=None,
+        observed_data=None,
+        log_likelihood=None,
+        coords=None,
+        dims=None
+    ):
+        self.posterior = posterior
+        self.posterior_predictive = posterior_predictive
+        self.prior = prior
+        self.prior_predictive = prior_predictive
+        self.observed_data = observed_data
+        self.log_likelihood = log_likelihood
+        self.coords = coords
+        self.dims = dims
+
+        import cmdstanpy  # pylint: disable=import-error
+
+        self.cmdstanpy = cmdstanpy
+
+    @requires("posterior")
+    def posterior_to_xarray(self):
+        """Extract posterior samples from output csv."""
+        columns = self.posterior.column_names
+
+        # filter posterior_predictive and log_likelihood
+        posterior_predictive = self.posterior_predictive
+        if posterior_predictive is None:
+            posterior_predictive = []
+        elif isinstance(posterior_predictive, str):
+            posterior_predictive = [
+                col for col in columns if posterior_predictive == col.split(".")[0]
+            ]
+        else:
+            posterior_predictive = [
+                col
+                for col in columns
+                if any(item == col.split(".")[0] for item in posterior_predictive)
+            ]
+
+        log_likelihood = self.log_likelihood
+        if log_likelihood is None:
+            log_likelihood = []
+        else:
+            log_likelihood = [col for col in columns if log_likelihood == col.split(".")[0]]
+
+        invalid_cols = (
+            posterior_predictive + log_likelihood + [col for col in columns if col.endswith("__")]
+        )
+        valid_cols = [col for col in columns if col not in invalid_cols]
+        data = _unpack_frame(self.posterior.sample, columns, valid_cols)
+        return dict_to_dataset(data, library=self.cmdstanpy, coords=self.coords, dims=self.dims)
+
+    @requires("posterior")
+    def sample_stats_to_xarray(self):
+        """Extract sample_stats from fit."""
+        dtypes = {"divergent__": bool, "n_leapfrog__": np.int64, "treedepth__": np.int64}
+
+        columns = self.posterior.column_names
+        valid_cols = [col for col in columns if col.endswith("__")]
+        # copy dims and coords
+        dims = deepcopy(self.dims) if self.dims is not None else {}
+        coords = deepcopy(self.coords) if self.coords is not None else {}
+
+        log_likelihood = self.log_likelihood
+        if isinstance(log_likelihood, str):
+            valid_cols.append(log_likelihood)
+
+            log_likelihood_cols = [col for col in columns if log_likelihood == col.split(".")[0]]
+            # change dims and coords for log_likelihood if defined
+            if log_likelihood in dims:
+                dims["log_likelihood"] = dims.pop(log_likelihood)
+
+            log_likelihood_dims = np.array(
+                [list(map(int, col.split(".")[1:])) for col in log_likelihood_cols]
+            )
+            max_dims = log_likelihood_dims.max(0)
+            max_dims = max_dims if hasattr(max_dims, "__iter__") else (max_dims,)
+            default_dim_names, _ = generate_dims_coords(shape=max_dims, var_name=log_likelihood)
+            log_likelihood_dim_names, _ = generate_dims_coords(
+                shape=max_dims, var_name="log_likelihood"
+            )
+            for default_dim_name, log_likelihood_dim_name in zip(
+                default_dim_names, log_likelihood_dim_names
+            ):
+                if default_dim_name in coords:
+                    coords[log_likelihood_dim_name] = coords.pop(default_dim_name)
+
+        data = _unpack_frame(self.posterior.sample, columns, valid_cols)
+        for s_param in list(data.keys()):
+            s_param_, *_ = s_param.split(".")
+            name = re.sub("__$", "", s_param_)
+            name = "diverging" if name == "divergent" else name
+            data[name] = data.pop(s_param).astype(dtypes.get(s_param, float))
+        return dict_to_dataset(data, library=self.cmdstanpy, coords=coords, dims=dims)
+
+    @requires("posterior")
+    @requires("posterior_predictive")
+    def posterior_predictive_to_xarray(self):
+        """Convert posterior_predictive samples to xarray."""
+        posterior_predictive = self.posterior_predictive
+        columns = self.posterior.column_names
+
+        if isinstance(posterior_predictive, str):
+            posterior_predictive = [posterior_predictive]
+        valid_cols = [
+            col
+            for col in columns
+            if any(item == col.split(".")[0] for item in posterior_predictive)
+        ]
+        data = _unpack_frame(self.posterior.sample, columns, valid_cols)
+        return dict_to_dataset(data, library=self.cmdstanpy, coords=self.coords, dims=self.dims)
+
+    @requires("prior")
+    def prior_to_xarray(self):
+        """Convert prior samples to xarray."""
+        # filter prior_predictive
+        columns = self.prior.column_names
+
+        # filter posterior_predictive and log_likelihood
+        prior_predictive = self.prior_predictive
+        if prior_predictive is None:
+            prior_predictive = []
+        elif isinstance(prior_predictive, str):
+            prior_predictive = [col for col in columns if prior_predictive == col.split(".")[0]]
+        else:
+            prior_predictive = [
+                col
+                for col in columns
+                if any(item == col.split(".")[0] for item in prior_predictive)
+            ]
+
+        valid_cols = [col for col in columns if col not in prior_predictive]
+        data = _unpack_frame(self.posterior.sample, columns, valid_cols)
+        return dict_to_dataset(data, library=self.cmdstanpy, coords=self.coords, dims=self.dims)
+
+    @requires("prior")
+    def sample_stats_prior_to_xarray(self):
+        """Extract sample_stats from fit."""
+        dtypes = {"divergent__": bool, "n_leapfrog__": np.int64, "treedepth__": np.int64}
+
+        columns = self.prior.column_names
+        valid_cols = [col for col in columns if col.endswith("__")]
+        # copy dims and coords
+        dims = deepcopy(self.dims) if self.dims is not None else {}
+        coords = deepcopy(self.coords) if self.coords is not None else {}
+
+        data = _unpack_frame(self.prior.sample, columns, valid_cols)
+        for s_param in list(data.keys()):
+            s_param_, *_ = s_param.split(".")
+            name = re.sub("__$", "", s_param_)
+            name = "diverging" if name == "divergent" else name
+            data[name] = data.pop(s_param).astype(dtypes.get(s_param, float))
+        return dict_to_dataset(data, library=self.cmdstanpy, coords=coords, dims=dims)
+
+    @requires("prior")
+    @requires("prior_predictive")
+    def prior_predictive_to_xarray(self):
+        """Convert prior_predictive samples to xarray."""
+        prior_predictive = self.prior_predictive
+        columns = self.prior.column_names
+
+        if isinstance(prior_predictive, str):
+            prior_predictive = [prior_predictive]
+        valid_cols = [
+            col for col in columns if any(item == col.split(".")[0] for item in prior_predictive)
+        ]
+        data = _unpack_frame(self.prior.sample, columns, valid_cols)
+        return dict_to_dataset(data, library=self.cmdstanpy, coords=self.coords, dims=self.dims)
+
+    @requires("observed_data")
+    def observed_data_to_xarray(self):
+        """Convert observed data to xarray."""
+        observed_data = {}
+        for key, vals in self.observed_data.items():
+            vals = np.atleast_1d(vals)
+            val_dims = self.dims.get(key)
+            val_dims, coords = generate_dims_coords(
+                vals.shape, key, dims=val_dims, coords=self.coords
+            )
+            observed_data[key] = xr.DataArray(vals, dims=val_dims, coords=coords)
+        return xr.Dataset(data_vars=observed_data, attrs=make_attrs(library=self.cmdstanpy))
+
+    def to_inference_data(self):
+        """Convert all available data to an InferenceData object.
+
+        Note that if groups can not be created (i.e., there is no `output`, so
+        the `posterior` and `sample_stats` can not be extracted), then the InferenceData
+        will not have those groups.
+        """
+        return InferenceData(
+            **{
+                "posterior": self.posterior_to_xarray(),
+                "sample_stats": self.sample_stats_to_xarray(),
+                "posterior_predictive": self.posterior_predictive_to_xarray(),
+                "prior": self.prior_to_xarray(),
+                "sample_stats_prior": self.sample_stats_prior_to_xarray(),
+                "prior_predictive": self.prior_predictive_to_xarray(),
+                "observed_data": self.observed_data_to_xarray(),
+            }
+        )
+
+
+def _unpack_frame(data, columns, valid_cols):
+    """Transform a list of pandas.DataFrames to dictionary containing ndarrays.
+
+    Parameters
+    ----------
+    data : np.ndarray
+    columns : list
+    valid_cols : list
+
+    Returns
+    -------
+    dict
+        key, values pairs. Values are formatted to shape = (chains, draws, *shape)
+    """
+    draws, chains, *_ = data.shape
+
+    column_groups = defaultdict(list)
+    column_locs = defaultdict(list)
+    for i, col in enumerate(columns):
+        col_base, *col_tail = col.split(".")
+        if len(col_tail):
+            column_groups[col_base].append(tuple(map(int, col_tail)))
+        column_locs[col_base].append(i)
+    dims = {}
+    for colname, col_dims in column_groups.items():
+        dims[colname] = tuple(np.array(col_dims).max(0))
+    sample = {}
+    valid_base_cols = []
+    for col in valid_cols:
+        base_col, *_ = col.split(".")
+        if base_col not in valid_base_cols:
+            valid_base_cols.append(base_col)
+
+    for key in valid_base_cols:
+        ndim = dims.get(key, None)
+        if ndim is not None:
+            sample[key] = np.full((chains, draws, *ndim), np.nan)
+        else:
+            sample[key] = np.full((chains, draws), np.nan)
+        shape_location = column_groups.get(key, None)
+        if shape_location is None:
+            sample[key][Ellipsis] = np.swapaxes(data[..., column_locs[key][0]], 0, 1)
+        else:
+            for i, shape_loc in zip(column_locs[key], shape_location):
+                shape_loc = [Ellipsis] + [j - 1 for j in shape_loc]
+                sample[key][tuple(shape_loc)] = np.swapaxes(data[..., i], 0, 1)
+    return sample
+
+
+def from_cmdstanpy(
+    posterior=None,
+    *,
+    posterior_predictive=None,
+    prior=None,
+    prior_predictive=None,
+    observed_data=None,
+    log_likelihood=None,
+    coords=None,
+    dims=None
+):
+    """Convert CmdStan data into an InferenceData object.
+
+    Parameters
+    ----------
+    posterior : PosteriorSample object
+        PyCmdStan PosteriorSample
+    posterior_predictive : str, list of str
+        Posterior predictive samples for the fit.
+    prior : PosteriorSample
+        PyCmdStan PosteriorSample
+    prior_predictive : str, list of str
+        Prior predictive samples for the fit.
+    observed_data : dict
+        Observed data used in the sampling.
+    log_likelihood : str
+        Pointwise log_likelihood for the data.
+    coords : dict of str or dict of iterable
+        A dictionary containing the values that are used as index. The key
+        is the name of the dimension, the values are the index values.
+    dims : dict of str or list of str
+        A mapping from variables to a list of coordinate names for the variable.
+
+    Returns
+    -------
+    InferenceData object
+    """
+    return CmdStanPyConverter(
+        posterior=posterior,
+        posterior_predictive=posterior_predictive,
+        prior=prior,
+        prior_predictive=prior_predictive,
+        observed_data=observed_data,
+        log_likelihood=log_likelihood,
+        coords=coords,
+        dims=dims,
+    ).to_inference_data()

--- a/arviz/data/io_cmdstanpy.py
+++ b/arviz/data/io_cmdstanpy.py
@@ -1,3 +1,4 @@
+# pylint: disable=duplicate-code
 """CmdStan-specific conversion code."""
 from collections import defaultdict
 from copy import deepcopy


### PR DESCRIPTION
Implements `from_cmdstanpy`

Also fixes `convert` function to correctly handle different special groups and enables also `from_cmdstan` if input is a `list` or `str` that endswith `.csv`.