### PR TITLE
[WIP] Set up ArviZ rcParams

### DIFF
--- a/arviz/__init__.py
+++ b/arviz/__init__.py
@@ -23,7 +23,7 @@ if not logging.root.handlers:
     _log.setLevel(logging.INFO)
     _log.addHandler(handler)
 
-from .rcparams import rcParams
+from .rcparams import rcParams, rc_context
 from .data import *
 from .plots import *
 from .stats import *

--- a/arviz/__init__.py
+++ b/arviz/__init__.py
@@ -23,6 +23,7 @@ if not logging.root.handlers:
     _log.setLevel(logging.INFO)
     _log.addHandler(handler)
 
+from .rcparams import rcParams
 from .data import *
 from .plots import *
 from .stats import *

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -8,6 +8,8 @@ import netCDF4 as nc
 import numpy as np
 import xarray as xr
 
+from ..rcparams import rcParams
+
 
 class InferenceData:
     """Container for accessing netCDF files using xarray."""
@@ -52,9 +54,8 @@ class InferenceData:
         """Initialize object from a netcdf file.
 
         Expects that the file will have groups, each of which can be loaded by xarray.
-        By default, the datasets of the InferenceData object will be lazily loaded. To
-        modify this behaviour, the environment variable ``ARVIZ_LOAD`` must be set to
-        ``EAGER`` (case insensitive) in order to load objects in memory instead.
+        By default, the datasets of the InferenceData object will be lazily loaded. This
+        behaviour is regulated by the value of ``az.rcParams["data.load"]``.
 
         Parameters
         ----------
@@ -69,10 +70,9 @@ class InferenceData:
         with nc.Dataset(filename, mode="r") as data:
             data_groups = list(data.groups)
 
-        arviz_load_mode = os.environ.get("ARVIZ_LOAD", "lazy").lower()
         for group in data_groups:
             with xr.open_dataset(filename, group=group) as data:
-                if arviz_load_mode == "eager":
+                if rcParams["data.load"] == "eager":
                     groups[group] = data.load()
                 else:
                     groups[group] = data

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -54,7 +54,8 @@ class InferenceData:
         """Initialize object from a netcdf file.
 
         Expects that the file will have groups, each of which can be loaded by xarray.
-        By default, the datasets of the InferenceData object will be lazily loaded. This
+        By default, the datasets of the InferenceData object will be lazily loaded instead
+        of being loaded into memory. This
         behaviour is regulated by the value of ``az.rcParams["data.load"]``.
 
         Parameters

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -1,5 +1,4 @@
 """Data structure for using netcdf groups with xarray."""
-import os
 from collections import OrderedDict
 from collections.abc import Sequence
 from copy import copy as ccopy, deepcopy

--- a/arviz/data/io_netcdf.py
+++ b/arviz/data/io_netcdf.py
@@ -18,9 +18,9 @@ def from_netcdf(filename):
 
     Notes
     -----
-    By default, the datasets of the InferenceData object will be lazily loaded. To
-    modify this behaviour, the environment variable ``ARVIZ_LOAD`` must be set to
-    ``EAGER`` (case insensitive) in order to load objects in memory instead.
+    By default, the datasets of the InferenceData object will be lazily loaded instead
+    of loaded into memory. This behaviour is regulated by the value of
+    ``az.rcParams["data.load"]``.
     """
     return InferenceData.from_netcdf(filename)
 

--- a/arviz/plots/elpdplot.py
+++ b/arviz/plots/elpdplot.py
@@ -13,6 +13,7 @@ from .plot_utils import (
     set_xticklabels,
 )
 from ..stats import waic, loo, ELPDData
+from ..rcparams import rcParams
 
 
 def plot_elpd(
@@ -25,7 +26,7 @@ def plot_elpd(
     legend=False,
     threshold=None,
     ax=None,
-    ic="waic",
+    ic=None,
     scale="deviance",
     plot_kwargs=None,
 ):
@@ -59,7 +60,8 @@ def plot_elpd(
     ax: axes, optional
         Matplotlib axes
     ic : str, optional
-        Information Criterion (WAIC or LOO) used to compare models. Default WAIC. Only taken
+        Information Criterion (WAIC or LOO) used to compare models. Defaults to
+        ``rcParams["stats.information_criterion"]``. Only taken
         into account when input is InferenceData.
     scale : str, optional
         scale argument passed to az.waic or az.loo, see their docs for details. Only taken
@@ -88,7 +90,7 @@ def plot_elpd(
 
     """
     valid_ics = ["waic", "loo"]
-    ic = ic.lower()
+    ic = rcParams["stats.information_criterion"] if ic is None else ic.lower()
     if ic not in valid_ics:
         raise ValueError(
             ("Information Criteria type {} not recognized." "IC must be in {}").format(

--- a/arviz/rcparams.py
+++ b/arviz/rcparams.py
@@ -10,9 +10,8 @@ import locale
 _log = logging.getLogger(__name__)
 
 
-def make_validate_choice(accepted_values):
+def _make_validate_choice(accepted_values):
     """Validate value is in accepted_values."""
-
     def validate_choice(value):
         if value.lower() in accepted_values:
             return value.lower()
@@ -21,7 +20,7 @@ def make_validate_choice(accepted_values):
     return validate_choice
 
 
-def validate_positive_int(value):
+def _validate_positive_int(value):
     """Validate value is a natural number."""
     try:
         value = int(value)
@@ -33,18 +32,18 @@ def validate_positive_int(value):
         raise ValueError("Only positive values are valid")
 
 
-def validate_positive_int_or_none(value):
+def _validate_positive_int_or_none(value):
     """Validate value is a natural number or None."""
     if value is None or isinstance(value, str) and value.lower() == "none":
         return None
     else:
-        return validate_positive_int(value)
+        return _validate_positive_int(value)
 
 
 defaultParams = {
-    "data.load": ("lazy", make_validate_choice(("lazy", "eager"))),
-    "plot.max_subplots": (40, validate_positive_int_or_none),
-    "stats.information_criterion": ("waic", make_validate_choice(("waic", "loo"))),
+    "data.load": ("lazy", _make_validate_choice(("lazy", "eager"))),
+    "plot.max_subplots": (40, _validate_positive_int_or_none),
+    "stats.information_criterion": ("waic", _make_validate_choice(("waic", "loo"))),
 }
 
 
@@ -61,6 +60,7 @@ class RcParams(dict):
         self.update(*args, **kwargs)
 
     def __setitem__(self, key, val):
+        """Add validation to __setitem__ function."""
         try:
             try:
                 cval = self.validate[key](val)
@@ -74,6 +74,7 @@ class RcParams(dict):
             )
 
     def __repr__(self):
+        """Customize repr of RcParams objects."""
         class_name = self.__class__.__name__
         indent = len(class_name) + 1
         repr_split = pprint.pformat(dict(self), indent=1, width=80 - indent).split("\n")
@@ -81,17 +82,17 @@ class RcParams(dict):
         return "{}({})".format(class_name, repr_indented)
 
     def __str__(self):
+        """Customize str/print of RcParams objects."""
         return "\n".join(map("{0[0]:<22}: {0[1]}".format, sorted(self.items())))
 
     def __iter__(self):
         """Yield sorted list of keys."""
         yield from sorted(dict.__iter__(self))
 
-    def __len__(self):
-        return dict.__len__(self)
-
     def find_all(self, pattern):
         """
+        Find keys that match a regex pattern.
+
         Return the subset of this RcParams dictionary whose keys match,
         using :func:`re.search`, the given ``pattern``.
 
@@ -104,6 +105,7 @@ class RcParams(dict):
         return RcParams((key, value) for key, value in self.items() if pattern_re.search(key))
 
     def copy(self):
+        """Get a copy of the RcParams object."""
         return {k: dict.__getitem__(self, k) for k in self}
 
 
@@ -124,7 +126,6 @@ def get_arviz_rcfile():
 
     Otherwise, the default defined in ``rcparams.py`` file will be used.
     """
-
     def gen_candidates():
         yield os.path.join(os.getcwd(), "arvizrc")
         arviz_data_dir = os.environ.get("ARVIZ_DATA")

--- a/arviz/rcparams.py
+++ b/arviz/rcparams.py
@@ -69,8 +69,8 @@ class RcParams(dict):
             dict.__setitem__(self, key, cval)
         except KeyError:
             raise KeyError(
-                f"{key} is not a valid rc parameter (see rcParams.keys() for "
-                f"a list of valid parameters)"
+                "{} is not a valid rc parameter (see rcParams.keys() for "
+                "a list of valid parameters)".format(key)
             )
 
     def __repr__(self):

--- a/arviz/rcparams.py
+++ b/arviz/rcparams.py
@@ -220,7 +220,7 @@ def rc_params():
 rcParams = rc_params()  # pylint: disable=invalid-name
 
 
-class rc_context:
+class rc_context:  # pylint: disable=invalid-name
     """
     Return a context manager for managing rc settings.
 

--- a/arviz/rcparams.py
+++ b/arviz/rcparams.py
@@ -51,7 +51,7 @@ defaultParams = {  # pylint: disable=invalid-name
 }
 
 
-class RcParams(MutableMapping, dict): # pylint: disable=too-many-ancestors
+class RcParams(MutableMapping, dict):  # pylint: disable=too-many-ancestors
     """Class to contain ArviZ default parameters.
 
     It is implemented as a dict with validation when setting items.
@@ -234,6 +234,7 @@ class rc_context:
     The 'rc' dictionary takes precedence over the settings loaded from
     'fname'. Passing a dictionary only is also valid.
     """
+
     # Based on mpl.rc_context
 
     def __init__(self, rc=None, fname=None):

--- a/arviz/rcparams.py
+++ b/arviz/rcparams.py
@@ -78,9 +78,11 @@ class RcParams(MutableMapping, dict):  # pylint: disable=too-many-ancestors
             )
 
     def __getitem__(self, key):
+        """Use dict getitem method."""
         return dict.__getitem__(self, key)
 
     def __delitem__(self, key):
+        """Raise TypeError if someone ever tries to delete a key from RcParams."""
         raise TypeError("RcParams keys cannot be deleted")
 
     def __repr__(self):
@@ -221,6 +223,16 @@ rcParams = rc_params()  # pylint: disable=invalid-name
 class rc_context:
     """
     Return a context manager for managing rc settings.
+
+    Parameters
+    ----------
+    rc : dict, optional
+        Mapping containing the rcParams to modify temporally.
+    fname : str, optional
+        Filename of the file containig the rcParams to use inside the rc_context.
+
+    Examples
+    --------
     This allows one to do::
         with az.rc_context(fname='pystan.rc'):
             idata = az.load_arviz_data("radon")
@@ -246,7 +258,9 @@ class rc_context:
             rcParams.update(rc)
 
     def __enter__(self):
+        """Define enter method of context manager."""
         return self
 
     def __exit__(self, exc_type, exc_value, exc_tb):
+        """Define exit method of context manager."""
         rcParams.update(self._orig)

--- a/arviz/rcparams.py
+++ b/arviz/rcparams.py
@@ -12,6 +12,7 @@ _log = logging.getLogger(__name__)
 
 def _make_validate_choice(accepted_values):
     """Validate value is in accepted_values."""
+
     def validate_choice(value):
         if value.lower() in accepted_values:
             return value.lower()
@@ -40,7 +41,7 @@ def _validate_positive_int_or_none(value):
         return _validate_positive_int(value)
 
 
-defaultParams = {
+defaultParams = {  # pylint: disable=invalid-name
     "data.load": ("lazy", _make_validate_choice(("lazy", "eager"))),
     "plot.max_subplots": (40, _validate_positive_int_or_none),
     "stats.information_criterion": ("waic", _make_validate_choice(("waic", "loo"))),
@@ -64,8 +65,8 @@ class RcParams(dict):
         try:
             try:
                 cval = self.validate[key](val)
-            except ValueError as ve:
-                raise ValueError("Key %s: %s" % (key, str(ve)))
+            except ValueError as verr:
+                raise ValueError("Key %s: %s" % (key, str(verr)))
             dict.__setitem__(self, key, cval)
         except KeyError:
             raise KeyError(
@@ -126,6 +127,7 @@ def get_arviz_rcfile():
 
     Otherwise, the default defined in ``rcparams.py`` file will be used.
     """
+
     def gen_candidates():
         yield os.path.join(os.getcwd(), "arvizrc")
         arviz_data_dir = os.environ.get("ARVIZ_DATA")
@@ -172,9 +174,9 @@ def read_rcfile(fname):
                     _log.warning("Duplicate key in file %r line #%d.", fname, line_no)
                 try:
                     config[key] = val
-                except ValueError as va:
+                except ValueError as verr:
                     error_details = _error_details_fmt % (line_no, line, fname)
-                    raise ValueError("Bad val {} on {}\n\t{}".format(val, error_details, va))
+                    raise ValueError("Bad val {} on {}\n\t{}".format(val, error_details, str(verr)))
 
         except UnicodeDecodeError:
             _log.warning(
@@ -198,4 +200,4 @@ def rc_params():
     return defaults
 
 
-rcParams = rc_params()
+rcParams = rc_params()  # pylint: disable=invalid-name

--- a/arviz/rcparams.py
+++ b/arviz/rcparams.py
@@ -1,0 +1,200 @@
+"""ArviZ rcparams."""
+import sys
+import os
+from pathlib import Path
+import re
+import pprint
+import logging
+import locale
+
+_log = logging.getLogger(__name__)
+
+
+def make_validate_choice(accepted_values):
+    """Validate value is in accepted_values."""
+
+    def validate_choice(value):
+        if value.lower() in accepted_values:
+            return value.lower()
+        raise ValueError("{} is not one of {}".format(value, accepted_values))
+
+    return validate_choice
+
+
+def validate_positive_int(value):
+    """Validate value is a natural number."""
+    try:
+        value = int(value)
+    except ValueError:
+        raise ValueError("Could not convert to int")
+    if value > 0:
+        return value
+    else:
+        raise ValueError("Only positive values are valid")
+
+
+def validate_positive_int_or_none(value):
+    """Validate value is a natural number or None."""
+    if value is None or isinstance(value, str) and value.lower() == "none":
+        return None
+    else:
+        return validate_positive_int(value)
+
+
+defaultParams = {
+    "data.load": ("lazy", make_validate_choice(("lazy", "eager"))),
+    "plot.max_subplots": (40, validate_positive_int_or_none),
+    "stats.information_criterion": ("waic", make_validate_choice(("waic", "loo"))),
+}
+
+
+class RcParams(dict):
+    """Class to contain ArviZ default parameters.
+
+    It is implemented as a dict with validation when setting items.
+    """
+
+    validate = {key: validate_fun for key, (_, validate_fun) in defaultParams.items()}
+
+    # validate values on the way in
+    def __init__(self, *args, **kwargs):  # pylint: disable=super-init-not-called
+        self.update(*args, **kwargs)
+
+    def __setitem__(self, key, val):
+        try:
+            try:
+                cval = self.validate[key](val)
+            except ValueError as ve:
+                raise ValueError("Key %s: %s" % (key, str(ve)))
+            dict.__setitem__(self, key, cval)
+        except KeyError:
+            raise KeyError(
+                f"{key} is not a valid rc parameter (see rcParams.keys() for "
+                f"a list of valid parameters)"
+            )
+
+    def __repr__(self):
+        class_name = self.__class__.__name__
+        indent = len(class_name) + 1
+        repr_split = pprint.pformat(dict(self), indent=1, width=80 - indent).split("\n")
+        repr_indented = ("\n" + " " * indent).join(repr_split)
+        return "{}({})".format(class_name, repr_indented)
+
+    def __str__(self):
+        return "\n".join(map("{0[0]:<22}: {0[1]}".format, sorted(self.items())))
+
+    def __iter__(self):
+        """Yield sorted list of keys."""
+        yield from sorted(dict.__iter__(self))
+
+    def __len__(self):
+        return dict.__len__(self)
+
+    def find_all(self, pattern):
+        """
+        Return the subset of this RcParams dictionary whose keys match,
+        using :func:`re.search`, the given ``pattern``.
+
+        Notes
+        -----
+            Changes to the returned dictionary are *not* propagated to
+            the parent RcParams dictionary.
+        """
+        pattern_re = re.compile(pattern)
+        return RcParams((key, value) for key, value in self.items() if pattern_re.search(key))
+
+    def copy(self):
+        return {k: dict.__getitem__(self, k) for k in self}
+
+
+def get_arviz_rcfile():
+    """Get arvizrc file.
+
+    The file location is determined in the following order:
+
+    - ``$PWD/arvizrc``
+    - ``$ARVIZ_DATA/arvizrc``
+    - On Linux,
+        - ``$XDG_CONFIG_HOME/arviz/arvizrc`` (if ``$XDG_CONFIG_HOME``
+          is defined)
+        - or ``$HOME/.config/arviz/arvizrc`` (if ``$XDG_CONFIG_HOME``
+          is not defined)
+    - On other platforms,
+        - ``$HOME/.arviz/arvizrc`` if ``$HOME`` is defined
+
+    Otherwise, the default defined in ``rcparams.py`` file will be used.
+    """
+
+    def gen_candidates():
+        yield os.path.join(os.getcwd(), "arvizrc")
+        arviz_data_dir = os.environ.get("ARVIZ_DATA")
+        if arviz_data_dir:
+            yield os.path.join(arviz_data_dir, "arvizrc")
+        xdg_base = os.environ.get("XDG_CONFIG_HOME", str(Path.home() / ".config"))
+        if sys.platform.startswith(("linux", "freebsd")):
+            configdir = Path(xdg_base, "arviz")
+        else:
+            configdir = Path.home() / ".arviz"
+        yield os.path.join(configdir, "arvizrc")
+
+    for fname in gen_candidates():
+        if os.path.exists(fname) and not os.path.isdir(fname):
+            return fname
+
+    return None
+
+
+def read_rcfile(fname):
+    """Return :class:`arviz.RcParams` from the contents of the given file.
+
+    Unlike `rc_params_from_file`, the configuration class only contains the
+    parameters specified in the file (i.e. default values are not filled in).
+    """
+    _error_details_fmt = 'line #%d\n\t"%s"\n\tin file "%s"'
+
+    config = RcParams()
+    with open(fname, "r") as rcfile:
+        try:
+            for line_no, line in enumerate(rcfile, 1):
+                strippedline = line.split("#", 1)[0].strip()
+                if not strippedline:
+                    continue
+                tup = strippedline.split(":", 1)
+                if len(tup) != 2:
+                    error_details = _error_details_fmt % (line_no, line, fname)
+                    _log.warning("Illegal %s", error_details)
+                    continue
+                key, val = tup
+                key = key.strip()
+                val = val.strip()
+                if key in config:
+                    _log.warning("Duplicate key in file %r line #%d.", fname, line_no)
+                try:
+                    config[key] = val
+                except ValueError as va:
+                    error_details = _error_details_fmt % (line_no, line, fname)
+                    raise ValueError("Bad val {} on {}\n\t{}".format(val, error_details, va))
+
+        except UnicodeDecodeError:
+            _log.warning(
+                "Cannot decode configuration file %s with encoding "
+                "%s, check LANG and LC_* variables.",
+                fname,
+                locale.getpreferredencoding(do_setlocale=False) or "utf-8 (default)",
+            )
+            raise
+
+        return config
+
+
+def rc_params():
+    """Read and validate arvizrc file."""
+    fname = get_arviz_rcfile()
+    defaults = RcParams([(key, default) for key, (default, _) in defaultParams.items()])
+    if fname is not None:
+        file_defaults = read_rcfile(fname)
+        defaults.update(file_defaults)
+    return defaults
+
+
+rcParams = rc_params()

--- a/arviz/rcparams.py
+++ b/arviz/rcparams.py
@@ -132,9 +132,9 @@ def get_arviz_rcfile():
             yield os.path.join(arviz_data_dir, "arvizrc")
         xdg_base = os.environ.get("XDG_CONFIG_HOME", str(Path.home() / ".config"))
         if sys.platform.startswith(("linux", "freebsd")):
-            configdir = Path(xdg_base, "arviz")
+            configdir = str(Path(xdg_base, "arviz"))
         else:
-            configdir = Path.home() / ".arviz"
+            configdir = str(Path.home() / ".arviz")
         yield os.path.join(configdir, "arvizrc")
 
     for fname in gen_candidates():

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -21,6 +21,7 @@ from .stats_utils import (
     stats_variance_2d as svar,
 )
 from ..utils import _var_names, Numba, _numba_var
+from ..rcparams import rcParams
 
 _log = logging.getLogger(__name__)
 
@@ -39,7 +40,7 @@ __all__ = [
 
 def compare(
     dataset_dict,
-    ic="waic",
+    ic=None,
     method="BB-pseudo-BMA",
     b_samples=1000,
     alpha=1,
@@ -57,7 +58,8 @@ def compare(
     dataset_dict : dict[str] -> InferenceData
         A dictionary of model names and InferenceData objects
     ic : str
-        Information Criterion (WAIC or LOO) used to compare models. Default WAIC.
+        Information Criterion (WAIC or LOO) used to compare models. Defaults to
+        ``rcParams["stats.information_criterion"]``.
     method : str
         Method used to estimate the weights for each model. Available options are:
 
@@ -142,7 +144,7 @@ def compare(
             scale_value = -2
         ascending = True
 
-    ic = ic.lower()
+    ic = rcParams["stats.information_criterion"] if ic is None else ic.lower()
     if ic == "waic":
         ic_func = waic
         df_comp = pd.DataFrame(

--- a/arviz/tests/test_diagnostics.py
+++ b/arviz/tests/test_diagnostics.py
@@ -27,12 +27,13 @@ from ..stats.diagnostics import (
     _circular_standard_deviation,
 )
 from ..utils import Numba
+from ..rcparams import rcParams
 
 # For tests only, recommended value should be closer to 1.01-1.05
 # See discussion in https://github.com/stan-dev/rstan/pull/618
 GOOD_RHAT = 1.1
 
-os.environ["ARVIZ_LOAD"] = "EAGER"
+rcParams["data.load"] = "eager"
 
 
 @pytest.fixture(scope="session")

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -16,6 +16,7 @@ from .helpers import (  # pylint: disable=unused-import
     multidim_models,
     create_multidimensional_model,
 )
+from ..rcparams import rcParams
 from ..plots import (
     plot_density,
     plot_trace,
@@ -42,7 +43,7 @@ from ..plots import (
 )
 
 np.random.seed(0)
-os.environ["ARVIZ_LOAD"] = "EAGER"
+rcParams["data.load"] = "eager"
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/arviz/tests/test_rcparams.py
+++ b/arviz/tests/test_rcparams.py
@@ -5,15 +5,52 @@ from xarray.core.indexing import MemoryCachedArray
 
 
 from ..data import load_arviz_data
+from ..stats import compare
 from ..rcparams import rcParams, rc_context
+from .helpers import models  # pylint: disable=unused-import
+
+
+def test_bad_key():
+    """Test the error when using unexistent keys in rcParams is correct."""
+    with pytest.raises(KeyError, match="bad_key is not a valid rc"):
+        rcParams["bad_key"] = "nothing"
+
+
+@pytest.mark.parametrize("param", ["data.load", "stats.information_criterion"])
+def test_choice_bad_values(param):
+    """Test error messages are correct for rcParams validated with _make_validate_choice."""
+    msg = "{}: bad_value is not one of".format(param.replace(".", r"\."))
+    with pytest.raises(ValueError, match=msg):
+        rcParams[param] = "bad_value"
+
+
+def test_rc_context():
+    rcParams["data.load"] = "lazy"
+    with rc_context(rc={"data.load": "eager"}):
+        assert rcParams["data.load"] == "eager"
+    assert rcParams["data.load"] == "lazy"
 
 
 def test_data_load():
     rcParams["data.load"] = "lazy"
     idata_lazy = load_arviz_data("centered_eight")
-    assert isinstance(idata_lazy.posterior.mu.variable._data, MemoryCachedArray)
+    assert isinstance(
+        idata_lazy.posterior.mu.variable._data,  # pylint: disable=protected-access
+        MemoryCachedArray,
+    )
     assert rcParams["data.load"] == "lazy"
     rcParams["data.load"] = "eager"
     idata_eager = load_arviz_data("centered_eight")
-    assert isinstance(idata_eager.posterior.mu.variable._data, np.ndarray)
+    assert isinstance(
+        idata_eager.posterior.mu.variable._data, np.ndarray  # pylint: disable=protected-access
+    )
     assert rcParams["data.load"] == "eager"
+
+
+def test_stats_information_criterion(models):
+    rcParams["stats.information_criterion"] = "waic"
+    df_comp = compare({"model1": models.model_1, "model2": models.model_2})
+    assert "waic" in df_comp.columns
+    rcParams["stats.information_criterion"] = "loo"
+    df_comp = compare({"model1": models.model_1, "model2": models.model_2})
+    assert "loo" in df_comp.columns

--- a/arviz/tests/test_rcparams.py
+++ b/arviz/tests/test_rcparams.py
@@ -1,0 +1,19 @@
+# pylint: disable=redefined-outer-name
+import numpy as np
+import pytest
+from xarray.core.indexing import MemoryCachedArray
+
+
+from ..data import load_arviz_data
+from ..rcparams import rcParams, rc_context
+
+
+def test_data_load():
+    rcParams["data.load"] = "lazy"
+    idata_lazy = load_arviz_data("centered_eight")
+    assert isinstance(idata_lazy.posterior.mu.variable._data, MemoryCachedArray)
+    assert rcParams["data.load"] == "lazy"
+    rcParams["data.load"] = "eager"
+    idata_eager = load_arviz_data("centered_eight")
+    assert isinstance(idata_eager.posterior.mu.variable._data, np.ndarray)
+    assert rcParams["data.load"] == "eager"

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -1,5 +1,4 @@
 # pylint: disable=redefined-outer-name, no-member
-import os
 from copy import deepcopy
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_almost_equal

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -24,8 +24,10 @@ from ..stats import (
 from ..stats.stats import _gpinv
 from ..utils import Numba
 from .helpers import check_multiple_attrs, multidim_models  # pylint: disable=unused-import
+from ..rcparams import rcParams
 
-os.environ["ARVIZ_LOAD"] = "EAGER"
+
+rcParams["data.load"] = "eager"
 
 
 @pytest.fixture(scope="session")

--- a/arvizrc.template
+++ b/arvizrc.template
@@ -1,0 +1,14 @@
+#### ArviZ rcParams template ####
+### DATA  ###
+# rcParams related with data loading related functions
+data.load                    : lazy  # Sets the default data loading mode.
+                                     # "lazy" stands for xarray lazy loading,
+                                     # "eager" loads all datasets into memory
+
+### PLOT  ###
+# rcParams related with plotting functions
+plot.max_subplots            : 40    # Maximum number of subplots.
+
+### STATS ###
+# rcParams related with statistical and diagnostic functions
+stats.information_criterion  : waic  # Default information criterion

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -109,3 +109,12 @@ Utils
 
       Numba
       interactive_backend
+
+rcParams
+--------
+
+.. autosummary::
+   :toctree: generated/
+   :template: class.rst
+
+   rc_context

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,10 +20,11 @@
 import os
 import sys
 
-os.environ["ARVIZ_LOAD"] = "EAGER"
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import sphinx_bootstrap_theme
 import arviz
+
+arviz.rcParams["data.load"] = "eager"
 
 
 # -- General configuration ------------------------------------------------


### PR DESCRIPTION
Set ArviZ global options as rcParams, following the behaviour of matplotlib's rcParams. The idea is to have a slightly simplified version of matplotlib's implementation. For now and as an example, only 3 parameters are present. This PR itself can be used to propose and discuss other possible global parameters.

Closes #609 and closes #706.

Below I will write (and keep updating the list) to check that all relevant functions and docs have been updated:
* [x] `data.load`
* [ ] `plot.max_subplots`
* [x] `stats.inference_criterion` 

rcParams modification and loading from different folders and files should already work. However, all of it is still preliminary. The folders do not make much sense yet, the parameters can be modified in `az.rcParams` but the functions have not been updated yet either... Please review and comment.