### PR TITLE
Centralize number formatting.

### DIFF
--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -304,7 +304,9 @@ def _plot_posterior_op(
         elif point_estimate == "median":
             point_value = np.median(values)
         sig_figs = significant_fig_func(point_value)
-        point_text = f"{point_estimate}={point_value:.{sig_figs}g}"
+        point_text = "{point_estimate}={point_value:.{sig_figs}g}".format(
+            point_estimate=point_estimate, point_value=point_value, sig_figs=sig_figs
+        )
         ax.text(
             point_value,
             plot_height * 0.8,
@@ -320,7 +322,7 @@ def _plot_posterior_op(
 
         def round_num(n: float) -> str:
             sig_figs = significant_fig_func(n)
-            return f"{n:.{sig_figs}g}"
+            return "{n:.{sig_figs}g}".format(n=n, sig_figs=sig_figs)
 
         ax.plot(
             hpd_intervals,

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -210,10 +210,7 @@ def _plot_posterior_op(
 ):  # noqa: D202
     """Artist to draw posterior."""
 
-    if round_to is None:
-        significant_fig_func = format_sig_figs
-    else:
-        significant_fig_func = lambda v: round_to
+    significant_fig_func = lambda v: format_sig_figs(v, default=round_to)
 
     def format_as_percent(x, round_to=0):
         return "{0:.{1:d}f}%".format(100 * x, round_to)
@@ -322,7 +319,8 @@ def _plot_posterior_op(
         hpd_intervals = hpd(values, credible_interval=credible_interval)  # type: np.ndarray
 
         def round_num(n: float) -> str:
-            return f"{n:.{significant_fig_func(n)}g}"
+            sig_figs = significant_fig_func(n)
+            return f"{n:.{sig_figs}g}"
 
         ax.plot(
             hpd_intervals,

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -16,7 +16,7 @@ from .plot_utils import (
     _create_axes_grid,
     get_coords,
 )
-from ..utils import _var_names
+from ..utils import _var_names, format_sig_figs
 
 
 def plot_posterior(
@@ -26,8 +26,7 @@ def plot_posterior(
     figsize=None,
     textsize=None,
     credible_interval=0.94,
-    round_to=1,
-    significant_figs: Optional[int] = None,
+    round_to: Optional[int] = None,
     point_estimate="mean",
     rope=None,
     ref_val=None,
@@ -55,10 +54,8 @@ def plot_posterior(
         on figsize.
     credible_interval : float, optional
         Credible intervals. Defaults to 0.94.
-    round_to : int
-        Controls formatting for floating point numbers
-    significant_figs : int, optional
-        Alternative means of controlling formatting of floats.
+    round_to : int, optional
+        Controls formatting of floats. Defaults to 2 or the integer part, whichever is bigger.
     point_estimate: str
         Must be in ('mode', 'mean', 'median')
     rope: tuple or dictionary of tuples
@@ -179,7 +176,6 @@ def plot_posterior(
             bins=bins,
             kind=kind,
             point_estimate=point_estimate,
-            significant_figs=significant_figs,
             round_to=round_to,
             credible_interval=credible_interval,
             ref_val=ref_val,
@@ -204,16 +200,20 @@ def _plot_posterior_op(
     bins,
     kind,
     point_estimate,
-    round_to,
     credible_interval,
     ref_val,
     rope,
     ax_labelsize,
     xt_labelsize,
-    significant_figs: Optional[int] = None,
+    round_to: Optional[int] = None,
     **kwargs
 ):  # noqa: D202
     """Artist to draw posterior."""
+
+    if round_to is None:
+        significant_fig_func = format_sig_figs
+    else:
+        significant_fig_func = lambda v: round_to
 
     def format_as_percent(x, round_to=0):
         return "{0:.{1:d}f}%".format(100 * x, round_to)
@@ -303,16 +303,11 @@ def _plot_posterior_op(
                 x = np.linspace(lower, upper, len(density))
                 point_value = x[np.argmax(density)]
             else:
-                if significant_figs is None:
-                    point_value = mode(values.round(round_to))[0][0]
-                else:
-                    point_value = mode(values)[0][0]
+                point_value = mode(values)[0][0]
         elif point_estimate == "median":
             point_value = np.median(values)
-        if significant_figs is None:
-            point_text = "{}={:.{}f}".format(point_estimate, point_value, round_to)
-        else:
-            point_text = "{}={:.{}g}".format(point_estimate, point_value, significant_figs)
+        sig_figs = significant_fig_func(point_value)
+        point_text = f"{point_estimate}={point_value:.{sig_figs}g}"
         ax.text(
             point_value,
             plot_height * 0.8,
@@ -327,11 +322,7 @@ def _plot_posterior_op(
         hpd_intervals = hpd(values, credible_interval=credible_interval)  # type: np.ndarray
 
         def round_num(n: float) -> str:
-            if significant_figs is None:
-                fstr = "%%.%df" % round_to
-            else:
-                fstr = "%%.%dg" % significant_figs
-            return fstr % n
+            return f"{n:.{significant_fig_func(n)}g}"
 
         ax.plot(
             hpd_intervals,

--- a/arviz/tests/test_utils.py
+++ b/arviz/tests/test_utils.py
@@ -124,8 +124,8 @@ def test_conditional_jit_numba_decorator_keyword(monkeypatch):
         "value, default, expected",
     [
         (123.456, 2, 3),
-        (123.456, 3, 3),
-        (123.456, 4, 4),
+        (-123.456, 3, 3),
+        (-123.456, 4, 4),
         (12.3456, 2, 2),
         (1.23456, 2, 2),
         (0.123456, 2, 2),

--- a/arviz/tests/test_utils.py
+++ b/arviz/tests/test_utils.py
@@ -120,8 +120,9 @@ def test_conditional_jit_numba_decorator_keyword(monkeypatch):
     assert wrapper_result == {"keyword_argument": "A keyword argument"}
     assert function_results == "output"
 
+
 @pytest.mark.parametrize(
-        "value, default, expected",
+    "value, default, expected",
     [
         (123.456, 2, 3),
         (-123.456, 3, 3),

--- a/arviz/tests/test_utils.py
+++ b/arviz/tests/test_utils.py
@@ -5,7 +5,7 @@ Tests for arviz.utils.
 from unittest.mock import Mock
 import numpy as np
 import pytest
-from ..utils import _var_names
+from ..utils import _var_names, format_sig_figs
 from ..data import load_arviz_data, from_dict
 
 
@@ -119,3 +119,17 @@ def test_conditional_jit_numba_decorator_keyword(monkeypatch):
     function_results, wrapper_result = placeholder_func
     assert wrapper_result == {"keyword_argument": "A keyword argument"}
     assert function_results == "output"
+
+@pytest.mark.parametrize(
+        "value, default, expected",
+    [
+        (123.456, 2, 3),
+        (123.456, 3, 3),
+        (123.456, 4, 4),
+        (12.3456, 2, 2),
+        (1.23456, 2, 2),
+        (0.123456, 2, 2),
+    ],
+)
+def test_format_sig_figs(value, default, expected):
+    assert format_sig_figs(value, default=default) == expected

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -84,7 +84,7 @@ def conditional_jit(function=None, **kwargs):  # noqa: D202
 
 
 def format_sig_figs(value, default=None):
-    """Default for significant figures.
+    """Get a default number of significant figures.
 
     Gives the integer part or `default`, whichever is bigger.
 

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -81,3 +81,20 @@ def conditional_jit(function=None, **kwargs):  # noqa: D202
         return wrapper(function)
     else:
         return wrapper
+
+
+def format_sig_figs(value, default=2):
+    """Default for significant figures.
+
+    Gives the integer part or `default`, whichever is bigger.
+
+    Examples
+    --------
+    0.1234 --> 0.12
+    1.234  --> 1.2
+    12.34  --> 12
+    123.4  --> 123
+    """
+    if value == 0:
+        return 1
+    return max(int(np.log10(np.abs(value))) + 1, default)

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -83,7 +83,7 @@ def conditional_jit(function=None, **kwargs):  # noqa: D202
         return wrapper
 
 
-def format_sig_figs(value, default=2):
+def format_sig_figs(value, default=None):
     """Default for significant figures.
 
     Gives the integer part or `default`, whichever is bigger.
@@ -95,6 +95,8 @@ def format_sig_figs(value, default=2):
     12.34  --> 12
     123.4  --> 123
     """
+    if default is None:
+        default = 2
     if value == 0:
         return 1
     return max(int(np.log10(np.abs(value))) + 1, default)


### PR DESCRIPTION
Uses the code from #705, but re-simplifies the API to have only the single formatting option. Right now formatting will be the integer part or `round_to`, whichever is bigger.

@rpgoldman tagging you in case you have opinions.

```python
az.plot_posterior(data, ['mu', 'tau']);
```
![image](https://user-images.githubusercontent.com/2295568/59968956-cba34100-9510-11e9-81b5-15cdd75b10e6.png)

```python
az.plot_posterior(data, ['mu', 'tau'], round_to=0);
```
![image](https://user-images.githubusercontent.com/2295568/59968960-e4135b80-9510-11e9-99ce-a729c8663153.png)
```python
az.plot_posterior(data, ['mu', 'tau'], round_to=5);
```
![image](https://user-images.githubusercontent.com/2295568/59968962-f55c6800-9510-11e9-9b4e-161c4c7f27c3.png)
