### PR TITLE
Improve pymc posterior predictive handling

### DIFF
--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -17,7 +17,7 @@ class PyMC3Converter:
     ):
         self.trace = trace
         self.nchains = trace.nchains if hasattr(trace, "nchains") else 1
-        self.ndraws = len(trace._straces[0]) # pylint: disable=protected-access
+        self.ndraws = len(trace)
         self.prior = prior
         self.posterior_predictive = posterior_predictive
         self.coords = coords

--- a/arviz/tests/test_data_pymc.py
+++ b/arviz/tests/test_data_pymc.py
@@ -27,13 +27,16 @@ class TestDataPyMC3:
             prior = pm.sample_prior_predictive()
             posterior_predictive = pm.sample_posterior_predictive(data.obj)
 
-        return from_pymc3(
-            trace=data.obj,
-            prior=prior,
-            posterior_predictive=posterior_predictive,
-            coords={"school": np.arange(eight_schools_params["J"])},
-            dims={"theta": ["school"], "eta": ["school"]},
-        ), posterior_predictive
+        return (
+            from_pymc3(
+                trace=data.obj,
+                prior=prior,
+                posterior_predictive=posterior_predictive,
+                coords={"school": np.arange(eight_schools_params["J"])},
+                dims={"theta": ["school"], "eta": ["school"]},
+            ),
+            posterior_predictive,
+        )
 
     def test_from_pymc(self, data, eight_schools_params, chains, draws):
         inference_data, posterior_predictive = self.get_inference_data(data, eight_schools_params)
@@ -49,7 +52,9 @@ class TestDataPyMC3:
         for key, values in posterior_predictive.items():
             ivalues = inference_data.posterior_predictive[key]
             for chain in range(chains):
-                assert np.all(np.isclose(ivalues[chain], values[chain * draws : (chain + 1) * draws]))
+                assert np.all(
+                    np.isclose(ivalues[chain], values[chain * draws : (chain + 1) * draws])
+                )
 
     def test_posterior_predictive_reshaped(self, data, chains, draws, eight_schools_params):
         with data.model:

--- a/arviz/tests/test_data_pymc.py
+++ b/arviz/tests/test_data_pymc.py
@@ -33,10 +33,10 @@ class TestDataPyMC3:
             posterior_predictive=posterior_predictive,
             coords={"school": np.arange(eight_schools_params["J"])},
             dims={"theta": ["school"], "eta": ["school"]},
-        )
+        ), posterior_predictive
 
-    def test_from_pymc(self, data, eight_schools_params):
-        inference_data = self.get_inference_data(data, eight_schools_params)
+    def test_from_pymc(self, data, eight_schools_params, chains, draws):
+        inference_data, posterior_predictive = self.get_inference_data(data, eight_schools_params)
         test_dict = {
             "posterior": ["mu", "tau", "eta", "theta"],
             "sample_stats": ["diverging", "log_likelihood"],
@@ -46,6 +46,10 @@ class TestDataPyMC3:
         }
         fails = check_multiple_attrs(test_dict, inference_data)
         assert not fails
+        for key, values in posterior_predictive.items():
+            ivalues = inference_data.posterior_predictive[key]
+            for chain in range(chains):
+                assert np.all(np.isclose(ivalues[chain], values[chain * draws : (chain + 1) * draws]))
 
     def test_posterior_predictive_reshaped(self, data, chains, draws, eight_schools_params):
         with data.model:

--- a/arviz/tests/test_data_pymc.py
+++ b/arviz/tests/test_data_pymc.py
@@ -56,15 +56,13 @@ class TestDataPyMC3:
                     np.isclose(ivalues[chain], values[chain * draws : (chain + 1) * draws])
                 )
 
-    def test_posterior_predictive_reshaped(self, data, chains, draws, eight_schools_params):
+    def test_posterior_predictive_keep_size(self, data, chains, draws, eight_schools_params):
         with data.model:
-            posterior_predictive = pm.sample_posterior_predictive(data.obj)
+            posterior_predictive = pm.sample_posterior_predictive(data.obj, keep_size=True)
 
         inference_data = from_pymc3(
             trace=data.obj,
-            posterior_predictive={
-                k: v.reshape((chains, draws, *v.shape[1:])) for k, v in posterior_predictive.items()
-            },
+            posterior_predictive=posterior_predictive,
             coords={"school": np.arange(eight_schools_params["J"])},
             dims={"theta": ["school"], "eta": ["school"]},
         )


### PR DESCRIPTION
`form_pymc` currently stores all posterior predictive samples in 1 chain. Therefore, the default case, where an array of shape `(nchains*ndraws, *shape)` is returned, the posterior_predictive dataset has shape `(1,nchains*ndraws, *shape)`, instead of being `(nchains, ndraws, *shape)` (which would be the same shape as the log_likelihood for instance). 

I have modified for it to work in the following cases:

* `(nchains, ndraws, *shape)` -> `(nchains, ndraws, *shape)`
* `(nchains*ndraws, *shape)` -> `(nchains, ndraws, *shape)`

and for nsamples different than nchains*ndraws:
* `(nsamples, *shape)` -> `(1, nsamples, *shape)` plus a `logging.warning`