### PR TITLE
No observations in MultiObservedRV

### DIFF
--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -27,7 +27,10 @@ class PyMC3Converter:
             if self.trace is None
             else True
             if any(
-                hasattr(obs, "observations") for obs in self.trace._straces[0].model.observed_RVs
+                hasattr(obs, "observations")
+                for obs in self.trace._straces[  # pylint: disable=protected-access
+                    0
+                ].model.observed_RVs
             )
             else None
         )

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -22,6 +22,16 @@ class PyMC3Converter:
         self.posterior_predictive = posterior_predictive
         self.coords = coords
         self.dims = dims
+        self.observations = (
+            None
+            if self.trace is None
+            else True
+            if any(
+                hasattr(obs, "observations") for obs in self.trace._straces[0].model.observed_RVs
+            )
+            else None
+        )
+
         import pymc3
 
         self.pymc3 = pymc3
@@ -117,7 +127,7 @@ class PyMC3Converter:
             dims=self.dims,
         )
 
-    @requires("trace")
+    @requires("observations")
     def observed_data_to_xarray(self):
         """Convert observed data to xarray."""
         # This next line is brittle and may not work forever, but is a secret

--- a/arviz/tests/test_data_pymc.py
+++ b/arviz/tests/test_data_pymc.py
@@ -120,8 +120,8 @@ class TestDataPyMC3:
 
     def test_multiple_observed_rv_without_observations(self):
         with pm.Model():
-            mu = pm.Normal('mu')
-            x = pm.DensityDist('x', pm.Normal.dist(mu, 1.).logp, observed={'value': .1})
+            mu = pm.Normal("mu")
+            x = pm.DensityDist("x", pm.Normal.dist(mu, 1.0).logp, observed={"value": 0.1})
             trace = pm.sample(100, chains=2)
         inference_data = from_pymc3(trace=trace)
         assert inference_data

--- a/arviz/tests/test_data_pymc.py
+++ b/arviz/tests/test_data_pymc.py
@@ -118,6 +118,17 @@ class TestDataPyMC3:
         assert not fails
         assert not hasattr(inference_data.sample_stats, "log_likelihood")
 
+    def test_multiple_observed_rv_without_observations(self):
+        with pm.Model():
+            mu = pm.Normal('mu')
+            x = pm.DensityDist('x', pm.Normal.dist(mu, 1.).logp, observed={'value': .1})
+            trace = pm.sample(100, chains=2)
+        inference_data = from_pymc3(trace=trace)
+        assert inference_data
+        assert not hasattr(inference_data, "observed_data")
+        assert hasattr(inference_data, "posterior")
+        assert hasattr(inference_data, "sample_stats")
+
     def test_single_observation(self):
         with pm.Model():
             p = pm.Uniform("p", 0, 1)

--- a/arviz/tests/test_data_pymc.py
+++ b/arviz/tests/test_data_pymc.py
@@ -121,7 +121,9 @@ class TestDataPyMC3:
     def test_multiple_observed_rv_without_observations(self):
         with pm.Model():
             mu = pm.Normal("mu")
-            x = pm.DensityDist("x", pm.Normal.dist(mu, 1.0).logp, observed={"value": 0.1})
+            x = pm.DensityDist(  # pylint disable=unused-variable
+                "x", pm.Normal.dist(mu, 1.0).logp, observed={"value": 0.1}
+            )
             trace = pm.sample(100, chains=2)
         inference_data = from_pymc3(trace=trace)
         assert inference_data

--- a/arviz/tests/test_data_pymc.py
+++ b/arviz/tests/test_data_pymc.py
@@ -121,7 +121,7 @@ class TestDataPyMC3:
     def test_multiple_observed_rv_without_observations(self):
         with pm.Model():
             mu = pm.Normal("mu")
-            x = pm.DensityDist(  # pylint disable=unused-variable
+            x = pm.DensityDist(  # pylint: disable=unused-variable
                 "x", pm.Normal.dist(mu, 1.0).logp, observed={"value": 0.1}
             )
             trace = pm.sample(100, chains=2)


### PR DESCRIPTION
Fixes the problem, when MultiObservedRV does not contain observations (DensityDist)

See https://discourse.pymc.io/t/pm-traceplot-error/3524