### PR TITLE
LOO-PIT

### DIFF
--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -1,4 +1,5 @@
 """Data structure for using netcdf groups with xarray."""
+import os
 from collections import OrderedDict
 from collections.abc import Sequence
 from copy import copy as ccopy, deepcopy
@@ -60,9 +61,13 @@ class InferenceData:
         with nc.Dataset(filename, mode="r") as data:
             data_groups = list(data.groups)
 
+        arviz_load_mode = os.environ.get("ARVIZ_LOAD", "lazy").lower()
         for group in data_groups:
             with xr.open_dataset(filename, group=group) as data:
-                groups[group] = data
+                if arviz_load_mode == "eager":
+                    groups[group] = data.load()
+                else:
+                    groups[group] = data
         return InferenceData(**groups)
 
     def to_netcdf(self, filename, compress=True):

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -47,6 +47,9 @@ class InferenceData:
         """Initialize object from a netcdf file.
 
         Expects that the file will have groups, each of which can be loaded by xarray.
+        By default, the datasets of the InferenceData object will be lazily loaded. To
+        modify this behaviour, the environment variable ``ARVIZ_LOAD`` must be set to
+        ``EAGER`` (case insensitive) in order to load objects in memory instead.
 
         Parameters
         ----------

--- a/arviz/data/io_netcdf.py
+++ b/arviz/data/io_netcdf.py
@@ -11,6 +11,16 @@ def from_netcdf(filename):
     ----------
     filename : str
         name or path of the file to load trace
+
+    Returns
+    -------
+        InferenceData object
+
+    Notes
+    -----
+    By default, the datasets of the InferenceData object will be lazily loaded. To
+    modify this behaviour, the environment variable ``ARVIZ_LOAD`` must be set to
+    ``EAGER`` (case insensitive) in order to load objects in memory instead.
     """
     return InferenceData.from_netcdf(filename)
 

--- a/arviz/plots/__init__.py
+++ b/arviz/plots/__init__.py
@@ -11,6 +11,7 @@ from .hpdplot import plot_hpd
 from .jointplot import plot_joint
 from .kdeplot import plot_kde, _fast_kde, _fast_kde_2d
 from .khatplot import plot_khat
+from .loopitplot import plot_loo_pit
 from .pairplot import plot_pair
 from .parallelplot import plot_parallel
 from .posteriorplot import plot_posterior
@@ -35,6 +36,7 @@ __all__ = [
     "_fast_kde",
     "_fast_kde_2d",
     "plot_khat",
+    "plot_loo_pit",
     "plot_pair",
     "plot_parallel",
     "plot_posterior",

--- a/arviz/plots/loopitplot.py
+++ b/arviz/plots/loopitplot.py
@@ -67,10 +67,8 @@ def plot_loo_pit(
         raise ValueError("idata must be of type InferenceData")
 
     if ax is None:
-        (figsize, ax_labelsize, _, xt_labelsize, linewidth, markersize) = _scale_fig_size(
-            figsize, textsize, 1, 1
-        )
-        fig, ax = plt.subplots(1, 1, figsize=figsize)
+        (figsize, _, _, xt_labelsize, linewidth, _) = _scale_fig_size(figsize, textsize, 1, 1)
+        _, ax = plt.subplots(1, 1, figsize=figsize, constrained_layout=True)
 
     if plot_kwargs is None:
         plot_kwargs = {}
@@ -121,6 +119,7 @@ def plot_loo_pit(
             ax.plot(x_vals, unif_density, **plot_unif_kwargs)
     ax.plot(x_vals, loo_pit_kde, **plot_kwargs)
 
+    ax.tick_params(labelsize=xt_labelsize)
     if legend:
         if not use_hpd:
             ax.plot([], label="Uniform", **plot_unif_kwargs)

--- a/arviz/plots/loopitplot.py
+++ b/arviz/plots/loopitplot.py
@@ -49,8 +49,9 @@ def plot_loo_pit(
         Plot the difference between the LOO-PIT Empirical Cumulative Distribution Function
         (ECDF) and the uniform CDF instead of LOO-PIT kde.
         In this case, instead of overlaying uniform distributions, the beta ``credible_interval``
-        interval around the theoretical uniform CDF is shown. For more information, see
-        `Vehtari et al. (2019)`, `Appendix G <https://avehtari.github.io/rhat_ess/rhat_ess.html>`_
+        interval around the theoretical uniform CDF is shown. This approximation only holds
+        for large S and ECDF values not vary close to 0 nor 1. For more information, see
+        `Vehtari et al. (2019)`, `Appendix G <https://avehtari.github.io/rhat_ess/rhat_ess.html>`_.
     ecdf_fill : bool, optional
         Use fill_between to mark the area inside the credible interval. Otherwise, plot the
         border lines.

--- a/arviz/plots/loopitplot.py
+++ b/arviz/plots/loopitplot.py
@@ -1,9 +1,12 @@
 import numpy as np
 import matplotlib.pyplot as plt
+from matplotlib.colors import to_rgb, rgb_to_hsv, hsv_to_rgb
 
-from ..stats import loo_pit as _loo_pit
+from ..data import InferenceData
+from ..stats import loo_pit as _loo_pit, psislw as _psislw
 from .plot_utils import _scale_fig_size
 from .kdeplot import _fast_kde
+from .hpdplot import plot_hpd
 
 
 def plot_loo_pit(
@@ -11,17 +14,56 @@ def plot_loo_pit(
     y,
     y_hat=None,
     n_unif=100,
+    use_hpd=False,
     figsize=None,
     textsize=None,
+    color="C0",
+    legend=True,
     ax=None,
     plot_kwargs=None,
     plot_unif_kwargs=None,
+    hpd_kwargs=None,
 ):
-    """Plot LOO-PIT."""
-    if plot_kwargs is None:
-        plot_kwargs = {}
-    if plot_unif_kwargs is None:
-        plot_unif_kwargs = {}
+    """Plot Leave-One-Out (LOO) probability integral transformation (PIT) predictive checks.
+
+    Parameters
+    ----------
+    idata : InferenceData
+        InferenceData object with groups `observed_data`, `posterior_predictive` and
+        `sample_stats`. Objects that can be converted to InferenceData are not accepted.
+    y : str
+        Name of the observed_data variable to use.
+    y_hat : str, optional
+        Name of the posterior_predictive variable to use. If None, it will be taken as equal
+        to y.
+    n_unif : int, optional
+        Number of datasets to simulate and overlay from the uniform distribution.
+    use_hpd : bool, optional
+        Use plot_hpd to fill between hpd values instead of overlaying the uniform distributions.
+    figsize : figure size tuple, optional
+        If None, size is (8 + numvars, 8 + numvars)
+    textsize: int, optional
+        Text size for labels. If None it will be autoscaled based on figsize.
+    color : str or array_like, optional
+        Color of the LOO-PIT estimated pdf plot.
+    legend : bool, optional
+        Show the legend of the figure.
+    ax : axes, optional
+        Matplotlib axes
+    plot_kwargs : dict, optional
+        Additional keywords passed to ax.plot, for LOO-PIT line
+    plot_unif_kwargs : dict, optional
+        Additional keywords passed to ax.plot, for overlaid uniform distributions.
+    hpd_kwargs : dict, optional
+        Additional keywords passed to az.plot_hpd
+
+    Returns
+    -------
+    axes : axes
+        Matplotlib axes
+    """
+    if not isinstance(idata, InferenceData):
+        raise ValueError("idata must be of type InferenceData")
 
     if ax is None:
         (figsize, ax_labelsize, _, xt_labelsize, linewidth, markersize) = _scale_fig_size(
@@ -29,21 +71,53 @@ def plot_loo_pit(
         )
         fig, ax = plt.subplots(1, 1, figsize=figsize)
 
-    plot_kwargs.setdefault("color", "C0")
+    if plot_kwargs is None:
+        plot_kwargs = {}
+    plot_kwargs["color"] = color
     plot_kwargs.setdefault("linewidth", linewidth)
-    plot_unif_kwargs.setdefault("color", "cyan")
+    plot_kwargs.setdefault("label", "LOO-PIT")
+
+    if plot_unif_kwargs is None:
+        plot_unif_kwargs = {}
+    light_color = rgb_to_hsv(to_rgb(plot_kwargs.get("color")))
+    light_color[1] /= 2
+    light_color[2] += (1 - light_color[2]) / 2
+    plot_unif_kwargs.setdefault("color", hsv_to_rgb(light_color))
     plot_unif_kwargs.setdefault("alpha", 0.5)
     plot_unif_kwargs.setdefault("linewidth", 0.6 * linewidth)
-    plot_unif_kwargs.setdefault("zorder", -10)
+    plot_unif_kwargs.setdefault("zorder", -1)
 
-    loo_pit = _loo_pit(idata, y=y, y_hat=y_hat)
+    if hpd_kwargs is None:
+        hpd_kwargs = {}
+    hpd_kwargs.setdefault("color", hsv_to_rgb(light_color))
+    fill_kwargs = hpd_kwargs.pop("fill_kwargs", {})
+    fill_kwargs.setdefault("label", "Uniform HPD")
+    hpd_kwargs["fill_kwargs"] = fill_kwargs
+
+    if y_hat is None:
+        y_hat = y
+    y = idata.observed_data[y]
+    y_hat = idata.posterior_predictive[y_hat].stack(samples=("chain", "draw"))
+    log_likelihood = idata.sample_stats.log_likelihood.stack(samples=("chain", "draw"))
+    log_weights, _ = _psislw(-log_likelihood)
+    loo_pit = _loo_pit(y, y_hat, log_weights)
     loo_pit_kde, _, _ = _fast_kde(loo_pit.values.flatten(), xmin=0, xmax=1)
 
-    unif = np.random.uniform(size=(loo_pit.size, n_unif))
+    unif = np.random.uniform(size=(n_unif, loo_pit.size))
     x_vals = np.linspace(0, 1, len(loo_pit_kde))
-    for idx in range(n_unif):
-        unif_density, _, _ = _fast_kde(unif[:, idx], xmin=0, xmax=1)
-        ax.plot(x_vals, unif_density, **plot_unif_kwargs)
-
+    if use_hpd:
+        unif_densities = np.empty((n_unif, len(loo_pit_kde)))
+        for idx in range(n_unif):
+            unif_densities[idx, :], _, _ = _fast_kde(unif[idx, :], xmin=0, xmax=1)
+        plot_hpd(x_vals, unif_densities, **hpd_kwargs)
+    else:
+        for idx in range(n_unif):
+            unif_density, _, _ = _fast_kde(unif[idx, :], xmin=0, xmax=1)
+            ax.plot(x_vals, unif_density, **plot_unif_kwargs)
     ax.plot(x_vals, loo_pit_kde, **plot_kwargs)
+
+    if legend:
+        if not use_hpd:
+            ax.plot([], label="Uniform", **plot_unif_kwargs)
+        ax.legend()
     return ax

--- a/arviz/plots/loopitplot.py
+++ b/arviz/plots/loopitplot.py
@@ -66,8 +66,8 @@ def plot_loo_pit(
     if not isinstance(idata, InferenceData):
         raise ValueError("idata must be of type InferenceData")
 
+    (figsize, _, _, xt_labelsize, linewidth, _) = _scale_fig_size(figsize, textsize, 1, 1)
     if ax is None:
-        (figsize, _, _, xt_labelsize, linewidth, _) = _scale_fig_size(figsize, textsize, 1, 1)
         _, ax = plt.subplots(1, 1, figsize=figsize, constrained_layout=True)
 
     if plot_kwargs is None:

--- a/arviz/plots/loopitplot.py
+++ b/arviz/plots/loopitplot.py
@@ -1,3 +1,4 @@
+"""Plot LOO-PIT predictive checks of inference data."""
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.colors import to_rgb, rgb_to_hsv, hsv_to_rgb

--- a/arviz/plots/loopitplot.py
+++ b/arviz/plots/loopitplot.py
@@ -73,7 +73,7 @@ def plot_loo_pit(
     if plot_kwargs is None:
         plot_kwargs = {}
     plot_kwargs["color"] = color
-    plot_kwargs.setdefault("linewidth", linewidth)
+    plot_kwargs.setdefault("linewidth", linewidth * 1.4)
     plot_kwargs.setdefault("label", "LOO-PIT")
 
     if plot_unif_kwargs is None:

--- a/arviz/plots/loopitplot.py
+++ b/arviz/plots/loopitplot.py
@@ -66,7 +66,9 @@ def plot_loo_pit(
     textsize: int, optional
         Text size for labels. If None it will be autoscaled based on figsize.
     color : str or array_like, optional
-        Color of the LOO-PIT estimated pdf plot.
+        Color of the LOO-PIT estimated pdf plot. If ``plot_unif_kwargs`` has no "color" key,
+        an slightly lighter color than this argument will be used for the uniform kde lines.
+        This will ensure that LOO-PIT kde and uniform kde have different default colors.
     legend : bool, optional
         Show the legend of the figure.
     ax : axes, optional

--- a/arviz/plots/loopitplot.py
+++ b/arviz/plots/loopitplot.py
@@ -12,7 +12,6 @@ from .hpdplot import plot_hpd
 
 def plot_loo_pit(
     idata=None,
-    *,
     y=None,
     y_hat=None,
     log_weights=None,

--- a/arviz/plots/loopitplot.py
+++ b/arviz/plots/loopitplot.py
@@ -51,7 +51,7 @@ def plot_loo_pit(
         In this case, instead of overlaying uniform distributions, the beta ``credible_interval``
         interval around the theoretical uniform CDF is shown. For more information, see
         `Vehtari et al. (2019)`, Appendix G.
-    fill_ecdf : bool, optional
+    ecdf_fill : bool, optional
         Use fill_between to mark the area inside the credible interval. Otherwise, plot the
         border lines.
     n_unif : int, optional
@@ -126,8 +126,8 @@ def plot_loo_pit(
         )
         unif_ecdf = unif_ecdf / n_data_points
 
-        plot_kwargs.setdefault("drawstyle", "steps" if n_data_points < 100 else "default")
-        plot_unif_kwargs.setdefault("drawstyle", "steps" if n_data_points < 100 else "default")
+        plot_kwargs.setdefault("drawstyle", "steps-mid" if n_data_points < 100 else "default")
+        plot_unif_kwargs.setdefault("drawstyle", "steps-mid" if n_data_points < 100 else "default")
 
         ax.plot(
             np.hstack((0, loo_pit, 1)), np.hstack((0, loo_pit_ecdf - loo_pit, 0)), **plot_kwargs
@@ -137,7 +137,9 @@ def plot_loo_pit(
                 fill_kwargs = {}
             fill_kwargs.setdefault("color", hsv_to_rgb(light_color))
             fill_kwargs.setdefault("alpha", 0.5)
-            fill_kwargs.setdefault("step", "pre" if plot_kwargs["drawstyle"] == "steps" else None)
+            fill_kwargs.setdefault(
+                "step", "mid" if plot_kwargs["drawstyle"] == "steps-mid" else None
+            )
             fill_kwargs.setdefault("label", "{:.3g}% credible interval".format(credible_interval))
 
             ax.fill_between(unif_ecdf, p975 - unif_ecdf, p025 - unif_ecdf, **fill_kwargs)
@@ -169,7 +171,7 @@ def plot_loo_pit(
 
     ax.tick_params(labelsize=xt_labelsize)
     if legend:
-        if not use_hpd and not ecdf_fill:
+        if not (use_hpd or (ecdf and ecdf_fill)):
             label = "{:.3g}% credible interval".format(credible_interval) if ecdf else "Uniform"
             ax.plot([], label=label, **plot_unif_kwargs)
         ax.legend()

--- a/arviz/plots/loopitplot.py
+++ b/arviz/plots/loopitplot.py
@@ -100,8 +100,12 @@ def plot_loo_pit(
     y_hat = idata.posterior_predictive[y_hat].stack(samples=("chain", "draw"))
     log_likelihood = idata.sample_stats.log_likelihood.stack(samples=("chain", "draw"))
     log_weights, _ = _psislw(-log_likelihood)
-    loo_pit = _loo_pit(y, y_hat, log_weights)
-    loo_pit_kde, _, _ = _fast_kde(loo_pit.values.flatten(), xmin=0, xmax=1)
+
+    if log_weights.dims == y_hat.dims and y_hat.dims[:-1] == y.dims:
+        loo_pit = _loo_pit(y, y_hat, log_weights).values
+    else:
+        loo_pit = _loo_pit(y.values, y_hat.values, log_weights.values)
+    loo_pit_kde, _, _ = _fast_kde(loo_pit.flatten(), xmin=0, xmax=1)
 
     unif = np.random.uniform(size=(n_unif, loo_pit.size))
     x_vals = np.linspace(0, 1, len(loo_pit_kde))

--- a/arviz/plots/loopitplot.py
+++ b/arviz/plots/loopitplot.py
@@ -1,0 +1,49 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+from ..stats import loo_pit as _loo_pit
+from .plot_utils import _scale_fig_size
+from .kdeplot import _fast_kde
+
+
+def plot_loo_pit(
+    idata,
+    y,
+    y_hat=None,
+    n_unif=100,
+    figsize=None,
+    textsize=None,
+    ax=None,
+    plot_kwargs=None,
+    plot_unif_kwargs=None,
+):
+    """Plot LOO-PIT."""
+    if plot_kwargs is None:
+        plot_kwargs = {}
+    if plot_unif_kwargs is None:
+        plot_unif_kwargs = {}
+
+    if ax is None:
+        (figsize, ax_labelsize, _, xt_labelsize, linewidth, markersize) = _scale_fig_size(
+            figsize, textsize, 1, 1
+        )
+        fig, ax = plt.subplots(1, 1, figsize=figsize)
+
+    plot_kwargs.setdefault("color", "C0")
+    plot_kwargs.setdefault("linewidth", linewidth)
+    plot_unif_kwargs.setdefault("color", "cyan")
+    plot_unif_kwargs.setdefault("alpha", 0.5)
+    plot_unif_kwargs.setdefault("linewidth", 0.6 * linewidth)
+    plot_unif_kwargs.setdefault("zorder", -10)
+
+    loo_pit = _loo_pit(idata, y=y, y_hat=y_hat)
+    loo_pit_kde, _, _ = _fast_kde(loo_pit.values.flatten(), xmin=0, xmax=1)
+
+    unif = np.random.uniform(size=(loo_pit.size, n_unif))
+    x_vals = np.linspace(0, 1, len(loo_pit_kde))
+    for idx in range(n_unif):
+        unif_density, _, _ = _fast_kde(unif[:, idx], xmin=0, xmax=1)
+        ax.plot(x_vals, unif_density, **plot_unif_kwargs)
+
+    ax.plot(x_vals, loo_pit_kde, **plot_kwargs)
+    return ax

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -4,6 +4,7 @@ from numbers import Number
 import numpy as np
 from scipy.stats import mode
 
+
 from ..data import convert_to_dataset
 from ..stats import hpd
 from .kdeplot import plot_kde, _fast_kde

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -28,6 +28,7 @@ def plot_posterior(
     credible_interval=0.94,
     round_to: Optional[int] = None,
     point_estimate="mean",
+    group="posterior",
     rope=None,
     ref_val=None,
     kind="kde",
@@ -58,6 +59,8 @@ def plot_posterior(
         Controls formatting of floats. Defaults to 2 or the integer part, whichever is bigger.
     point_estimate: str
         Must be in ('mode', 'mean', 'median')
+    group : str, optional
+        Specifies which InferenceData group should be plotted. Defaults to ‘posterior’.
     rope: tuple or dictionary of tuples
         Lower and upper values of the Region Of Practical Equivalence. If a list is provided, its
         length should match the number of variables.
@@ -146,7 +149,7 @@ def plot_posterior(
 
         >>> az.plot_posterior(data, var_names=['mu'], credible_interval=.75)
     """
-    data = convert_to_dataset(data, group="posterior")
+    data = convert_to_dataset(data, group=group)
     var_names = _var_names(var_names, data)
 
     if coords is None:

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -4,7 +4,6 @@ from numbers import Number
 import numpy as np
 from scipy.stats import mode
 
-
 from ..data import convert_to_dataset
 from ..stats import hpd
 from .kdeplot import plot_kde, _fast_kde

--- a/arviz/stats/__init__.py
+++ b/arviz/stats/__init__.py
@@ -6,6 +6,7 @@ from .diagnostics import *
 
 
 __all__ = [
+    "apply_test_function",
     "bfmi",
     "compare",
     "hpd",

--- a/arviz/stats/__init__.py
+++ b/arviz/stats/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     "compare",
     "hpd",
     "loo",
+    "loo_pit",
     "psislw",
     "r2_score",
     "summary",

--- a/arviz/stats/__init__.py
+++ b/arviz/stats/__init__.py
@@ -24,4 +24,6 @@ __all__ = [
     "geweke",
     "autocorr",
     "autocov",
+    "make_ufunc",
+    "wrap_xarray_ufunc",
 ]

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -1185,7 +1185,7 @@ def loo_pit(y, y_hat, log_weights):
 def _loo_pit(y, y_hat, lw):
     """Compute LOO-PIT values."""
     out = np.empty_like(y, dtype=np.float64)
-    for idx in np.ndindex(*y.shape):
+    for idx in np.ndindex(y.shape):
         sel = y_hat[idx] <= y[idx]
         out[idx] = np.exp(_logsumexp(lw[idx][sel]))
     return out

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -1159,13 +1159,13 @@ def loo_pit(idata, y, y_hat=None):
     y_hat = idata.posterior_predictive[y_hat]
     y_hat = y_hat.stack(samples=("chain", "draw"))
     log_likelihood = idata.sample_stats.log_likelihood.stack(samples=("chain", "draw"))
-    log_weights, _ = psislw(-log_likelihood.values.T)
+    log_weights, _ = psislw(-log_likelihood.values)
 
     return xr.apply_ufunc(
         _loo_pit,
         y,
         y_hat,
-        log_weights.T,
+        log_weights,
         input_core_dims=[[], ["samples"], ["samples"]],
         output_core_dims=[[]],
     )

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -1350,24 +1350,24 @@ def apply_test_function(
         func_kwargs["out"] = np.empty(out_data_shape)
         try:
             idata.observed_data[out_name_data] = _wrap_xarray_ufunc(
-            func,
-            in_data.values,
-            in_posterior.values,
-            func_args=func_args,
-            func_kwargs=func_kwargs,
-            ufunc_kwargs=ufunc_kwargs,
-            **wrap_data_kwargs,
-        )
+                func,
+                in_data.values,
+                in_posterior.values,
+                func_args=func_args,
+                func_kwargs=func_kwargs,
+                ufunc_kwargs=ufunc_kwargs,
+                **wrap_data_kwargs,
+            )
         except IndexError:
             input_core_dims = sum(*wrap_data_kwargs["input_core_dims"])
             wrap_data_kwargs["input_core_dims"] = [input_core_dims, input_core_dims]
             idata.observed_data[out_name_data] = _wrap_xarray_ufunc(
-            func,
-            *xr.broadcast(in_data, in_posterior),
-            func_args=func_args,
-            func_kwargs=func_kwargs,
-            ufunc_kwargs=ufunc_kwargs,
-            **wrap_data_kwargs,
-        )
+                func,
+                *xr.broadcast(in_data, in_posterior),
+                func_args=func_args,
+                func_kwargs=func_kwargs,
+                ufunc_kwargs=ufunc_kwargs,
+                **wrap_data_kwargs,
+            )
 
     return idata

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -1313,9 +1313,50 @@ def apply_test_function(
     pointwise : bool, optional
         If True, apply the test function to each observation and sample, otherwise, apply
         test function to each sample.
-    out_data_shape : tuple, optional
-        Output shape of the test function applied to the observed data. If None, the default
-        depends on the value of pointwise.
+    out_data_shape, out_pp_shape : tuple, optional
+        Output shape of the test function applied to the observed/posterior predictive data.
+        If None, the default depends on the value of pointwise.
+    out_name_data, out_name_pp : str, optional
+        Name of the variables to add to the observed_data and posterior_predictive datasets
+        respectively. ``out_name_pp`` can be ``None``, in which case will be taken equal to
+        ``out_name_data``.
+    func_args : sequence, optional
+        Passed as is to ``func``
+    func_kwargs : mapping, optional
+        Passed as is to ``func``
+    wrap_data_kwargs, wrap_pp_kwargs : mapping, optional
+        kwargs passed to ``az.stats.wrap_xarray_ufunc``. By default, some suitable input_core_dims
+        are used.
+    inplace : bool, optional
+        If True, add the variables inplace, othewise, return a copy of idata with the variables
+        added.
+
+    Returns
+    -------
+    idata : InferenceData
+        Output InferenceData object. If ``inplace=True``, it is the same input object modified
+        inplace.
+
+    Notes
+    -----
+    This function is provided for convenience to wrap scalar or functions working on low
+    dims to inference data object. It is not optimized to be faster nor as fast as vectorized
+    computations.
+
+    Examples
+    --------
+    Use ``apply_test_function`` to wrap ``np.min`` for illustration purposes. And plot the
+    results.
+
+    .. plot::
+        :context: close-figs
+
+        >>> import arviz as az
+        >>> idata = az.load_arviz_data("centered_eight")
+        >>> az.apply_test_function(idata, lambda y, theta: np.min(y))
+        >>> T = np.asscalar(idata.observed_data.T)
+        >>> az.plot_posterior(idata, var_names=["T"], group="posterior_predictive", ref_val=T)
+
     """
     out = idata if inplace else deepcopy(idata)
 
@@ -1326,7 +1367,7 @@ def apply_test_function(
         )
 
     if out_name_pp is None:
-        out_name_pp = out_name_data + "_hat"
+        out_name_pp = out_name_data
 
     if func_args is None:
         func_args = tuple()

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -1414,7 +1414,7 @@ def apply_test_function(
             out_group_shape = () if out_group_shape is None else out_group_shape
         elif grp == "posterior_predictive":
             out_group_shape = in_group.shape[:2] if out_group_shape is None else out_group_shape
-        loop_dims = in_group.dims[:len(out_group_shape)]
+        loop_dims = in_group.dims[: len(out_group_shape)]
 
         wrap_group_kwargs.setdefault(
             "input_core_dims",

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -1398,13 +1398,12 @@ def apply_test_function(
                 **wrap_group_kwargs,
             )
         except IndexError:
-            input_core_dims = set(
+            excluded_dims = set(
                 wrap_group_kwargs["input_core_dims"][0] + wrap_group_kwargs["input_core_dims"][1]
             )
-            wrap_group_kwargs["input_core_dims"] = [input_core_dims, input_core_dims]
             out_group[out_name_group] = _wrap_xarray_ufunc(
                 func,
-                *xr.broadcast(in_group, in_posterior),
+                *xr.broadcast(in_group, in_posterior, exclude=excluded_dims),
                 func_args=func_args,
                 func_kwargs=func_kwargs,
                 ufunc_kwargs=ufunc_kwargs,

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -1182,10 +1182,10 @@ def loo_pit(y, y_hat, log_weights):
     )
 
 
-def _loo_pit(y, y_hat, lw):
+def _loo_pit(y, y_hat, log_weights):
     """Compute LOO-PIT values."""
     out = np.empty_like(y, dtype=np.float64)
     for idx in np.ndindex(y.shape):
         sel = y_hat[idx] <= y[idx]
-        out[idx] = np.exp(_logsumexp(lw[idx][sel]))
+        out[idx] = np.exp(_logsumexp(log_weights[idx][sel]))
     return out

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -1146,7 +1146,7 @@ def waic(data, pointwise=False, scale="deviance"):
 
 
 def loo_pit(idata=None, *, y=None, y_hat=None, log_weights=None):
-    """Compute LOO-PIT values.
+    """Compute leave one out (LOO) probability integral transform (PIT) values.
 
     Parameters
     ----------
@@ -1213,7 +1213,7 @@ def loo_pit(idata=None, *, y=None, y_hat=None, log_weights=None):
             y_hat = idata.posterior_predictive[y_hat].stack(samples=("chain", "draw")).values
         elif not isinstance(y_hat, (np.ndarray, xr.DataArray)):
             raise ValueError(
-                "y_hat must be of types array, DataArray or str, not {}".format(type(y))
+                "y_hat must be of types array, DataArray or str, not {}".format(type(y_hat))
             )
         if log_weights is None:
             log_likelihood = idata.sample_stats.log_likelihood.stack(samples=("chain", "draw"))
@@ -1230,7 +1230,7 @@ def loo_pit(idata=None, *, y=None, y_hat=None, log_weights=None):
             log_weights = psislw(-log_likelihood, reff=reff)[0].values
         elif not isinstance(log_weights, (np.ndarray, xr.DataArray)):
             raise ValueError(
-                "log_weights must be None or of types array or DataArray, not {}".format(type(y))
+                "log_weights must be None or of types array or DataArray, not {}".format(type(log_weights))
             )
 
     if len(y.shape) + 1 != len(y_hat.shape):

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -1187,5 +1187,8 @@ def _loo_pit(y, y_hat, log_weights):
     out = np.empty_like(y, dtype=np.float64)
     for idx in np.ndindex(y.shape):
         sel = y_hat[idx] <= y[idx]
-        out[idx] = np.exp(_logsumexp(log_weights[idx][sel]))
+        if np.sum(sel) > 0:
+            out[idx] = np.exp(_logsumexp(log_weights[idx][sel]))
+        else:
+            out[idx] = 0
     return out

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -1145,11 +1145,11 @@ def waic(data, pointwise=False, scale="deviance"):
         )
 
 
-def loo_pit(idata=None, y=None, y_hat=None, log_weights=None):
+def loo_pit(idata=None, *, y=None, y_hat=None, log_weights=None):
     """Compute LOO-PIT values.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     idata : InferenceData
         InferenceData object.
     y : array, DataArray or str
@@ -1166,6 +1166,29 @@ def loo_pit(idata=None, y=None, y_hat=None, log_weights=None):
     -------
     loo_pit : array or DataArray
         Value of the LOO-PIT at each observed data point.
+
+    Examples
+    --------
+    Calculate LOO-PIT values using as test quantity the observed values themselves.
+
+    .. ipython::
+
+        In [1]: import arviz as az
+           ...: data = az.load_arviz_data("centered_eight")
+           ...: az.loo_pit(idata=data, y="obs")
+
+    Calculate LOO-PIT values using as test quantity the square of the difference between
+    each observation and `mu`. Both ``y`` and ``y_hat`` inputs will be array-like,
+    but ``idata`` will still be passed in order to calculate the ``log_weights`` from
+    there.
+
+    .. ipython::
+
+        In [1]: T = data.observed_data.obs - data.posterior.mu.median(dim=("chain", "draw"))
+           ...: T_hat = data.posterior_predictive.obs - data.posterior.mu
+           ...: T_hat = T_hat.stack(samples=("chain", "draw"))
+           ...: az.loo_pit(idata=data, y=T**2, y_hat=T_hat**2)
+
     """
     if idata is not None and not isinstance(idata, InferenceData):
         raise ValueError("idata must be of type InferenceData or None")
@@ -1268,8 +1291,8 @@ def apply_test_function(
 ):
     """Apply a Bayesian test function to an InferenceData object.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     idata : InferenceData
         InferenceData object on which to apply the test function. This function will add
         new variables to the InferenceData object to store the result without modifying the

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -1410,13 +1410,11 @@ def apply_test_function(
 
         if pointwise:
             out_group_shape = in_group.shape if out_group_shape is None else out_group_shape
-            loop_dims = in_group.dims
         elif grp == "observed_data":
             out_group_shape = () if out_group_shape is None else out_group_shape
-            loop_dims = ()
         elif grp == "posterior_predictive":
             out_group_shape = in_group.shape[:2] if out_group_shape is None else out_group_shape
-            loop_dims = ("chain", "draw")
+        loop_dims = in_group.dims[:len(out_group_shape)]
 
         wrap_group_kwargs.setdefault(
             "input_core_dims",

--- a/arviz/stats/stats_utils.py
+++ b/arviz/stats/stats_utils.py
@@ -165,19 +165,19 @@ def make_ufunc(
 
 
 def wrap_xarray_ufunc(
-    ufunc, dataset, *, ufunc_kwargs=None, func_args=None, func_kwargs=None, **kwargs
+    ufunc, *datasets, ufunc_kwargs=None, func_args=None, func_kwargs=None, **kwargs
 ):
     """Wrap make_ufunc with xarray.apply_ufunc.
 
     Parameters
     ----------
     ufunc : callable
-    dataset : xarray.dataset
+    datasets : xarray.dataset
     ufunc_kwargs : dict
         Keyword arguments passed to `make_ufunc`.
             - 'n_dims', int, by default 2
             - 'n_output', int, by default 1
-            - 'n_input', int, by default 1
+            - 'n_input', int, by default len(datasets)
             - 'index', slice, by default Ellipsis
             - 'ravel', bool, by default True
     func_args : tuple
@@ -193,6 +193,7 @@ def wrap_xarray_ufunc(
     """
     if ufunc_kwargs is None:
         ufunc_kwargs = {}
+    ufunc_kwargs.setdefault("n_input", len(datasets))
     if func_args is None:
         func_args = tuple()
     if func_kwargs is None:
@@ -205,7 +206,7 @@ def wrap_xarray_ufunc(
     )
     kwargs.setdefault("output_core_dims", tuple([] for _ in range(ufunc_kwargs.get("n_output", 1))))
 
-    return apply_ufunc(callable_ufunc, dataset, *func_args, kwargs=func_kwargs, **kwargs)
+    return apply_ufunc(callable_ufunc, *datasets, *func_args, kwargs=func_kwargs, **kwargs)
 
 
 def update_docstring(ufunc, func, n_output=1):

--- a/arviz/stats/stats_utils.py
+++ b/arviz/stats/stats_utils.py
@@ -124,7 +124,15 @@ def make_ufunc(
                 msg += " Correct shape is {}".format(arys[-1].shape[:-n_dims])
                 raise TypeError(msg)
         for idx in np.ndindex(out.shape):
-            arys_idx = [ary[idx].ravel() if ravel else ary[idx] for ary in arys]
+            try:
+                arys_idx = [ary[idx].ravel() if ravel else ary[idx] for ary in arys]
+            except IndexError:
+                arys_idx = []
+                for ary in arys:
+                    idx_broadcast = tuple(
+                        0 if dim_len == 1 else idx_i for idx_i, dim_len in zip(idx, ary.shape)
+                    )
+                    arys_idx.append(ary[idx_broadcast].ravel() if ravel else ary[idx_broadcast])
             out[idx] = np.asarray(func(*arys_idx, *args[n_input:], **kwargs))[index]
         return out
 

--- a/arviz/stats/stats_utils.py
+++ b/arviz/stats/stats_utils.py
@@ -74,7 +74,7 @@ def autocorr(ary, axis=-1):
 
 
 def make_ufunc(
-    func, n_dims=2, n_output=1, index=Ellipsis, ravel=True, check_shape=True
+    func, n_dims=2, n_output=1, n_input=1, index=Ellipsis, ravel=True, check_shape=None
 ):  # noqa: D202
     """Make ufunc from a function taking 1D array input.
 
@@ -87,13 +87,18 @@ def make_ufunc(
     n_output : int, optional
         Select number of results returned by `func`.
         If n_output > 1, ufunc returns a tuple of objects else returns an object.
+    n_input : int, optional
+        Number of **array** inputs to func, i.e. ``n_input=2`` means that func is called
+        with ``func(ary1, ary2, *args, **kwargs)``
     index : int, optional
         Slice ndarray with `index`. Defaults to `Ellipsis`.
     ravel : bool, optional
         If true, ravel the ndarray before calling `func`.
     check_shape: bool, optional
         If false, do not check if the shape of the output is compatible with n_dims and
-        n_output.
+        n_output. By default, True only for n_input=1. If n_input is larger than 1, the last
+        input array is used to check the shape, however, shape checking with multiple inputs
+        may not be correct.
 
     Returns
     -------
@@ -103,23 +108,30 @@ def make_ufunc(
     if n_dims < 1:
         raise TypeError("n_dims must be one or higher.")
 
-    def _ufunc(ary, *args, out=None, **kwargs):
+    if n_input == 1 and check_shape is None:
+        check_shape = True
+    elif check_shape is None:
+        check_shape = False
+
+    def _ufunc(*args, out=None, **kwargs):
         """General ufunc for single-output function."""
+        arys = args[:n_input]
         if out is None:
-            out = np.empty(ary.shape[:-n_dims])
+            out = np.empty(arys[-1].shape[:-n_dims])
         elif check_shape:
-            if out.shape != ary.shape[:-n_dims]:
+            if out.shape != arys[-1].shape[:-n_dims]:
                 msg = "Shape incorrect for `out`: {}.".format(out.shape)
-                msg += " Correct shape is {}".format(ary.shape[:-n_dims])
+                msg += " Correct shape is {}".format(arys[-1].shape[:-n_dims])
                 raise TypeError(msg)
         for idx in np.ndindex(out.shape):
-            ary_idx = ary[idx].ravel() if ravel else ary[idx]
-            out[idx] = np.asarray(func(ary_idx, *args, **kwargs))[index]
+            arys_idx = [ary[idx].ravel() if ravel else ary[idx] for ary in arys]
+            out[idx] = np.asarray(func(*arys_idx, *args[n_input:], **kwargs))[index]
         return out
 
-    def _multi_ufunc(ary, *args, out=None, **kwargs):
+    def _multi_ufunc(*args, out=None, **kwargs):
         """General ufunc for multi-output function."""
-        element_shape = ary.shape[:-n_dims]
+        arys = args[:n_input]
+        element_shape = arys[-1].shape[:-n_dims]
         if out is None:
             out = tuple(np.empty(element_shape) for _ in range(n_output))
         elif check_shape:
@@ -137,8 +149,8 @@ def make_ufunc(
                 msg += " Correct shapes are {}".format(correct_shape)
                 raise TypeError(msg)
         for idx in np.ndindex(element_shape):
-            ary_idx = ary[idx].ravel() if ravel else ary[idx]
-            results = func(ary_idx, *args, **kwargs)
+            arys_idx = [ary[idx].ravel() if ravel else ary[idx] for ary in arys]
+            results = func(*arys_idx, *args[n_input:], **kwargs)
             for i, res in enumerate(results):
                 out[i][idx] = np.asarray(res)[index]
         return out
@@ -165,6 +177,7 @@ def wrap_xarray_ufunc(
         Keyword arguments passed to `make_ufunc`.
             - 'n_dims', int, by default 2
             - 'n_output', int, by default 1
+            - 'n_input', int, by default 1
             - 'index', slice, by default Ellipsis
             - 'ravel', bool, by default True
     func_args : tuple

--- a/arviz/stats/stats_utils.py
+++ b/arviz/stats/stats_utils.py
@@ -214,7 +214,7 @@ def update_docstring(ufunc, func, n_output=1):
     module = ""
     name = ""
     docstring = ""
-    if hasattr(func, "__module__"):
+    if hasattr(func, "__module__") and isinstance(func.__module__, str):
         module += func.__module__
     if hasattr(func, "__name__"):
         name += func.__name__

--- a/arviz/stats/stats_utils.py
+++ b/arviz/stats/stats_utils.py
@@ -124,15 +124,7 @@ def make_ufunc(
                 msg += " Correct shape is {}".format(arys[-1].shape[:-n_dims])
                 raise TypeError(msg)
         for idx in np.ndindex(out.shape):
-            try:
-                arys_idx = [ary[idx].ravel() if ravel else ary[idx] for ary in arys]
-            except IndexError:
-                arys_idx = []
-                for ary in arys:
-                    idx_broadcast = tuple(
-                        0 if dim_len == 1 else idx_i for idx_i, dim_len in zip(idx, ary.shape)
-                    )
-                    arys_idx.append(ary[idx_broadcast].ravel() if ravel else ary[idx_broadcast])
+            arys_idx = [ary[idx].ravel() if ravel else ary[idx] for ary in arys]
             out[idx] = np.asarray(func(*arys_idx, *args[n_input:], **kwargs))[index]
         return out
 

--- a/arviz/tests/test_diagnostics.py
+++ b/arviz/tests/test_diagnostics.py
@@ -32,6 +32,8 @@ from ..utils import Numba
 # See discussion in https://github.com/stan-dev/rstan/pull/618
 GOOD_RHAT = 1.1
 
+os.environ["ARVIZ_LOAD"] = "EAGER"
+
 
 @pytest.fixture(scope="session")
 def data():

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -1,4 +1,4 @@
-# pylint: disable=redefined-outer-name
+# pylint: disable=redefined-outer-name,too-many-lines
 import os
 import matplotlib.pyplot as plt
 from pandas import DataFrame

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -1005,5 +1005,3 @@ def test_plot_loo_pit(models, kwargs):
 def test_plot_loo_pit_error(models):
     with pytest.raises(ValueError):
         plot_loo_pit(idata=models.model_1, y="y", ecdf=True, use_hpd=True)
-
-

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -1003,6 +1003,7 @@ def test_plot_loo_pit(models, kwargs):
     assert axes
 
 
-def test_plot_loo_pit_error(models):
+def test_plot_loo_pit_incompatible_args(models):
+    """Test error when both ecdf and use_hpd are True."""
     with pytest.raises(ValueError):
         plot_loo_pit(idata=models.model_1, y="y", ecdf=True, use_hpd=True)

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -1005,5 +1005,5 @@ def test_plot_loo_pit(models, kwargs):
 
 def test_plot_loo_pit_incompatible_args(models):
     """Test error when both ecdf and use_hpd are True."""
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="incompatible"):
         plot_loo_pit(idata=models.model_1, y="y", ecdf=True, use_hpd=True)

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -30,6 +30,7 @@ from ..plots import (
     plot_dist,
     plot_rank,
     plot_elpd,
+    plot_loo_pit,
 )
 
 np.random.seed(0)
@@ -981,3 +982,28 @@ def test_plot_ess_no_divergences(models):
     idata.sample_stats = idata.sample_stats.rename({"diverging": "diverging_missing"})
     with pytest.raises(ValueError):
         plot_ess(idata, rug=True)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"n_unif": 50, "legend": False},
+        {"use_hpd": True, "color": "gray"},
+        {"use_hpd": True, "credible_interval": 0.68, "plot_kwargs": {"ls": "--"}},
+        {"use_hpd": True, "hpd_kwargs": {"smooth": False}},
+        {"ecdf": True},
+        {"ecdf": True, "ecdf_fill": False, "plot_unif_kwargs": {"ls": "--"}},
+        {"ecdf": True, "credible_interval": 0.97, "fill_kwargs": {"hatch": "/"}},
+    ],
+)
+def test_plot_loo_pit(models, kwargs):
+    axes = plot_loo_pit(idata=models.model_1, y="y", **kwargs)
+    assert axes
+
+
+def test_plot_loo_pit_error(models):
+    with pytest.raises(ValueError):
+        plot_loo_pit(idata=models.model_1, y="y", ecdf=True, use_hpd=True)
+
+

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -34,6 +34,7 @@ from ..plots import (
 )
 
 np.random.seed(0)
+os.environ["ARVIZ_LOAD"] = "EAGER"
 
 
 def create_model(seed=10):

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -475,11 +475,17 @@ def test_apply_test_function(
 
 
 def test_apply_test_function_bad_group(centered_eight):
+    """Test error when group is an invalid name."""
     with pytest.raises(ValueError):
         apply_test_function(centered_eight, lambda y, theta: y, group="bad_group")
 
 
 def test_apply_test_function_missing_group():
+    """Test error when InferenceData object is missing a required group.
+
+    The function cannot work if group="both" but InferenceData object has no
+    posterior_predictive group.
+    """
     idata = from_dict(
         posterior={"a": np.random.random((4, 500, 30))}, observed_data={"y": np.random.random(30)}
     )

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -429,25 +429,25 @@ def test_loo_pit_bad_input_shape(incompatibility):
             loo_pit(y=y, y_hat=y_hat[:, :100], log_weights=log_weights)
 
 
-@pytest.mark.parametrize("group", ["both", "observed_data", "posterior_predictive"])
-@pytest.mark.parametrize(
-    "var_names",
-    [
-        None,
-        {"observed_data": "obs"},
-        {"both": "obs"},
-        {"posterior_predictive": "obs"},
-        {"both": "obs", "posterior": ["theta", "mu"]},
-    ],
-)
 @pytest.mark.parametrize("pointwise", [True, False])
-@pytest.mark.parametrize("out_data_shape", [None, "shape"])
-@pytest.mark.parametrize("out_pp_shape", [None, "shape"])
 @pytest.mark.parametrize("inplace", [True, False])
+@pytest.mark.parametrize("kwargs", [
+    {},
+    {"group": "posterior_predictive", "var_names": {"posterior_predictive": "obs"}},
+    {"group": "observed_data", "var_names": {"both": "obs"}, "out_data_shape": "shape"},
+    {"var_names": {"both": "obs", "posterior": ["theta", "mu"]}},
+    {"group": "observed_data", "out_name_data": "T_name"},
+])
 def test_apply_test_function(
-    centered_eight, group, var_names, pointwise, out_data_shape, out_pp_shape, inplace
+    centered_eight, pointwise, inplace, kwargs
 ):
+    """Test some usual call cases of apply_test_function"""
     centered_eight = deepcopy(centered_eight)
+    group = kwargs.get("group", "both")
+    var_names = kwargs.get("var_names", None)
+    out_data_shape = kwargs.get("out_data_shape", None)
+    out_pp_shape = kwargs.get("out_pp_shape", None)
+    out_name_data = kwargs.get("out_name_data", "T")
     if out_data_shape == "shape":
         out_data_shape = (8,) if pointwise else ()
     if out_pp_shape == "shape":
@@ -459,6 +459,7 @@ def test_apply_test_function(
         group=group,
         var_names=var_names,
         pointwise=pointwise,
+        out_name_data=out_name_data,
         out_data_shape=out_data_shape,
         out_pp_shape=out_pp_shape,
     )
@@ -466,9 +467,9 @@ def test_apply_test_function(
         assert idata is idata_out
 
     if group == "both":
-        test_dict = {"observed_data": "T", "posterior_predictive": ["T"]}
+        test_dict = {"observed_data": ["T"], "posterior_predictive": ["T"]}
     else:
-        test_dict = {group: "T"}
+        test_dict = {group: [kwargs.get("out_name_data", "T")]}
 
     fails = check_multiple_attrs(test_dict, idata_out)
     assert not fails

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -407,7 +407,7 @@ def test_loo_pit_bad_input(centered_eight, input_type):
 def test_loo_pit_bad_input_type(centered_eight, arg):
     """Test wrong input type (not None, str not DataArray."""
     kwargs = {"y": "obs", "y_hat": "obs", "log_weights": None}
-    kwargs[arg] = 2 # use int instead of array-like
+    kwargs[arg] = 2  # use int instead of array-like
     with pytest.raises(ValueError, match="not {}".format(type(2))):
         loo_pit(idata=centered_eight, **kwargs)
 
@@ -476,7 +476,7 @@ def test_apply_test_function(
 
 def test_apply_test_function_bad_group(centered_eight):
     """Test error when group is an invalid name."""
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Invalid group argument"):
         apply_test_function(centered_eight, lambda y, theta: y, group="bad_group")
 
 
@@ -489,8 +489,14 @@ def test_apply_test_function_missing_group():
     idata = from_dict(
         posterior={"a": np.random.random((4, 500, 30))}, observed_data={"y": np.random.random(30)}
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="must have posterior_predictive"):
         apply_test_function(idata, lambda y, theta: np.mean, group="both")
+
+
+def test_apply_test_function_should_overwrite_error(centered_eight):
+    """Test error when overwrite=False but out_name is already a present variable."""
+    with pytest.raises(ValueError, match="Should overwrite"):
+        apply_test_function(centered_eight, lambda y, theta: y, out_name_data="obs")
 
 
 def test_numba_stats():

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -1,4 +1,5 @@
 # pylint: disable=redefined-outer-name
+import os
 from copy import deepcopy
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_almost_equal
@@ -23,6 +24,8 @@ from ..stats import (
 from ..stats.stats import _gpinv
 from ..utils import Numba
 from .helpers import check_multiple_attrs
+
+os.environ["ARVIZ_LOAD"] = "EAGER"
 
 
 @pytest.fixture(scope="session")

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -349,24 +349,6 @@ def test_multidimensional_log_likelihood(func):
     assert_array_almost_equal(frm[:4], fr1[:4])
 
 
-def test_numba_stats():
-    """Numba test for r2_score"""
-    state = Numba.numba_flag  # Store the current state of Numba
-    set_1 = np.random.randn(100, 100)
-    set_2 = np.random.randn(100, 100)
-    set_3 = np.random.rand(100)
-    set_4 = np.random.rand(100)
-    Numba.disable_numba()
-    non_numba = r2_score(set_1, set_2)
-    non_numba_one_dimensional = r2_score(set_3, set_4)
-    Numba.enable_numba()
-    with_numba = r2_score(set_1, set_2)
-    with_numba_one_dimensional = r2_score(set_3, set_4)
-    assert state == Numba.numba_flag  # Ensure that inital state = final state
-    assert np.allclose(non_numba, with_numba)
-    assert np.allclose(non_numba_one_dimensional, with_numba_one_dimensional)
-
-
 @pytest.mark.parametrize(
     "args",
     [

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -431,16 +431,17 @@ def test_loo_pit_bad_input_shape(incompatibility):
 
 @pytest.mark.parametrize("pointwise", [True, False])
 @pytest.mark.parametrize("inplace", [True, False])
-@pytest.mark.parametrize("kwargs", [
-    {},
-    {"group": "posterior_predictive", "var_names": {"posterior_predictive": "obs"}},
-    {"group": "observed_data", "var_names": {"both": "obs"}, "out_data_shape": "shape"},
-    {"var_names": {"both": "obs", "posterior": ["theta", "mu"]}},
-    {"group": "observed_data", "out_name_data": "T_name"},
-])
-def test_apply_test_function(
-    centered_eight, pointwise, inplace, kwargs
-):
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"group": "posterior_predictive", "var_names": {"posterior_predictive": "obs"}},
+        {"group": "observed_data", "var_names": {"both": "obs"}, "out_data_shape": "shape"},
+        {"var_names": {"both": "obs", "posterior": ["theta", "mu"]}},
+        {"group": "observed_data", "out_name_data": "T_name"},
+    ],
+)
+def test_apply_test_function(centered_eight, pointwise, inplace, kwargs):
     """Test some usual call cases of apply_test_function"""
     centered_eight = deepcopy(centered_eight)
     group = kwargs.get("group", "both")

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -472,11 +472,9 @@ def test_apply_test_function(
         assert idata is idata_out
 
     if group == "both":
-        test_dict = {"observed_data": "T", "posterior_predictive": ["T_hat"]}
-    elif group == "observed_data":
-        test_dict = {"observed_data": "T"}
-    elif group == "posterior_predictive":
-        test_dict = {"posterior_predictive": ["T_hat"]}
+        test_dict = {"observed_data": "T", "posterior_predictive": ["T"]}
+    else:
+        test_dict = {group: "T"}
 
     fails = check_multiple_attrs(test_dict, idata_out)
     assert not fails

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -478,3 +478,21 @@ def test_apply_test_function(
 
     fails = check_multiple_attrs(test_dict, idata_out)
     assert not fails
+
+
+def test_numba_stats():
+    """Numba test for r2_score"""
+    state = Numba.numba_flag  # Store the current state of Numba
+    set_1 = np.random.randn(100, 100)
+    set_2 = np.random.randn(100, 100)
+    set_3 = np.random.rand(100)
+    set_4 = np.random.rand(100)
+    Numba.disable_numba()
+    non_numba = r2_score(set_1, set_2)
+    non_numba_one_dimensional = r2_score(set_3, set_4)
+    Numba.enable_numba()
+    with_numba = r2_score(set_1, set_2)
+    with_numba_one_dimensional = r2_score(set_3, set_4)
+    assert state == Numba.numba_flag  # Ensure that inital state = final state
+    assert np.allclose(non_numba, with_numba)
+    assert np.allclose(non_numba_one_dimensional, with_numba_one_dimensional)

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -436,6 +436,7 @@ def test_loo_pit_bad_input_shape():
 def test_apply_test_function(
     centered_eight, group, var_names, pointwise, out_data_shape, out_pp_shape, inplace
 ):
+    centered_eight = deepcopy(centered_eight)
     if out_data_shape == "shape":
         out_data_shape = (8,) if pointwise else ()
     if out_pp_shape == "shape":
@@ -460,6 +461,19 @@ def test_apply_test_function(
 
     fails = check_multiple_attrs(test_dict, idata_out)
     assert not fails
+
+
+def test_apply_test_function_bad_group(centered_eight):
+    with pytest.raises(ValueError):
+        apply_test_function(centered_eight, lambda y, theta: y, group="bad_group")
+
+
+def test_apply_test_function_missing_group():
+    idata = from_dict(
+        posterior={"a": np.random.random((4, 500, 30))}, observed_data={"y": np.random.random(30)}
+    )
+    with pytest.raises(ValueError):
+        apply_test_function(idata, lambda y, theta: np.mean, group="both")
 
 
 def test_numba_stats():

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -77,6 +77,8 @@ Stats utils
 
     autocov
     autocorr
+    make_ufunc
+    wrap_xarray_ufunc
 
 Data
 ----

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -25,6 +25,7 @@ Plots
     plot_joint
     plot_kde
     plot_khat
+    plot_loo_pit
     plot_pair
     plot_parallel
     plot_posterior
@@ -41,9 +42,11 @@ Stats
 .. autosummary::
     :toctree: generated/
 
+    apply_test_function
     compare
     hpd
     loo
+    loo_pit
     psislw
     r2_score
     summary

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,6 +20,7 @@
 import os
 import sys
 
+os.environ["ARVIZ_LOAD"] = "EAGER"
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import sphinx_bootstrap_theme
 import arviz

--- a/examples/plot_loo_pit_ecdf.py
+++ b/examples/plot_loo_pit_ecdf.py
@@ -1,0 +1,15 @@
+"""
+LOO-PIT ECDF Plot
+=========
+
+_thumb: .5, .7
+"""
+import arviz as az
+
+az.style.use('arviz-darkgrid')
+
+idata = az.load_arviz_data('radon')
+log_like = idata.sample_stats.log_likelihood.sel(chain=0).values.T
+log_weights = az.psislw(-log_like)[0]
+
+az.plot_loo_pit(idata, y="y_like", log_weights=log_weights, ecdf=True, color="maroon")

--- a/examples/plot_loo_pit_overlay.py
+++ b/examples/plot_loo_pit_overlay.py
@@ -1,0 +1,13 @@
+"""
+LOO-PIT Overlay Plot
+=========
+
+_thumb: .5, .7
+"""
+import arviz as az
+
+az.style.use('arviz-darkgrid')
+
+idata = az.load_arviz_data('non_centered_eight')
+
+az.plot_loo_pit(idata=idata, y="obs", color="indigo")


### PR DESCRIPTION
Add Leave-One-Out (LOO) predictive checks using probability integral transformation (PIT). Fixes #80.

EDIT: 

## PR changelog
### New features
#### `loo_pit`
Added a new function to stats module to calculate LOO-PIT values on idata/array-like objects. Its call signature (`loo_pit(idata, y, y_hat, log_weights)`) is very flexible, allowing to combine array inputs and data retrieved from the inference data object. It enforces hard boundaries on 0 and 1 so that numerical precision issues do not make `loo_pit` return values outside the range.
#### `plot_loo_pit`
Added a new function to plot the results of `loo_pit`. It has two main working modes:
1. The first one is to calculate the kde of the loo pit values, plot it and overlay the kde for several uniform variable realizations having each realization the same number of observations as the loo pit values.
![image](https://user-images.githubusercontent.com/23738400/60390843-38ee3d80-9ae0-11e9-9480-9c44586d8da5.png)

1. The second one is to calculate the Empirical CDF of the loo pit values and compare them with their theoretical value (uniform distribution). Then, the difference between the loo pit ecdf and the uniform cdf is plotted along with its envelope.
![image](https://user-images.githubusercontent.com/23738400/60390836-e7de4980-9adf-11e9-8de8-a50cfc45b455.png)

#### `apply_test_function`
Added a new function to ease the calculation of bayesian test quantities by retrieving the relevant data from idata objects, wrapping `wrap_xarray_ufunc` using some sensible defaults and then storing the result in the idata object itself. For example, it can be used like the examples in BDA p. 146-150 or pointwise mode to use for LOO-PIT checks (which are generally done on _T(y\_i,theta)=y\_i_ but can be applied to any test function result).

#### `$ARVIZ_LOAD`
Added env variable `$ARVIZ_LOAD` to regulate the behaviour of `InferenceData.from_netcdf`. The default has not been modified, it is still lazy loading, but when working with many files simultaneously (i.e. tests or generating docs) it is necessary to load the data into memory. Setting `$ARVIZ_LOAD="EAGER"` (case insensitive) loads the data into memory. I cannot think of any case other than tests or docs where this can happen, so I have not included anything about it on the documentation.

### Modified features
#### `plot_posterior`
Added the `group` argument like in plot_density.
#### `make_ufunc` and `wrap_xarray_ufunc`
Modified their call signature slightly to make them compatible with multiple input datasets. In addition, they are now public and present in the api docs.