### PR TITLE
CI broken again

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ numpydoc
 pydocstyle
 pylint
 pyro-ppl
-tensorflow==1.13.1
+tensorflow
 tensorflow-probability
 pytest
 pytest-cov


### PR DESCRIPTION
tfp 0.7 has just been released, so now tensorflow 1.14 is a requirement