### PR TITLE
New ess plots

### DIFF
--- a/arviz/plots/__init__.py
+++ b/arviz/plots/__init__.py
@@ -3,6 +3,7 @@ from .autocorrplot import plot_autocorr
 from .compareplot import plot_compare
 from .densityplot import plot_density
 from .energyplot import plot_energy
+from .essplot import plot_ess
 from .forestplot import plot_forest
 from .kdeplot import plot_kde, _fast_kde, _fast_kde_2d
 from .parallelplot import plot_parallel
@@ -23,6 +24,7 @@ __all__ = [
     "plot_compare",
     "plot_density",
     "plot_energy",
+    "plot_ess",
     "plot_forest",
     "plot_kde",
     "_fast_kde",

--- a/arviz/plots/essplot.py
+++ b/arviz/plots/essplot.py
@@ -149,6 +149,8 @@ def plot_ess(
 
     data = convert_to_dataset(idata, group="posterior")
     var_names = _var_names(var_names, data)
+    n_draws = len(data.draw)
+    n_samples = n_draws * len(data.chain)
 
     if kind == "quantile":
         probs = np.arange(1 / n_points, 1, 1 / n_points)
@@ -179,9 +181,7 @@ def plot_ess(
             dim="ess_dim",
         )
     else:
-        n_draws = len(data.draw)
         first_draw = data.draw.values[0]
-        n_samples = n_draws * len(data.chain)
         ylabel = "{}"
         xdata = np.linspace(n_samples / n_points, n_samples, n_points)
         draw_divisions = np.linspace(n_draws // n_points, n_draws, n_points, dtype=int)
@@ -267,11 +267,11 @@ def plot_ess(
             mask = idata.sample_stats[rug_kind].values.flatten()
             values = np.argsort(values)[mask]
             rug_space = np.max(x) * rug_kwargs.pop("space")
-            rug_x, rug_y = values/(len(mask)-1), np.zeros_like(values) - rug_space
+            rug_x, rug_y = values / (len(mask) - 1), np.zeros_like(values) - rug_space
             ax_.plot(rug_x, rug_y, **rug_kwargs)
             ax_.axhline(0, color="k", linewidth=_linewidth, alpha=0.7)
 
-        ax_.axhline(min_ess, **hline_kwargs)
+        ax_.axhline(400 / n_samples if relative else min_ess, **hline_kwargs)
 
         ax_.set_title(make_label(var_name, selection), fontsize=titlesize, wrap=True)
         ax_.tick_params(labelsize=xt_labelsize)

--- a/arviz/plots/essplot.py
+++ b/arviz/plots/essplot.py
@@ -180,14 +180,15 @@ def plot_ess(
         )
     else:
         n_draws = len(data.draw)
+        first_draw = data.draw.values[0]
         n_samples = n_draws * len(data.chain)
         ylabel = "{}"
         xdata = np.linspace(n_samples / n_points, n_samples, n_points)
-        draw_divisions = np.linspace(n_draws / n_points, n_draws, n_points)
+        draw_divisions = np.linspace(n_draws // n_points, n_draws, n_points, dtype=int)
         ess_dataset = xr.concat(
             [
                 ess(
-                    data.sel(draw=slice(draw_div)),
+                    data.sel(draw=slice(first_draw + draw_div)),
                     var_names=var_names,
                     relative=relative,
                     method="bulk",
@@ -199,7 +200,7 @@ def plot_ess(
         ess_tail_dataset = xr.concat(
             [
                 ess(
-                    data.sel(draw=slice(draw_div)),
+                    data.sel(draw=slice(first_draw + draw_div)),
                     var_names=var_names,
                     relative=relative,
                     method="tail",

--- a/arviz/plots/essplot.py
+++ b/arviz/plots/essplot.py
@@ -135,7 +135,8 @@ def plot_ess(
 
         >>> extra_kwargs = {"color": "lightsteelblue"}
         >>> az.plot_ess(
-        ...     idata, kind="evolution", var_names=["mu"], color="royalblue", extra_kwargs=extra_kwargs
+        ...     idata, kind="evolution", var_names=["mu"],
+        ...     color="royalblue", extra_kwargs=extra_kwargs
         ... )
 
     """
@@ -164,7 +165,7 @@ def plot_ess(
             dim="ess_dim",
         )
     elif kind == "local":
-        probs = np.linspace(0, 1 - 1 / n_points, n_points)
+        probs = np.linspace(0, 1, n_points, endpoint=False)
         xdata = probs
         ylabel = "{} for small intervals"
         ess_dataset = xr.concat(

--- a/arviz/plots/essplot.py
+++ b/arviz/plots/essplot.py
@@ -1,0 +1,136 @@
+"""Plot quantile or local effective sample sizes."""
+import numpy as np
+import xarray as xr
+
+from ..data import convert_to_dataset
+from ..stats import ess
+from .plot_utils import (
+    xarray_var_iter,
+    _scale_fig_size,
+    make_label,
+    default_grid,
+    _create_axes_grid,
+    get_coords,
+)
+from ..utils import _var_names
+
+
+def plot_ess(
+    data,
+    var_names=None,
+    kind="local",
+    relative=False,
+    coords=None,
+    figsize=None,
+    textsize=None,
+    n_points=20,
+    ax=None,
+    **kwargs
+):
+    """Plot quantile or local effective sample sizes.
+
+    Parameters
+    ----------
+    data : obj
+        Any object that can be converted to an az.InferenceData object
+        Refer to documentation of az.convert_to_dataset for details
+    var_names : list of variable names, optional
+        Variables to be plotted, two variables are required.
+    kind : str, optional
+        Options: ``local`` or ``quantile``, whether to plot local or quantile ess plot.
+    relative : bool
+        Show relative ess in plot.
+    coords : dict, optional
+        Coordinates of var_names to be plotted. Passed to `Dataset.sel`
+    figsize : tuple, optional
+        Figure size. If None it will be defined automatically.
+    textsize: float, optional
+        Text size scaling factor for labels, titles and lines. If None it will be autoscaled based
+        on figsize.
+    n_points : int
+        Number of quantiles for which to plot their quantile/local ess
+    ax : axes, optional
+        Matplotlib axes. Defaults to None.
+    **kwargs
+        Passed as-is to plt.hist() or plt.plot() function depending on the value of `kind`.
+
+    Returns
+    -------
+    ax : matplotlib axes
+
+    Examples
+    --------
+    """
+    valid_kinds = ("local", "quantile")
+    kind = kind.lower()
+    if kind not in valid_kinds:
+        raise ValueError("Invalid kind, kind must be one of {} not {}".format(valid_kinds, kind))
+
+    if coords is None:
+        coords = {}
+
+    data = convert_to_dataset(data, group="posterior")
+    var_names = _var_names(var_names, data)
+
+    if kind == "quantile":
+        probs = np.arange(1 / n_points, 1, 1 / n_points)
+        ess_dataset = xr.concat(
+            [
+                ess(data, var_names=var_names, relative=relative, method="quantile", prob=p)
+                for p in probs
+            ],
+            dim="quantile",
+        )
+    elif kind == "local":
+        probs = np.arange(0, 1, 1 / n_points)
+        ess_dataset = xr.concat(
+            [
+                ess(
+                    data,
+                    var_names=var_names,
+                    relative=relative,
+                    method="local",
+                    prob=[p, p + 1 / n_points],
+                )
+                for p in probs
+            ],
+            dim="quantile",
+        )
+
+    plotters = list(
+        xarray_var_iter(
+            get_coords(ess_dataset, coords), var_names=var_names, skip_dims={"quantile"}
+        )
+    )
+    length_plotters = len(plotters)
+    rows, cols = default_grid(length_plotters)
+
+    (figsize, ax_labelsize, titlesize, xt_labelsize, _linewidth, _markersize) = _scale_fig_size(
+        figsize, textsize, rows, cols
+    )
+    kwargs.setdefault("linestyle", "none")
+    kwargs.setdefault("linewidth", _linewidth)
+    kwargs.setdefault("marker", "o")
+    kwargs.setdefault("markersize", _markersize)
+
+    if ax is None:
+        _, ax = _create_axes_grid(
+            length_plotters, rows, cols, figsize=figsize, squeeze=False, constrained_layout=True
+        )
+
+    for (var_name, selection, x), ax_ in zip(plotters, np.ravel(ax)):
+        ax_.plot(probs, x, **kwargs)
+        ax_.set_title(make_label(var_name, selection), fontsize=titlesize, wrap=True)
+        ax_.tick_params(labelsize=xt_labelsize)
+        ax_.set_xlabel("Quantile", fontsize=ax_labelsize)
+        ax_.set_ylabel(
+            "{} for {}".format(
+                "Relative ESS" if relative else "ESS",
+                "small intervals" if kind == "local" else "quantiles",
+            ),
+            fontsize=ax_labelsize,
+            wrap=True,
+        )
+        ax_.set_xlim(0, 1)
+
+    return ax

--- a/arviz/stats/diagnostics.py
+++ b/arviz/stats/diagnostics.py
@@ -223,6 +223,7 @@ def ess(data, *, var_names=None, method="bulk", relative=False, prob=None):
         "z_scale": _ess_z_scale,
         "folded": _ess_folded,
         "identity": _ess_identity,
+        "local": _ess_local,
     }
 
     if method not in methods:
@@ -798,6 +799,20 @@ def _ess_quantile(ary, prob, relative=False):
         raise TypeError("Prob not defined.")
     quantile, = _quantile(ary, prob)
     iquantile = ary <= quantile
+    return _ess(_split_chains(iquantile), relative=relative)
+
+
+def _ess_local(ary, prob, relative=False):
+    """Compute the effective sample size for the specific residual."""
+    ary = np.asarray(ary)
+    if _not_valid(ary, shape_kwargs=dict(min_draws=4, min_chains=1)):
+        return np.nan
+    if prob is None:
+        raise TypeError("Prob not defined.")
+    if len(prob) != 2:
+        raise ValueError("Prob argument in ess local must be upper and lower bound")
+    quantile = _quantile(ary, prob)
+    iquantile = (quantile[0] <= ary) & (ary <= quantile[1])
     return _ess(_split_chains(iquantile), relative=relative)
 
 

--- a/arviz/stats/diagnostics.py
+++ b/arviz/stats/diagnostics.py
@@ -204,6 +204,13 @@ def ess(data, *, var_names=None, method="bulk", relative=False, prob=None):
 
         In [1]: az.ess(data, relative=True, var_names=["mu", "theta_t"])
 
+    Calculate the ess using the "tail" method, leaving the `prob` argument at its default
+    value.
+
+    .. ipython::
+
+        In [1]: az.ess(data, method="tail")
+
     """
     methods = {
         "bulk": _ess_bulk,

--- a/arviz/tests/test_diagnostics.py
+++ b/arviz/tests/test_diagnostics.py
@@ -212,6 +212,7 @@ class TestDiagnostics:
             "bulk",
             "tail",
             "quantile",
+            "local",
             "mean",
             "sd",
             "median",
@@ -236,6 +237,10 @@ class TestDiagnostics:
                 ess_hat = ess(
                     np.random.randn(4, 100), method=method, prob=(0.2, 0.8), relative=relative
                 )
+        elif method == "local":
+            ess_hat = ess(
+                np.random.randn(4, 100), method=method, prob=(0.2, 0.3), relative=relative
+            )
         else:
             ess_hat = ess(np.random.randn(4, 100), method=method, relative=relative)
         assert ess_hat > n_low
@@ -252,6 +257,7 @@ class TestDiagnostics:
             "bulk",
             "tail",
             "quantile",
+            "local",
             "mean",
             "sd",
             "median",
@@ -275,12 +281,16 @@ class TestDiagnostics:
         if (draw < 4) or use_nan:
             if method in ("quantile", "tail"):
                 ess_value = ess(data, method=method, prob=0.34, relative=relative)
+            elif method == "local":
+                ess_value = ess(data, method=method, prob=(0.2, 0.3), relative=relative)
             else:
                 ess_value = ess(data, method=method, relative=relative)
             assert np.isnan(ess_value)
         else:
             if method in ("quantile", "tail"):
                 ess_value = ess(data, method=method, prob=0.34, relative=relative)
+            elif method == "local":
+                ess_value = ess(data, method=method, prob=(0.2, 0.3), relative=relative)
             else:
                 ess_value = ess(data, method=method, relative=relative)
             assert not np.isnan(ess_value)
@@ -297,6 +307,13 @@ class TestDiagnostics:
             ess(np.random.randn(4, 100), method="quantile", relative=relative)
         with pytest.raises(TypeError):
             _ess_quantile(np.random.randn(4, 100), prob=None, relative=relative)
+        with pytest.raises(TypeError):
+            ess(np.random.randn(4, 100), method="local", relative=relative)
+
+    @pytest.mark.parametrize("relative", (True, False))
+    def test_effective_sample_size_too_many_probs(self, relative):
+        with pytest.raises(ValueError):
+            ess(np.random.randn(4, 100), method="local", prob=[0.1, 0.2, 0.9], relative=relative)
 
     def test_effective_sample_size_constant(self):
         assert ess(np.ones((4, 100))) == 400
@@ -315,6 +332,7 @@ class TestDiagnostics:
             "bulk",
             "tail",
             "quantile",
+            "local",
             "mean",
             "sd",
             "median",
@@ -330,6 +348,10 @@ class TestDiagnostics:
         n_low = 100 if not relative else 100 / (data.chain.size * data.draw.size)
         if method in ("quantile", "tail"):
             ess_hat = ess(data, var_names=var_names, method=method, prob=0.34, relative=relative)
+        elif method == "local":
+            ess_hat = ess(
+                data, var_names=var_names, method=method, prob=(0.2, 0.3), relative=relative
+            )
         else:
             ess_hat = ess(data, var_names=var_names, method=method, relative=relative)
         assert np.all(ess_hat.mu.values > n_low)  # This might break if the data is regenerated

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -936,7 +936,7 @@ def test_plot_elpd_one_model(models):
         {"min_ess": 600, "hline_kwargs": {"color": "r"}},
     ],
 )
-@pytest.mark.parametrize("kind", ["local", "quantile", "change"])
+@pytest.mark.parametrize("kind", ["local", "quantile", "evolution"])
 def test_plot_ess(models, kind, kwargs):
     idata = models.model_1
     ax = plot_ess(idata, kind=kind, **kwargs)
@@ -958,9 +958,9 @@ def test_plot_ess_local_quantile(models, kind, kwargs):
     assert np.all(ax)
 
 
-def test_plot_ess_change(models):
+def test_plot_ess_evolution(models):
     idata = models.model_1
-    ax = plot_ess(idata, kind="change", extra_kwargs={"linestyle": "--"}, color="b")
+    ax = plot_ess(idata, kind="evolution", extra_kwargs={"linestyle": "--"}, color="b")
     assert np.all(ax)
 
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -17,6 +17,7 @@ Plots
     plot_compare
     plot_density
     plot_energy
+    plot_ess
     plot_forest
     plot_hpd
     plot_joint


### PR DESCRIPTION
Add the plots for new ess (#621).

Example plots on the centered eight dataset. The default appearance is quite simple:

![image](https://user-images.githubusercontent.com/23738400/60195652-c2c9ac80-983b-11e9-9673-eafd28eeda0f.png)

![image](https://user-images.githubusercontent.com/23738400/60195496-7a11f380-983b-11e9-887e-91718f90ab96.png)

![image](https://user-images.githubusercontent.com/23738400/60195510-7ed6a780-983b-11e9-9db3-c286d2787071.png)

But it can be customized to look like the plots in the reference paper for example:

![image](https://user-images.githubusercontent.com/23738400/60195523-86964c00-983b-11e9-9740-1c918470d104.png)

![image](https://user-images.githubusercontent.com/23738400/60195669-ca895100-983b-11e9-8eee-2d1cd621ba3b.png)

I have set the same default appearance for both quantile and local, differing from the paper, because I think that using a hist like plot can be misleading. Now the only difference is the ylabel, which can be confusing to someone not familiar with this kind of plots. Would you rather have different appearance between quantile and local ess plots?

