### PR TITLE
Khat plot: hover tweaking [GSoC]

### DIFF
--- a/arviz/__init__.py
+++ b/arviz/__init__.py
@@ -26,4 +26,4 @@ if not logging.root.handlers:
 from .data import *
 from .plots import *
 from .stats import *
-from .utils import Numba
+from .utils import Numba, interactive_backend

--- a/arviz/plots/khatplot.py
+++ b/arviz/plots/khatplot.py
@@ -25,6 +25,7 @@ def plot_khat(
     bin_format="{1:.1f}%",
     annotate=False,
     hover_label=False,
+    hover_format="{1}",
     figsize=None,
     textsize=None,
     coords=None,
@@ -50,12 +51,14 @@ def plot_khat(
     show_bins : bool, optional
         Show the number of khats which fall in each bin.
     bin_format : str, optional
-        The string is used as formatting guide calling ``show_bins.format(count, pct)``.
+        The string is used as formatting guide calling ``bin_format.format(count, pct)``.
     annotate : bool, optional
         Show the labels of k values larger than 1.
     hover_label : bool, optional
         Show the datapoint label when hovering over it with the mouse. Requires an interactive
         backend.
+    hover_format : str, optional
+        String used to format the hover label via ``hover_format.format(idx, coord_label)``
     figsize : tuple, optional
         Figure size. If None it will be defined automatically.
     textsize: float, optional
@@ -251,12 +254,12 @@ def plot_khat(
         ax.legend(ncol=ncols, title=color)
 
     if hover_label and mpl.get_backend() in mpl.rcsetup.interactive_bk:
-        _make_hover_annotation(fig, ax, sc_plot, coord_labels, rgba_c)
+        _make_hover_annotation(fig, ax, sc_plot, coord_labels, rgba_c, hover_format)
 
     return ax
 
 
-def _make_hover_annotation(fig, ax, sc_plot, coord_labels, rgba_c):
+def _make_hover_annotation(fig, ax, sc_plot, coord_labels, rgba_c, hover_format):
     """Show data point label when hovering over it with mouse."""
     annot = ax.annotate(
         "",
@@ -275,11 +278,12 @@ def _make_hover_annotation(fig, ax, sc_plot, coord_labels, rgba_c):
 
         idx = ind["ind"][0]
         pos = sc_plot.get_offsets()[idx]
+        annot_text = hover_format.format(idx, coord_labels[idx])
         annot.xy = pos
         annot.set_position(
             (-offset if pos[0] > xmid else offset, -offset if pos[1] > ymid else offset)
         )
-        annot.set_text(coord_labels[idx])
+        annot.set_text(annot_text)
         annot.get_bbox_patch().set_facecolor(rgba_c[idx])
         annot.set_ha("right" if pos[0] > xmid else "left")
         annot.set_va("top" if pos[1] > ymid else "bottom")

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -98,7 +98,7 @@ class maybe_numba_fn:  # pylint: disable=invalid-name
             return self.function(*args, **kwargs)
 
 
-class interactive_backend: #pylint: disable=invalid-name
+class interactive_backend:  # pylint: disable=invalid-name
     """Context manager to change backend temporarily in ipython sesson.
 
     It uses ipython magic to change temporarily from the ipython inline backend to

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -131,6 +131,7 @@ class interactive_backend:
         >>> az.plot_trace(idata) # inline
 
     """
+
     def __init__(self, backend=""):
         try:
             from IPython import get_ipython
@@ -141,9 +142,7 @@ class interactive_backend:
             )
         self.ipython = get_ipython()
         if self.ipython is None:
-            raise EnvironmentError(
-                "This context manager can only be used inside ipython sessions"
-            )
+            raise EnvironmentError("This context manager can only be used inside ipython sessions")
         self.ipython.magic("matplotlib {}".format(backend))
 
     def __enter__(self):

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -98,12 +98,12 @@ class maybe_numba_fn:  # pylint: disable=invalid-name
             return self.function(*args, **kwargs)
 
 
-class interactive_backend:
-    """Context manager to change temporarily from inline backend to an interactive
-    backend inside an ipython session.
+class interactive_backend: #pylint: disable=invalid-name
+    """Context manager to change backend temporarily in ipython sesson.
 
-    Uses ipython magic to change temporarily from the ipython inline backend to
-    an interactive backend of choice.
+    It uses ipython magic to change temporarily from the ipython inline backend to
+    an interactive backend of choice. It cannot be used outside ipython sessions nor
+    to change backends different than inline -> interactive.
 
     Notes
     -----
@@ -132,7 +132,9 @@ class interactive_backend:
 
     """
 
+    # based on matplotlib.rc_context
     def __init__(self, backend=""):
+        """Initialize context manager."""
         try:
             from IPython import get_ipython
         except ImportError as err:
@@ -146,9 +148,11 @@ class interactive_backend:
         self.ipython.magic("matplotlib {}".format(backend))
 
     def __enter__(self):
+        """Enter context manager."""
         return self
 
     def __exit__(self, exc_type, exc_value, exc_tb):
+        """Exit context manager."""
         plt.show(block=True)
         self.ipython.magic("matplotlib inline")
 

--- a/doc/_templates/class.rst
+++ b/doc/_templates/class.rst
@@ -1,0 +1,30 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+
+   {% block methods %}
+   {% if methods %}
+
+   .. rubric:: Methods
+
+   .. autosummary::
+   {% for item in methods %}
+      {% if item != "__init__" %}
+         {{ item }}
+      {% endif %}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: Attributes
+
+   .. autosummary::
+   {% for item in attributes %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -103,6 +103,7 @@ Utils
 -----
 
 .. autosummary::
-	:toctree: generated/
-	
-	Numba
+      :toctree: generated/
+
+      Numba
+      interactive_backend

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -104,6 +104,7 @@ Utils
 
 .. autosummary::
       :toctree: generated/
+      :template: class.rst
 
       Numba
       interactive_backend

--- a/examples/plot_khat.py
+++ b/examples/plot_khat.py
@@ -1,0 +1,14 @@
+"""
+Pareto Shape Plot
+=================
+
+_thumb: .7, .5
+"""
+import arviz as az
+
+az.style.use("arviz-darkgrid")
+
+idata = az.load_arviz_data("radon")
+loo = az.loo(idata, pointwise=True)
+
+az.plot_khat(loo, show_bins=True)


### PR DESCRIPTION
## PR changelog

### `plot_khat`
* [x] Allow customization of hover labels
* [x] Add example to gallery

### Context manager
* [x] Create a class in arviz to manage an interactive backend context:
  ```python
  plt.plot(...) # inline
  with interactive_backend():
      plt.plot(...) # interactive
  plt.plot(...) # inine
  ```
  For now, a prototype of this class is present in ArviZ home. It seems to work, I will be on the lookout for issues. 

  I decided not to use CamelCase even though it is implemented as a class because most context managers are in lowercase. One example is `matplotlib.rc_context` itself. `interactive_backend` is based on `rc_context` and in addition, `rc_context` is the reason why it is defined as a class and not with `contextlib`.

### Documentation
* [x] Modify layout of class doc pages on the website. The first image is the current website, the bottom image is the proposed layout.
![image](https://user-images.githubusercontent.com/23738400/60760526-0c35ab00-a037-11e9-9165-fd7721051b0d.png)
![image](https://user-images.githubusercontent.com/23738400/60760540-31c2b480-a037-11e9-9d27-b953b19d9a67.png)



### `plot_elpd`
* Add hover labels to `plot_elpd`? If eventually added, they will be added in a following PR.