### PR TITLE
Update conditional_jit wrapper

### DIFF
--- a/arviz/stats/diagnostics.py
+++ b/arviz/stats/diagnostics.py
@@ -454,7 +454,7 @@ def _sqrt(a_a, b_b):
     return (a_a + b_b) ** 0.5
 
 
-@conditional_jit
+@conditional_jit(forceobj=True)
 def geweke(ary, first=0.1, last=0.5, intervals=20):
     r"""Compute z-scores for convergence diagnostics.
 

--- a/arviz/tests/test_utils.py
+++ b/arviz/tests/test_utils.py
@@ -123,7 +123,7 @@ def test_conditional_jit_numba_decorator_keyword(monkeypatch):
 
     def jit(**kwargs):
         """overwrite numba.jit function"""
-        return lambda x: (x(), kwargs)
+        return lambda fn: lambda: (fn(), kwargs)
 
     numba_mock.jit = jit
 
@@ -133,7 +133,7 @@ def test_conditional_jit_numba_decorator_keyword(monkeypatch):
         return "output"
 
     # pylint: disable=unpacking-non-sequence
-    function_results, wrapper_result = placeholder_func
+    function_results, wrapper_result = placeholder_func()
     assert wrapper_result == {"keyword_argument": "A keyword argument"}
     assert function_results == "output"
 


### PR DESCRIPTION
This looks a little complicated, but my goals were:

1. Docs should appear on decorated functions
2. Toggling `az.Numba.enable_numba()` and `az.Numba.disable_numba()` should work
3. Limit overhead when using numba (since that's the point)

The first is done with `functools.wraps`
The second is done in `__call__` in `maybe_numba_fn`
The third is done using a lazy property: it compiles the first time it is called, and then is an attribute lookup. This might be overkill, I feel least strongly about that. The alternative would evaluate something like `if self._numba_fn is None:` on every function call, which is not a ton of overhead.

There is one failing test with a lot of monkeypatching!

![image](https://user-images.githubusercontent.com/2295568/60757023-fa222100-9fd2-11e9-88c5-b5a2554ea297.png)
