### PR TITLE
pointwise elpd diagnostics (text formatting and plot)

### DIFF
--- a/arviz/plots/__init__.py
+++ b/arviz/plots/__init__.py
@@ -6,7 +6,7 @@ from .energyplot import plot_energy
 from .forestplot import plot_forest
 from .kdeplot import plot_kde, _fast_kde, _fast_kde_2d
 from .parallelplot import plot_parallel
-from .pointwiseelpdplot import plot_pointwise_elpd
+from .elpdplot import plot_elpd
 from .posteriorplot import plot_posterior
 from .traceplot import plot_trace
 from .pairplot import plot_pair
@@ -29,7 +29,7 @@ __all__ = [
     "_fast_kde",
     "_fast_kde_2d",
     "plot_parallel",
-    "plot_pointwise_elpd",
+    "plot_elpd",
     "plot_posterior",
     "plot_trace",
     "plot_pair",

--- a/arviz/plots/__init__.py
+++ b/arviz/plots/__init__.py
@@ -6,6 +6,7 @@ from .energyplot import plot_energy
 from .forestplot import plot_forest
 from .kdeplot import plot_kde, _fast_kde, _fast_kde_2d
 from .parallelplot import plot_parallel
+from .pointwiseelpdplot import plot_pointwise_elpd
 from .posteriorplot import plot_posterior
 from .traceplot import plot_trace
 from .pairplot import plot_pair
@@ -28,6 +29,7 @@ __all__ = [
     "_fast_kde",
     "_fast_kde_2d",
     "plot_parallel",
+    "plot_pointwise_elpd",
     "plot_posterior",
     "plot_trace",
     "plot_pair",

--- a/arviz/plots/elpdplot.py
+++ b/arviz/plots/elpdplot.py
@@ -104,7 +104,7 @@ def plot_elpd(
             "All Information Criteria must be of the same kind, but both loo and waic data present"
         )
     ic = ics[0]
-    scales = [elpd_data["scale"] for elpd_data in compare_dict.values()]
+    scales = [elpd_data["{}_scale".format(ic)] for elpd_data in compare_dict.values()]
     if not all(x == scales[0] for x in scales):
         raise SyntaxError(
             "All Information Criteria must be on the same scale, but {} are present".format(

--- a/arviz/plots/elpdplot.py
+++ b/arviz/plots/elpdplot.py
@@ -193,10 +193,8 @@ def plot_elpd(
                     label,
                     horizontalalignment="center",
                     verticalalignment="bottom" if ydata[outlier] > 0 else "top",
-                    fontsize=.8*xt_labelsize,
+                    fontsize=0.8 * xt_labelsize,
                 )
-
-
 
         ax.set_title("{} - {}".format(*models), fontsize=titlesize, wrap=True)
         ax.set_ylabel("ELPD difference", fontsize=ax_labelsize, wrap=True)
@@ -249,7 +247,7 @@ def plot_elpd(
                             label,
                             horizontalalignment="center",
                             verticalalignment="bottom" if ydata[outlier] > 0 else "top",
-                            fontsize=.8*xt_labelsize,
+                            fontsize=0.8 * xt_labelsize,
                         )
 
                 if j + 1 != numvars - 1:

--- a/arviz/plots/elpdplot.py
+++ b/arviz/plots/elpdplot.py
@@ -115,7 +115,9 @@ def plot_elpd(
         plot_kwargs = {}
     plot_kwargs.setdefault("marker", "+")
 
-    pointwise_data = [(compare_dict[model]["{}_i".format(ic)]) for model in models]
+    pointwise_data = [
+        get_coords(compare_dict[model]["{}_i".format(ic)], coords) for model in models
+    ]
     xdata = np.arange(pointwise_data[0].size)
 
     if isinstance(color, str):

--- a/arviz/plots/elpdplot.py
+++ b/arviz/plots/elpdplot.py
@@ -11,7 +11,7 @@ from .plot_utils import _scale_fig_size
 from ..stats import waic, loo
 
 
-def plot_pointwise_elpd(
+def plot_elpd(
     idata_dict,
     ic="waic",
     color=None,
@@ -70,7 +70,7 @@ def plot_pointwise_elpd(
         >>> import arviz as az
         >>> idata1 = az.load_arviz_data("centered_eight")
         >>> idata2 = az.load_arviz_data("non_centered_eight")
-        >>> az.plot_pointwise_elpd(
+        >>> az.plot_elpd(
         >>>     {"centered model": idata1, "non centered model": idata2},
         >>>     xlabels=True
         >>> )

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -407,7 +407,7 @@ def color_from_dim(dataarray, dim_name):
 
 
 def format_coords_as_labels(dataarray):
-    """Format 1d or multi-d dataarray coords as strings"""
+    """Format 1d or multi-d dataarray coords as strings."""
     coord_labels = dataarray.coords.to_index().values
     if isinstance(coord_labels[0], tuple):
         fmt = ", ".join(["{}" for _ in coord_labels[0]])

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -375,3 +375,57 @@ def get_coords(data, coords):
                 " dimensions are valid. {}"
             ).format(err)
         )
+
+
+def color_from_dim(dataarray, dim_name):
+    """Return colors and color mapping of a DataArray using coord values as color code.
+
+    Parameters
+    ----------
+    dataarray : xarray.DataArray
+    dim_name : str
+        dimension whose coordinates will be used as color code.
+
+    Returns
+    -------
+    colors : array of floats
+        Array of colors (as floats for use with a cmap) for each element in the dataarray.
+    color_mapping : mapping coord_value -> float
+        Mapping from coord values to corresponding color
+    """
+    present_dims = dataarray.dims
+    coord_values = dataarray[dim_name].values
+    unique_coords = set(coord_values)
+    color_mapping = {coord: num / len(unique_coords) for num, coord in enumerate(unique_coords)}
+    if len(present_dims) > 1:
+        multi_coords = dataarray.coords.to_index()
+        coord_idx = present_dims.index(dim_name)
+        colors = [color_mapping[coord[coord_idx]] for coord in multi_coords]
+    else:
+        colors = [color_mapping[coord] for coord in coord_values]
+    return colors, color_mapping
+
+
+def format_coords_as_labels(dataarray):
+    """Format 1d or multi-d dataarray coords as strings"""
+    coord_labels = dataarray.coords.to_index().values
+    if isinstance(coord_labels[0], tuple):
+        fmt = ", ".join(["{}" for _ in coord_labels[0]])
+        coord_labels[:] = [fmt.format(*x) for x in coord_labels]
+    else:
+        coord_labels[:] = ["{}".format(s) for s in coord_labels]
+    return dataarray
+
+
+def set_xticklabels(ax, coord_labels):
+    """Set xticklabels to label list using Matplotlib default formatter."""
+    xlim = ax.get_xlim()
+    ax.xaxis.get_major_locator().set_params(nbins=9, steps=[1, 2, 5, 10])
+    xticks = ax.get_xticks().astype(np.int64)
+    xticks = xticks[(xticks > xlim[0]) & (xticks < xlim[1])]
+    if len(xticks) > len(coord_labels):
+        ax.set_xticks(np.arange(len(coord_labels)))
+        ax.set_xticklabels(coord_labels)
+    else:
+        ax.set_xticks(xticks)
+        ax.set_xticklabels(coord_labels[xticks])

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -419,10 +419,9 @@ def format_coords_as_labels(dataarray):
 
 def set_xticklabels(ax, coord_labels):
     """Set xticklabels to label list using Matplotlib default formatter."""
-    xlim = ax.get_xlim()
     ax.xaxis.get_major_locator().set_params(nbins=9, steps=[1, 2, 5, 10])
     xticks = ax.get_xticks().astype(np.int64)
-    xticks = xticks[(xticks > xlim[0]) & (xticks < xlim[1])]
+    xticks = xticks[(xticks >= 0) & (xticks < len(coord_labels))]
     if len(xticks) > len(coord_labels):
         ax.set_xticks(np.arange(len(coord_labels)))
         ax.set_xticklabels(coord_labels)

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -414,7 +414,7 @@ def format_coords_as_labels(dataarray):
         coord_labels[:] = [fmt.format(*x) for x in coord_labels]
     else:
         coord_labels[:] = ["{}".format(s) for s in coord_labels]
-    return dataarray
+    return coord_labels
 
 
 def set_xticklabels(ax, coord_labels):

--- a/arviz/plots/pointwiseelpdplot.py
+++ b/arviz/plots/pointwiseelpdplot.py
@@ -1,0 +1,147 @@
+"""Plot pointwise elpd estimations of inference data."""
+import numpy as np
+import xarray as xr
+import matplotlib.pyplot as plt
+from matplotlib.ticker import NullFormatter
+
+from ..data import convert_to_inference_data
+from .plot_utils import _scale_fig_size
+from ..stats import waic, loo
+
+
+def plot_pointwise_elpd(
+    idata_dict,
+    ic="waic",
+    color=None,
+    figsize=None,
+    textsize=None,
+    coords=None,
+    ax=None,
+    scale="deviance",
+    plot_kwargs=None,
+):
+    """
+    Plot a scatter or hexbin matrix of the sampled parameters.
+
+    Parameters
+    ----------
+    idata_dict : mapping, str -> InferenceData
+        A dictionary mapping the model name to the object containing its inference data.
+        Refer to az.convert_to_inference_data for details on possible dict items
+    ic : str, optional
+        Information Criterion (WAIC or LOO) used to compare models. Default WAIC.
+    color : str or array_like, optional
+        Colors of the scatter plot, if color is a str all dots will have the same color,
+        if it is the size of the observations, each dot will have the specified color,
+        otherwise, it will be interpreted as a list of the dims to be used for the color code
+    figsize : figure size tuple, optional
+        If None, size is (8 + numvars, 8 + numvars)
+    textsize: int, optional
+        Text size for labels. If None it will be autoscaled based on figsize.
+    coords : mapping, optional
+        Coordinates of points to plot. **All** values are used for computation, but only a
+        a subset can be plotted for convenience.
+    ax: axes, optional
+        Matplotlib axes
+    scale : str, optional
+        scale argument passed to az.waic or az.loo, see their docs for details
+    plot_kwargs : dicts, optional
+        Additional keywords passed to ax.plot
+    Returns
+    -------
+    ax : matplotlib axes
+
+    Examples
+    --------
+    """
+    valid_ics = ["waic", "loo"]
+    ic = ic.lower()
+    if ic not in valid_ics:
+        raise ValueError(
+            ("Information Criteria type {} not recognized."
+             "IC must be in {}").format(ic, valid_ics)
+        )
+
+    if coords is None:
+        coords = {}
+
+    if plot_kwargs is None:
+        plot_kwargs = {}
+        plot_kwargs.setdefault("marker", ".")
+        plot_kwargs.setdefault("lw", 0)
+
+
+    def get_pointwise_as_dataarray(idata, coords=coords, ic=ic, scale=scale):
+        if ic == "waic":
+            pointwise_elpd = waic(idata, pointwise=True, scale=scale).waic_i
+        else:
+            pointwise_elpd = loo(idata, pointwise=True, scale=scale).loo_i
+        like_dataarray = idata.sample_stats.log_likelihood
+        dims = [dim for dim in like_dataarray.dims if dim not in ["chain", "draw"]]
+        coords = {dim: like_dataarray.coords.indexes[dim] for dim in dims}
+        elpd_dataarray = xr.DataArray(pointwise_elpd, dims=dims, coords=coords)
+        return elpd_dataarray.sel(**coords)
+
+
+    # Make sure all objects in idata_dict are InferenceData
+    idata_dict = {key: convert_to_inference_data(idata) for key, idata in idata_dict.items()}
+    numvars = len(idata_dict)
+    models = list(idata_dict.keys())
+    pointwise_data = [get_pointwise_as_dataarray(idata_dict[model]) for model in models]
+
+
+    if numvars < 2:
+        raise Exception("Number of models to compare must be 2 or greater.")
+
+    if numvars == 2:
+        (figsize, ax_labelsize, _, xt_labelsize, _, _) = _scale_fig_size(
+            figsize, textsize, numvars - 1, numvars - 1
+        )
+
+        if ax is None:
+            _, ax = plt.subplots(figsize=figsize, constrained_layout=True)
+
+        ax.plot(pointwise_data[0]-pointwise_data[1], **plot_kwargs)
+
+        ax.set_xlabel("{}".format(models[0]), fontsize=ax_labelsize, wrap=True)
+        ax.set_ylabel("{}".format(models[1]), fontsize=ax_labelsize, wrap=True)
+        ax.tick_params(labelsize=xt_labelsize)
+
+    else:
+        (figsize, ax_labelsize, _, xt_labelsize, _, _) = _scale_fig_size(
+            figsize, textsize, numvars - 2, numvars - 2
+        )
+
+        if ax is None:
+            _, ax = plt.subplots(
+                numvars - 1, numvars - 1, figsize=figsize, constrained_layout=True
+            )
+
+        for i in range(0, numvars - 1):
+            var1 = pointwise_data[i]
+
+            for j in range(0, numvars - 1):
+                if j < i:
+                    ax[j, i].axis("off")
+                    continue
+
+                var2 = pointwise_data[j + 1]
+
+                ax[j, i].plot(var1-var2, **plot_kwargs)
+
+                if j + 1 != numvars - 1:
+                    ax[j, i].axes.get_xaxis().set_major_formatter(NullFormatter())
+                else:
+                    ax[j, i].set_xlabel(
+                        "{}".format(models[i]), fontsize=ax_labelsize, wrap=True
+                    )
+                if i != 0:
+                    ax[j, i].axes.get_yaxis().set_major_formatter(NullFormatter())
+                else:
+                    ax[j, i].set_ylabel(
+                        "{}".format(models[j + 1]), fontsize=ax_labelsize, wrap=True
+                    )
+
+                ax[j, i].tick_params(labelsize=xt_labelsize)
+
+    return ax

--- a/arviz/plots/pointwiseelpdplot.py
+++ b/arviz/plots/pointwiseelpdplot.py
@@ -55,6 +55,7 @@ def plot_pointwise_elpd(
         scale argument passed to az.waic or az.loo, see their docs for details
     plot_kwargs : dicts, optional
         Additional keywords passed to ax.plot
+
     Returns
     -------
     ax : matplotlib axes
@@ -66,13 +67,13 @@ def plot_pointwise_elpd(
     .. plot::
         :context: close-figs
 
-        In [1]: import arviz as az
-           ...: idata1 = az.load_arviz_data("centered_eight")
-           ...: idata2 = az.load_arviz_data("non_centered_eight")
-           ...: az.plot_pointwise_elpd(
-           ...:     {"centered model": idata1, "non centered model": idata2},
-           ...:     xlabels=True
-           ...: )
+        >>> import arviz as az
+        >>> idata1 = az.load_arviz_data("centered_eight")
+        >>> idata2 = az.load_arviz_data("non_centered_eight")
+        >>> az.plot_pointwise_elpd(
+        >>>     {"centered model": idata1, "non centered model": idata2},
+        >>>     xlabels=True
+        >>> )
 
     """
     valid_ics = ["waic", "loo"]
@@ -228,7 +229,7 @@ def plot_pointwise_elpd(
 
 
 def _set_xticklabels(ax, coord_labels):
-    """Set xticklabels to coordinate labels using Matplotlib default formatter"""
+    """Set xticklabels to coordinate labels using Matplotlib default formatter."""
     xlim = ax.get_xlim()
     ax.xaxis.get_major_locator().set_params(nbins=9, steps=[1, 2, 5, 10])
     xticks = ax.get_xticks().astype(np.int64)

--- a/arviz/plots/pointwiseelpdplot.py
+++ b/arviz/plots/pointwiseelpdplot.py
@@ -127,7 +127,9 @@ def plot_pointwise_elpd(
         )
 
         if ax is None:
-            fig, ax = plt.subplots(numvars - 1, numvars - 1, figsize=figsize, constrained_layout=True)
+            fig, ax = plt.subplots(
+                numvars - 1, numvars - 1, figsize=figsize, constrained_layout=True
+            )
 
         for i in range(0, numvars - 1):
             var1 = pointwise_data[i]
@@ -154,7 +156,9 @@ def plot_pointwise_elpd(
                     ax[j, i].set_ylabel("ELPD difference", fontsize=ax_labelsize, wrap=True)
 
                 ax[j, i].tick_params(labelsize=xt_labelsize)
-                ax[j, i].set_title("{} - {}".format(models[i], models[j+1]), fontsize=titlesize, wrap=True)
+                ax[j, i].set_title(
+                    "{} - {}".format(models[i], models[j + 1]), fontsize=titlesize, wrap=True
+                )
         if xlabels:
             fig.autofmt_xdate()
 

--- a/arviz/plots/pointwiseelpdplot.py
+++ b/arviz/plots/pointwiseelpdplot.py
@@ -3,6 +3,7 @@ import numpy as np
 import xarray as xr
 import matplotlib.pyplot as plt
 from matplotlib.ticker import NullFormatter
+import matplotlib.ticker as mticker
 
 from ..data import convert_to_inference_data
 from .plot_utils import _scale_fig_size
@@ -13,6 +14,7 @@ def plot_pointwise_elpd(
     idata_dict,
     ic="waic",
     color=None,
+    xlabels=False,
     figsize=None,
     textsize=None,
     coords=None,
@@ -34,6 +36,8 @@ def plot_pointwise_elpd(
         Colors of the scatter plot, if color is a str all dots will have the same color,
         if it is the size of the observations, each dot will have the specified color,
         otherwise, it will be interpreted as a list of the dims to be used for the color code
+    xlabels : bool, optional
+        Use coords as xticklabels
     figsize : figure size tuple, optional
         If None, size is (8 + numvars, 8 + numvars)
     textsize: int, optional
@@ -58,8 +62,9 @@ def plot_pointwise_elpd(
     ic = ic.lower()
     if ic not in valid_ics:
         raise ValueError(
-            ("Information Criteria type {} not recognized."
-             "IC must be in {}").format(ic, valid_ics)
+            ("Information Criteria type {} not recognized." "IC must be in {}").format(
+                ic, valid_ics
+            )
         )
 
     if coords is None:
@@ -68,8 +73,7 @@ def plot_pointwise_elpd(
     if plot_kwargs is None:
         plot_kwargs = {}
         plot_kwargs.setdefault("marker", ".")
-        plot_kwargs.setdefault("lw", 0)
-
+        # plot_kwargs.setdefault("lw", 0)
 
     def get_pointwise_as_dataarray(idata, coords=coords, ic=ic, scale=scale):
         if ic == "waic":
@@ -80,46 +84,50 @@ def plot_pointwise_elpd(
         dims = [dim for dim in like_dataarray.dims if dim not in ["chain", "draw"]]
         present_coords = {dim: like_dataarray.coords.indexes[dim] for dim in dims}
         elpd_dataarray = xr.DataArray(pointwise_elpd, dims=dims, coords=present_coords)
-        print(elpd_dataarray)
-        print(coords)
         elpd_dataarray = elpd_dataarray.sel(**coords)
-        print(elpd_dataarray)
         return elpd_dataarray
-
 
     # Make sure all objects in idata_dict are InferenceData
     idata_dict = {key: convert_to_inference_data(idata) for key, idata in idata_dict.items()}
     numvars = len(idata_dict)
     models = list(idata_dict.keys())
     pointwise_data = [get_pointwise_as_dataarray(idata_dict[model]) for model in models]
-
+    xdata = np.arange(pointwise_data[0].size)
+    if xlabels:
+        coord_labels = pointwise_data[0].coords.to_index().values
+        if isinstance(coord_labels[0], tuple):
+            fmt = ", ".join(["{}" for _ in coord_labels[0]])
+            coord_labels[:] = [fmt.format(*x) for x in coord_labels]
+        else:
+            coord_labels[:] = ["{}".format(s) for s in coord_labels]
 
     if numvars < 2:
         raise Exception("Number of models to compare must be 2 or greater.")
 
     if numvars == 2:
-        (figsize, ax_labelsize, _, xt_labelsize, _, _) = _scale_fig_size(
+        (figsize, ax_labelsize, titlesize, xt_labelsize, _, _) = _scale_fig_size(
             figsize, textsize, numvars - 1, numvars - 1
         )
 
         if ax is None:
-            _, ax = plt.subplots(figsize=figsize, constrained_layout=True)
+            fig, ax = plt.subplots(figsize=figsize, constrained_layout=True)
 
-        ax.plot(pointwise_data[0]-pointwise_data[1], **plot_kwargs)
+        ax.scatter(xdata, pointwise_data[0] - pointwise_data[1], **plot_kwargs)
 
-        ax.set_xlabel("{}".format(models[0]), fontsize=ax_labelsize, wrap=True)
-        ax.set_ylabel("{}".format(models[1]), fontsize=ax_labelsize, wrap=True)
+        ax.set_title("{} - {}".format(*models), fontsize=titlesize, wrap=True)
+        ax.set_ylabel("ELPD difference", fontsize=ax_labelsize, wrap=True)
         ax.tick_params(labelsize=xt_labelsize)
+        if xlabels:
+            set_xticklabels(ax, coord_labels)
+            fig.autofmt_xdate()
 
     else:
-        (figsize, ax_labelsize, _, xt_labelsize, _, _) = _scale_fig_size(
+        (figsize, ax_labelsize, titlesize, xt_labelsize, _, _) = _scale_fig_size(
             figsize, textsize, numvars - 2, numvars - 2
         )
 
         if ax is None:
-            _, ax = plt.subplots(
-                numvars - 1, numvars - 1, figsize=figsize, constrained_layout=True
-            )
+            fig, ax = plt.subplots(numvars - 1, numvars - 1, figsize=figsize, constrained_layout=True)
 
         for i in range(0, numvars - 1):
             var1 = pointwise_data[i]
@@ -131,21 +139,36 @@ def plot_pointwise_elpd(
 
                 var2 = pointwise_data[j + 1]
 
-                ax[j, i].plot(var1-var2, **plot_kwargs)
+                ax[j, i].scatter(xdata, var1 - var2, **plot_kwargs)
 
                 if j + 1 != numvars - 1:
                     ax[j, i].axes.get_xaxis().set_major_formatter(NullFormatter())
-                else:
-                    ax[j, i].set_xlabel(
-                        "{}".format(models[i]), fontsize=ax_labelsize, wrap=True
-                    )
+                    ax[j, i].set_xticks([])
+                elif xlabels:
+                    set_xticklabels(ax[j, i], coord_labels)
+
                 if i != 0:
                     ax[j, i].axes.get_yaxis().set_major_formatter(NullFormatter())
+                    ax[j, i].set_yticks([])
                 else:
-                    ax[j, i].set_ylabel(
-                        "{}".format(models[j + 1]), fontsize=ax_labelsize, wrap=True
-                    )
+                    ax[j, i].set_ylabel("ELPD difference", fontsize=ax_labelsize, wrap=True)
 
                 ax[j, i].tick_params(labelsize=xt_labelsize)
+                ax[j, i].set_title("{} - {}".format(models[i], models[j+1]), fontsize=titlesize, wrap=True)
+        if xlabels:
+            fig.autofmt_xdate()
 
     return ax
+
+
+def set_xticklabels(ax, coord_labels):
+    xlim = ax.get_xlim()
+    ax.xaxis.get_major_locator().set_params(nbins=9, steps=[1, 2, 5, 10])
+    xticks = ax.get_xticks().astype(np.int64)
+    xticks = xticks[(xticks > xlim[0]) & (xticks < xlim[1])]
+    if len(xticks) > len(coord_labels):
+        ax.set_xticks(np.arange(len(coord_labels)))
+        ax.set_xticklabels(coord_labels)
+    else:
+        ax.set_xticks(xticks)
+        ax.set_xticklabels(coord_labels[xticks])

--- a/arviz/plots/pointwiseelpdplot.py
+++ b/arviz/plots/pointwiseelpdplot.py
@@ -78,9 +78,13 @@ def plot_pointwise_elpd(
             pointwise_elpd = loo(idata, pointwise=True, scale=scale).loo_i
         like_dataarray = idata.sample_stats.log_likelihood
         dims = [dim for dim in like_dataarray.dims if dim not in ["chain", "draw"]]
-        coords = {dim: like_dataarray.coords.indexes[dim] for dim in dims}
-        elpd_dataarray = xr.DataArray(pointwise_elpd, dims=dims, coords=coords)
-        return elpd_dataarray.sel(**coords)
+        present_coords = {dim: like_dataarray.coords.indexes[dim] for dim in dims}
+        elpd_dataarray = xr.DataArray(pointwise_elpd, dims=dims, coords=present_coords)
+        print(elpd_dataarray)
+        print(coords)
+        elpd_dataarray = elpd_dataarray.sel(**coords)
+        print(elpd_dataarray)
+        return elpd_dataarray
 
 
     # Make sure all objects in idata_dict are InferenceData

--- a/arviz/stats/__init__.py
+++ b/arviz/stats/__init__.py
@@ -15,6 +15,7 @@ __all__ = [
     "summary",
     "waic",
     "effective_sample_size",
+    "ELPDData",
     "ess",
     "rhat",
     "mcse",

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -225,9 +225,9 @@ def compare(
         for idx, val in enumerate(ics.index):
             res = ics.loc[val]
             if scale_value < 0:
-                diff = res[ic_i] - min_ic_i_val
+                diff = (res[ic_i] - min_ic_i_val).values
             else:
-                diff = min_ic_i_val - res[ic_i]
+                diff = (min_ic_i_val - res[ic_i]).values
             d_ic = np.sum(diff)
             d_std_err = np.sqrt(len(diff) * np.var(diff))
             std_err = ses.loc[val]

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -522,14 +522,19 @@ def psislw(log_weights, reff=1.0):
     kss : array
         Pareto tail indices
     """
-    n_samples = log_weights.shape[-1]
+    if hasattr(log_weights, "samples"):
+        n_samples = len(log_weights.samples)
+        shape = [size for size, dim in zip(log_weights.shape, log_weights.dims) if dim != "samples"]
+    else:
+        n_samples = log_weights.shape[-1]
+        shape = log_weights.shape[:-1]
     # precalculate constants
     cutoff_ind = -int(np.ceil(min(n_samples / 5.0, 3 * (n_samples / reff) ** 0.5))) - 1
     cutoffmin = np.log(np.finfo(float).tiny)  # pylint: disable=no-member, assignment-from-no-return
     k_min = 1.0 / 3
 
     # create output array with proper dimensions
-    out = tuple([np.empty_like(log_weights), np.empty(log_weights.shape[:-1])])
+    out = tuple([np.empty_like(log_weights), np.empty(shape)])
 
     # define kwargs
     func_kwargs = {"cutoff_ind": cutoff_ind, "cutoffmin": cutoffmin, "k_min": k_min, "out": out}
@@ -564,7 +569,6 @@ def _psislw(log_weights, cutoff_ind, cutoffmin, k_min=1.0 / 3):
     kss : float
         Pareto tail index
     """
-
     x = np.asarray(log_weights)
 
     # improve numerical accuracy

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -452,12 +452,8 @@ def loo(data, pointwise=False, reff=None, scale="deviance"):
     p_loo = lppd - loo_lppd / scale_value
 
     if pointwise:
-        loo_lppd_i = xr.DataArray(
-            loo_lppd_i.reshape(shape), dims=dims, coords=present_coords
-        )
-        pareto_shape = xr.DataArray(
-            pareto_shape.reshape(shape), dims=dims, coords=present_coords
-        )
+        loo_lppd_i = xr.DataArray(loo_lppd_i.reshape(shape), dims=dims, coords=present_coords)
+        pareto_shape = xr.DataArray(pareto_shape.reshape(shape), dims=dims, coords=present_coords)
         if np.equal(loo_lppd, loo_lppd_i).all():  # pylint: disable=no-member
             warnings.warn(
                 "The point-wise LOO is the same with the sum LOO, please double check "
@@ -1048,9 +1044,7 @@ def waic(data, pointwise=False, scale="deviance"):
     p_waic = np.sum(vars_lpd)
 
     if pointwise:
-        waic_i = xr.DataArray(
-            waic_i.reshape(shape), dims=dims, coords=present_coords
-        )
+        waic_i = xr.DataArray(waic_i.reshape(shape), dims=dims, coords=present_coords)
         if np.equal(waic_sum, waic_i).all():  # pylint: disable=no-member
             warnings.warn(
                 """The point-wise WAIC is the same with the sum WAIC, please double check

--- a/arviz/stats/stats_utils.py
+++ b/arviz/stats/stats_utils.py
@@ -11,7 +11,7 @@ from xarray import apply_ufunc
 
 _log = logging.getLogger(__name__)
 
-__all__ = ["autocorr", "autocov", "make_ufunc", "wrap_xarray_ufunc"]
+__all__ = ["autocorr", "autocov", "ELPDData", "make_ufunc", "wrap_xarray_ufunc"]
 
 
 def autocov(ary, axis=-1):

--- a/arviz/stats/stats_utils.py
+++ b/arviz/stats/stats_utils.py
@@ -382,6 +382,7 @@ Pareto k diagnostic values:
 """
 scale_dict = {"deviance": "IC", "log": "elpd", "negative_log": "-elpd"}
 
+
 class ELPDData(pd.Series):  # pylint: disable=too-many-ancestors
     def __str__(self):
         kind = self.index[0]
@@ -390,17 +391,26 @@ class ELPDData(pd.Series):  # pylint: disable=too-many-ancestors
             raise ValueError("Invalid ELPDData object")
 
         scale_str = scale_dict[self["{}_scale".format(kind)]]
-        padding = len(scale_str)+len(kind)+1
-        base = base_fmt.format(padding, padding-2)
-        base = base.format("", kind=kind, scale=scale_str, n_samples=self.n_samples, n_points=self.n_data_points, *self.values)
+        padding = len(scale_str) + len(kind) + 1
+        base = base_fmt.format(padding, padding - 2)
+        base = base.format(
+            "",
+            kind=kind,
+            scale=scale_str,
+            n_samples=self.n_samples,
+            n_points=self.n_data_points,
+            *self.values
+        )
 
         if self.warning:
             base += "\n\nThere has been a warning during the calculation. Please check the results."
 
-        if kind == "loo" and  "pareto_k" in self:
-            counts, _ = np.histogram(self.pareto_k, bins=[-np.inf, .5, .7, 1, np.inf])
+        if kind == "loo" and "pareto_k" in self:
+            counts, _ = np.histogram(self.pareto_k, bins=[-np.inf, 0.5, 0.7, 1, np.inf])
             extended = pointwise_loo_fmt.format(max(4, len(str(np.max(counts)))))
-            extended = extended.format("Count", "Pct.", *[*counts, *(counts/np.sum(counts)*100)])
+            extended = extended.format(
+                "Count", "Pct.", *[*counts, *(counts / np.sum(counts) * 100)]
+            )
             base = "\n".join([base, extended])
         return base
 

--- a/arviz/stats/stats_utils.py
+++ b/arviz/stats/stats_utils.py
@@ -384,7 +384,10 @@ SCALE_DICT = {"deviance": "IC", "log": "elpd", "negative_log": "-elpd"}
 
 
 class ELPDData(pd.Series):  # pylint: disable=too-many-ancestors
+    """Class to contain the data from elpd information criterion like waic or loo."""
+
     def __str__(self):
+        """Print elpd data in a user friendly way."""
         kind = self.index[0]
 
         if kind not in ("waic", "loo"):
@@ -415,4 +418,5 @@ class ELPDData(pd.Series):  # pylint: disable=too-many-ancestors
         return base
 
     def __repr__(self):
+        """Alias to ``__str__``."""
         return self.__str__()

--- a/arviz/stats/stats_utils.py
+++ b/arviz/stats/stats_utils.py
@@ -72,7 +72,9 @@ def autocorr(ary, axis=-1):
     return corr
 
 
-def make_ufunc(func, n_dims=2, n_output=1, index=Ellipsis, ravel=True):  # noqa: D202
+def make_ufunc(
+    func, n_dims=2, n_output=1, index=Ellipsis, ravel=True, check_shape=True
+):  # noqa: D202
     """Make ufunc from a function taking 1D array input.
 
     Parameters
@@ -88,6 +90,9 @@ def make_ufunc(func, n_dims=2, n_output=1, index=Ellipsis, ravel=True):  # noqa:
         Slice ndarray with `index`. Defaults to `Ellipsis`.
     ravel : bool, optional
         If true, ravel the ndarray before calling `func`.
+    check_shape: bool, optional
+        If false, do not check if the shape of the output is compatible with n_dims and
+        n_output.
 
     Returns
     -------
@@ -101,7 +106,7 @@ def make_ufunc(func, n_dims=2, n_output=1, index=Ellipsis, ravel=True):  # noqa:
         """General ufunc for single-output function."""
         if out is None:
             out = np.empty(ary.shape[:-n_dims])
-        else:
+        elif check_shape:
             if out.shape != ary.shape[:-n_dims]:
                 msg = "Shape incorrect for `out`: {}.".format(out.shape)
                 msg += " Correct shape is {}".format(ary.shape[:-n_dims])
@@ -116,7 +121,7 @@ def make_ufunc(func, n_dims=2, n_output=1, index=Ellipsis, ravel=True):  # noqa:
         element_shape = ary.shape[:-n_dims]
         if out is None:
             out = tuple(np.empty(element_shape) for _ in range(n_output))
-        else:
+        elif check_shape:
             raise_error = False
             correct_shape = tuple(element_shape for _ in range(n_output))
             if isinstance(out, tuple):

--- a/arviz/stats/stats_utils.py
+++ b/arviz/stats/stats_utils.py
@@ -366,12 +366,12 @@ def not_valid(ary, check_nan=True, check_shape=True, nan_kwargs=None, shape_kwar
     return nan_error | chain_error | draw_error
 
 
-base_fmt = """Computed from {{n_samples}} by {{n_points}} log-likelihood matrix
+BASE_FMT = """Computed from {{n_samples}} by {{n_points}} log-likelihood matrix
 
 {{0:{0}}} Estimate       SE
 {{scale}}_{{kind}} {{1:8.2f}}  {{2:7.2f}}
 p_{{kind:{1}}} {{3:8.2f}}        -"""
-pointwise_loo_fmt = """------
+POINTWISE_LOO_FMT = """------
 
 Pareto k diagnostic values:
                          {{0:>{0}}} {{1:>6}}
@@ -380,7 +380,7 @@ Pareto k diagnostic values:
    (0.7, 1]   (bad)      {{4:{0}d}} {{8:6.1f}}%
    (1, Inf)   (very bad) {{5:{0}d}} {{9:6.1f}}%
 """
-scale_dict = {"deviance": "IC", "log": "elpd", "negative_log": "-elpd"}
+SCALE_DICT = {"deviance": "IC", "log": "elpd", "negative_log": "-elpd"}
 
 
 class ELPDData(pd.Series):  # pylint: disable=too-many-ancestors
@@ -390,9 +390,9 @@ class ELPDData(pd.Series):  # pylint: disable=too-many-ancestors
         if kind not in ("waic", "loo"):
             raise ValueError("Invalid ELPDData object")
 
-        scale_str = scale_dict[self["{}_scale".format(kind)]]
+        scale_str = SCALE_DICT[self["{}_scale".format(kind)]]
         padding = len(scale_str) + len(kind) + 1
-        base = base_fmt.format(padding, padding - 2)
+        base = BASE_FMT.format(padding, padding - 2)
         base = base.format(
             "",
             kind=kind,
@@ -407,7 +407,7 @@ class ELPDData(pd.Series):  # pylint: disable=too-many-ancestors
 
         if kind == "loo" and "pareto_k" in self:
             counts, _ = np.histogram(self.pareto_k, bins=[-np.inf, 0.5, 0.7, 1, np.inf])
-            extended = pointwise_loo_fmt.format(max(4, len(str(np.max(counts)))))
+            extended = POINTWISE_LOO_FMT.format(max(4, len(str(np.max(counts)))))
             extended = extended.format(
                 "Count", "Pct.", *[*counts, *(counts / np.sum(counts) * 100)]
             )

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -81,11 +81,68 @@ def create_model(seed=10):
     return model
 
 
+def create_multidimensional_model(seed=10):
+    """Create model with fake data."""
+    np.random.seed(seed)
+    nchains = 4
+    ndraws = 500
+    ndim1 = 5
+    ndim2 = 7
+    data = {
+        "y": np.random.normal(size=(ndim1, ndim2)),
+        "sigma": np.random.normal(size=(ndim1, ndim2)),
+    }
+    posterior = {
+        "mu": np.random.randn(nchains, ndraws),
+        "tau": abs(np.random.randn(nchains, ndraws)),
+        "eta": np.random.randn(nchains, ndraws, ndim1, ndim2),
+        "theta": np.random.randn(nchains, ndraws, ndim1, ndim2),
+    }
+    posterior_predictive = {"y": np.random.randn(nchains, ndraws, ndim1, ndim2)}
+    sample_stats = {
+        "energy": np.random.randn(nchains, ndraws),
+        "diverging": np.random.randn(nchains, ndraws) > 0.90,
+        "log_likelihood": np.random.randn(nchains, ndraws, ndim1, ndim2),
+    }
+    prior = {
+        "mu": np.random.randn(nchains, ndraws) / 2,
+        "tau": abs(np.random.randn(nchains, ndraws)) / 2,
+        "eta": np.random.randn(nchains, ndraws, ndim1, ndim2) / 2,
+        "theta": np.random.randn(nchains, ndraws, ndim1, ndim2) / 2,
+    }
+    prior_predictive = {"y": np.random.randn(nchains, ndraws, ndim1, ndim2) / 2}
+    sample_stats_prior = {
+        "energy": np.random.randn(nchains, ndraws),
+        "diverging": (np.random.randn(nchains, ndraws) > 0.95).astype(int),
+    }
+    model = from_dict(
+        posterior=posterior,
+        posterior_predictive=posterior_predictive,
+        sample_stats=sample_stats,
+        prior=prior,
+        prior_predictive=prior_predictive,
+        sample_stats_prior=sample_stats_prior,
+        observed_data={"y": data["y"]},
+        dims={"y": ["dim1", "dim2"], "log_likelihood": ["dim1", "dim2"]},
+        coords={"dim1": range(ndim1), "dim2": range(ndim2)},
+    )
+    return model
+
+
 @pytest.fixture(scope="module")
 def models():
     class Models:
         model_1 = create_model(seed=10)
         model_2 = create_model(seed=11)
+
+    return Models()
+
+
+@pytest.fixture(scope="module")
+def multidim_models():
+    class Models:
+        model_1 = create_multidimensional_model(seed=10)
+        model_2 = create_multidimensional_model(seed=11)
 
     return Models()
 
@@ -785,6 +842,7 @@ def test_plot_elpd(models, add_model, use_elpddata, kwargs):
     model_dict = {"Model 1": models.model_1, "Model 2": models.model_2}
     if add_model:
         model_dict["Model 3"] = create_model(seed=12)
+
     if use_elpddata:
         ic = kwargs.get("ic", "waic")
         scale = kwargs.get("scale", "deviance")
@@ -792,11 +850,55 @@ def test_plot_elpd(models, add_model, use_elpddata, kwargs):
             model_dict = {k: waic(v, scale=scale, pointwise=True) for k, v in model_dict.items()}
         else:
             model_dict = {k: loo(v, scale=scale, pointwise=True) for k, v in model_dict.items()}
+
     axes = plot_elpd(model_dict, **kwargs)
     assert np.all(axes)
     if add_model:
         assert axes.shape[0] == axes.shape[1]
         assert axes.shape[0] == len(model_dict) - 1
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"ic": "loo"},
+        {"xlabels": True, "scale": "log"},
+        {"color": "dim1", "xlabels": True},
+        {"color": "dim2", "legend": True},
+        {"ic": "loo", "color": "blue", "coords": {"dim2": slice(2, 4)}},
+        {"color": np.random.uniform(size=35), "threshold": 0.1},
+    ],
+)
+@pytest.mark.parametrize("add_model", [False, True])
+@pytest.mark.parametrize("use_elpddata", [False, True])
+def test_plot_elpd_multidim(multidim_models, add_model, use_elpddata, kwargs):
+    model_dict = {"Model 1": multidim_models.model_1, "Model 2": multidim_models.model_2}
+    if add_model:
+        model_dict["Model 3"] = create_multidimensional_model(seed=12)
+
+    if use_elpddata:
+        ic = kwargs.get("ic", "waic")
+        scale = kwargs.get("scale", "deviance")
+        if ic == "waic":
+            model_dict = {k: waic(v, scale=scale, pointwise=True) for k, v in model_dict.items()}
+        else:
+            model_dict = {k: loo(v, scale=scale, pointwise=True) for k, v in model_dict.items()}
+
+    axes = plot_elpd(model_dict, **kwargs)
+    assert np.all(axes)
+    if add_model:
+        assert axes.shape[0] == axes.shape[1]
+        assert axes.shape[0] == len(model_dict) - 1
+
+
+def test_plot_elpd_bad_ic(models):
+    model_dict = {
+        "Model 1": waic(models.model_1, pointwise=True),
+        "Model 2": loo(models.model_2, pointwise=True),
+    }
+    with pytest.raises(ValueError):
+        plot_elpd(model_dict, ic="bad_ic")
 
 
 def test_plot_elpd_ic_error(models):

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -216,6 +216,15 @@ def test_waic_warning(centered_eight):
         assert waic(centered_eight, pointwise=True) is not None
 
 
+@pytest.mark.parametrize("scale", ["deviance", "log", "negative_log"])
+def test_waic_print(centered_eight, scale):
+    waic_data = waic(centered_eight, scale=scale).__repr__()
+    waic_pointwise = waic(centered_eight, scale=scale, pointwise=True).__repr__()
+    assert waic_data is not None
+    assert waic_pointwise is not None
+    assert waic_data == waic_pointwise
+
+
 def test_loo(centered_eight):
     assert loo(centered_eight) is not None
 
@@ -263,6 +272,16 @@ def test_loo_warning(centered_eight):
     centered_eight.sample_stats["log_likelihood"][:, :, :] = 0
     with pytest.warns(UserWarning):
         assert loo(centered_eight, pointwise=True) is not None
+
+
+@pytest.mark.parametrize("scale", ["deviance", "log", "negative_log"])
+def test_loo_print(centered_eight, scale):
+    loo_data = loo(centered_eight, scale=scale).__repr__()
+    loo_pointwise = loo(centered_eight, scale=scale, pointwise=True).__repr__()
+    assert loo_data is not None
+    assert loo_pointwise is not None
+    assert len(loo_data) < len(loo_pointwise)
+    assert loo_data == loo_pointwise[: len(loo_data)]
 
 
 def test_psislw():

--- a/arviz/tests/test_stats_utils.py
+++ b/arviz/tests/test_stats_utils.py
@@ -206,6 +206,6 @@ def test_valid_shape():
     )
 
 
-def test_ELPDData_error():
+def test_elpd_data_error():
     with pytest.raises(ValueError):
         ELPDData(data=[0, 1, 2], index=["not IC", "se", "p"]).__repr__()

--- a/arviz/tests/test_stats_utils.py
+++ b/arviz/tests/test_stats_utils.py
@@ -4,7 +4,13 @@ from numpy.testing import assert_array_almost_equal
 import pytest
 from scipy.special import logsumexp
 
-from ..stats.stats_utils import logsumexp as _logsumexp, make_ufunc, wrap_xarray_ufunc, not_valid
+from ..stats.stats_utils import (
+    logsumexp as _logsumexp,
+    make_ufunc,
+    wrap_xarray_ufunc,
+    not_valid,
+    ELPDData,
+)
 
 
 @pytest.mark.parametrize("ary_dtype", [np.float64, np.float32, np.int32, np.int64])
@@ -198,3 +204,8 @@ def test_valid_shape():
     assert not_valid(
         np.ones((10, 10)), check_nan=False, shape_kwargs=dict(min_chains=100, min_draws=2)
     )
+
+
+def test_ELPDData_error():
+    with pytest.raises(ValueError):
+        ELPDData(data=[0, 1, 2], index=["not IC", "se", "p"]).__repr__()

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -24,6 +24,7 @@ Plots
     plot_khat
     plot_pair
     plot_parallel
+    plot_pointwise_elpd
     plot_posterior
     plot_ppc
     plot_rank

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -24,7 +24,7 @@ Plots
     plot_khat
     plot_pair
     plot_parallel
-    plot_pointwise_elpd
+    plot_elpd
     plot_posterior
     plot_ppc
     plot_rank


### PR DESCRIPTION
PR to improve the output of waic and loo to make it more verbose and to create the pointwise elpd comparison plot. Will fix #496 and will fix #660.

This first version of the plot already works, but there is still much work needed.

### Plots
* [x] coloring?
![image](https://user-images.githubusercontent.com/23738400/58762435-4c919d00-8550-11e9-9ca0-501a41c52b73.png)

Data from the toy model in [this notebook](https://github.com/OriolAbril/Bayesian-Inference-examples/blob/master/Binomial_on_2D_data/binomial_on_2D_data_intention_pystan.ipynb). This was generated with `color="river_distance"` and `legend=True`.

* [x] tick labels?
![image](https://user-images.githubusercontent.com/23738400/58441282-07e5ac00-80e1-11e9-9a95-0b1169ea6726.png)

* [x] highlight worst points?
![image](https://user-images.githubusercontent.com/23738400/58922536-a0aca500-873b-11e9-8092-2cb0f4e978eb.png)
Added a `threshold` argument in order to show labels of point further away than threshold times elpd_i.std(). In the example, `threshold=1` to force showing the labels.

* [x] move common coloring/labeling data functions to `plot_utils.py` to have the same functionality in `plot_elpd` and `plot_khat`

### Stats functions
* [x] improve verbosity
![image](https://user-images.githubusercontent.com/23738400/58445495-28236400-80fd-11e9-99a8-0686ae4b8d47.png)
![image](https://user-images.githubusercontent.com/23738400/58445525-3ffae800-80fd-11e9-8220-540a16db632b.png)

* [x] Use xarray for all computations.
See #501 for some more detail.


### Both
* [x] check behaviour on more than 3D items (not only chain, draw and one extra dim).

Everything working after some corrections, still debating between reshaping pointwise loo/waic to original shape or work with multi-index objects from there on (eventually the scatter plot is flattened, thus at some point they are needed)

* [x] Optimize API: find a way to call waic and loo only once per InferenceData object ideally. 

Idea: Store pointwise loo, waic and pareto_k as dataarrays in the `ELPDData` object instead of as a flattened array and call `plot_elpd` with a dict of `ELPDData` and `plot_khat` with an `ELPDData` object instead of the array of pareto shape values. Using the dataarray will allow coloring, ticklabels, selection of a subset of observations and so on, and thanks to the overwritten `__str__` method, including this extra information it the `ELPDData` object won't clutter the relevant info when printed.