### PR TITLE
Add missing examples and functions in api [GSoC]

### DIFF
--- a/arviz/plots/__init__.py
+++ b/arviz/plots/__init__.py
@@ -2,44 +2,44 @@
 from .autocorrplot import plot_autocorr
 from .compareplot import plot_compare
 from .densityplot import plot_density
+from .distplot import plot_dist
+from .elpdplot import plot_elpd
 from .energyplot import plot_energy
 from .essplot import plot_ess
 from .forestplot import plot_forest
-from .kdeplot import plot_kde, _fast_kde, _fast_kde_2d
-from .parallelplot import plot_parallel
-from .elpdplot import plot_elpd
-from .posteriorplot import plot_posterior
-from .traceplot import plot_trace
-from .pairplot import plot_pair
-from .jointplot import plot_joint
-from .khatplot import plot_khat
-from .ppcplot import plot_ppc
-from .violinplot import plot_violin
 from .hpdplot import plot_hpd
-from .distplot import plot_dist
+from .jointplot import plot_joint
+from .kdeplot import plot_kde, _fast_kde, _fast_kde_2d
+from .khatplot import plot_khat
+from .pairplot import plot_pair
+from .parallelplot import plot_parallel
+from .posteriorplot import plot_posterior
+from .ppcplot import plot_ppc
 from .rankplot import plot_rank
+from .traceplot import plot_trace
+from .violinplot import plot_violin
 
 
 __all__ = [
     "plot_autocorr",
     "plot_compare",
     "plot_density",
+    "plot_dist",
+    "plot_elpd",
     "plot_energy",
     "plot_ess",
     "plot_forest",
+    "plot_hpd",
+    "plot_joint",
     "plot_kde",
     "_fast_kde",
     "_fast_kde_2d",
-    "plot_parallel",
-    "plot_elpd",
-    "plot_posterior",
-    "plot_trace",
-    "plot_pair",
-    "plot_joint",
     "plot_khat",
+    "plot_pair",
+    "plot_parallel",
+    "plot_posterior",
     "plot_ppc",
-    "plot_violin",
-    "plot_hpd",
-    "plot_dist",
     "plot_rank",
+    "plot_trace",
+    "plot_violin",
 ]

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -16,6 +16,8 @@ Plots
     plot_autocorr
     plot_compare
     plot_density
+    plot_dist
+    plot_elpd
     plot_energy
     plot_ess
     plot_forest
@@ -25,11 +27,11 @@ Plots
     plot_khat
     plot_pair
     plot_parallel
-    plot_elpd
     plot_posterior
     plot_ppc
     plot_rank
     plot_trace
+    plot_violin
 
 .. _stats_api:
 

--- a/examples/plot_elpd.py
+++ b/examples/plot_elpd.py
@@ -1,0 +1,14 @@
+"""
+ELPD Plot
+=========
+
+_thumb: .6, .5
+"""
+import arviz as az
+
+az.style.use("arviz-darkgrid")
+
+d1 = az.load_arviz_data("centered_eight")
+d2 = az.load_arviz_data("non_centered_eight")
+
+az.plot_elpd({"Centered eight": d1, "Non centered eight": d2}, xlabels=True)

--- a/examples/plot_ess_evolution.py
+++ b/examples/plot_ess_evolution.py
@@ -1,0 +1,13 @@
+"""
+ESS Quantile Plot
+=========
+
+_thumb: .2, .8
+"""
+import arviz as az
+
+az.style.use("arviz-darkgrid")
+
+idata = az.load_arviz_data("radon")
+
+az.plot_ess(idata, var_names=["b"], kind="evolution")

--- a/examples/plot_ess_local.py
+++ b/examples/plot_ess_local.py
@@ -1,0 +1,13 @@
+"""
+ESS Local Plot
+=========
+
+_thumb: .7, .5
+"""
+import arviz as az
+
+az.style.use("arviz-darkgrid")
+
+idata = az.load_arviz_data("centered_eight")
+
+az.plot_ess(idata, var_names=["mu"], kind="local", marker="_", ms=20, mew=2)

--- a/examples/plot_ess_quantile.py
+++ b/examples/plot_ess_quantile.py
@@ -1,0 +1,13 @@
+"""
+ESS Quantile Plot
+=========
+
+_thumb: .4, .5
+"""
+import arviz as az
+
+az.style.use("arviz-darkgrid")
+
+idata = az.load_arviz_data("radon")
+
+az.plot_ess(idata, var_names=["sigma_y"], kind="quantile")


### PR DESCRIPTION
I also sorted alphabetically both the functions in the `api.rst` file and in `plot/__init__.py` to ease the comparison.