### PR TITLE
Fix warning from io_pymc3

### DIFF
--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -52,7 +52,7 @@ class PyMC3Converter:
 
         chain_likelihoods = []
         for chain in self.trace.chains:
-            log_like = (log_likelihood_vals_point(point) for point in self.trace.points([chain]))
+            log_like = [log_likelihood_vals_point(point) for point in self.trace.points([chain])]
             chain_likelihoods.append(np.stack(log_like))
         return np.stack(chain_likelihoods), coord_name
 


### PR DESCRIPTION
This fixes the following warning whenever `from_pymc3` is called: 

```
/arviz/arviz/data/io_pymc3.py:56: FutureWarning: arrays to stack must be passed as a "sequence" type such as list or tuple. Support for non-sequence iterables such as generators is deprecated as of NumPy 1.16 and will raise an error in the future.
  chain_likelihoods.append(np.stack(log_like))
```