### PR TITLE
Handle pm.Data on observed data

### DIFF
--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -114,6 +114,8 @@ class PyMC3Converter:
             dims = self.dims
         observed_data = {}
         for name, vals in observations.items():
+            if hasattr(vals, "get_value"):
+                vals = vals.get_value()
             vals = np.atleast_1d(vals)
             val_dims = dims.get(name)
             val_dims, coords = generate_dims_coords(


### PR DESCRIPTION
Fixes #682

This fixes a bug that kept the shared theano array after `np.atleast1d`.

This PR checks first if value has `get_value` and transform theano array to numpy array if `get_value`  is true.

I let our pymc experts to fix this implementation and also decide if other methods need to be fixed.