### PR TITLE
Numba-plots

### DIFF
--- a/arviz/plots/essplot.py
+++ b/arviz/plots/essplot.py
@@ -334,7 +334,7 @@ def plot_ess(
             ylabel.format("Relative ESS" if relative else "ESS"), fontsize=ax_labelsize, wrap=True
         )
         if kind == "evolution":
-            ax_.legend(title="Method", fontsize=xt_labelsize)
+            ax_.legend(title="Method", fontsize=xt_labelsize, title_fontsize=xt_labelsize)
         else:
             ax_.set_xlim(0, 1)
         if rug:

--- a/arviz/plots/essplot.py
+++ b/arviz/plots/essplot.py
@@ -334,7 +334,7 @@ def plot_ess(
             ylabel.format("Relative ESS" if relative else "ESS"), fontsize=ax_labelsize, wrap=True
         )
         if kind == "evolution":
-            ax_.legend(title="Method", title_fontsize=xt_labelsize, fontsize=xt_labelsize)
+            ax_.legend(title="Method", fontsize=xt_labelsize)
         else:
             ax_.set_xlim(0, 1)
         if rug:

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -291,7 +291,7 @@ class PlotHandler:
         """Collect labels and ticks from plotters."""
         val = self.plotters.values()
 
-        @conditional_jit
+        @conditional_jit(forceobj=True)
         def label_idxs():
             labels, idxs = [], []
             for plotter in val:

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -298,10 +298,9 @@ class PlotHandler:
                 sub_labels, sub_idxs, _, _ = plotter.labels_ticks_and_vals()
                 labels.append(sub_labels)
                 idxs.append(sub_idxs)
-            return labels, idxs
+            return np.concatenate(labels), np.concatenate(idxs)
 
-        labels, idxs = label_idxs()
-        return np.concatenate(labels), np.concatenate(idxs)
+        return label_idxs()
 
     def display_multiple_ropes(self, rope, ax, y, linewidth, rope_var):
         """Display ROPE when more than one interval is provided."""

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -11,7 +11,7 @@ from ..stats import hpd
 from ..stats.diagnostics import _ess, _rhat
 from .plot_utils import _scale_fig_size, xarray_var_iter, make_label, get_bins
 from .kdeplot import _fast_kde
-from ..utils import _var_names
+from ..utils import _var_names, conditional_jit
 
 
 def pairwise(iterable):
@@ -289,11 +289,18 @@ class PlotHandler:
 
     def labels_and_ticks(self):
         """Collect labels and ticks from plotters."""
-        labels, idxs = [], []
-        for plotter in self.plotters.values():
-            sub_labels, sub_idxs, _, _ = plotter.labels_ticks_and_vals()
-            labels.append(sub_labels)
-            idxs.append(sub_idxs)
+        val = self.plotters.values()
+
+        @conditional_jit
+        def label_idxs():
+            labels, idxs = [], []
+            for plotter in val:
+                sub_labels, sub_idxs, _, _ = plotter.labels_ticks_and_vals()
+                labels.append(sub_labels)
+                idxs.append(sub_idxs)
+            return labels, idxs
+
+        labels, idxs = label_idxs()
         return np.concatenate(labels), np.concatenate(idxs)
 
     def display_multiple_ropes(self, rope, ax, y, linewidth, rope_var):

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -345,9 +345,9 @@ def _cov_1d(x):
 
 
 def _cov(data):
-    if data.ndimn == 1:
+    if data.ndim == 1:
         return _cov_1d(data)
-    elif data.ndimn == 2:
+    elif data.ndim == 2:
         x = data
         avg, _ = np.average(x, axis=1, weights=None, returned=True)
         fact = x.shape[1] - 1

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -338,12 +338,12 @@ def _histogram(x, n_bins, range_hist=None):
 
 
 @conditional_jit(cache=True)
-def cov_(data):
+def _cov(data):
     return np.cov(data)
 
 
 @conditional_jit(cache=True)
-def stack(x, y):
+def _stack(x, y):
     return np.vstack((x, y))
 
 
@@ -384,13 +384,13 @@ def _fast_kde_2d(x, y, gridsize=(128, 128), circular=False):
     d_x = (xmax - xmin) / (n_x - 1)
     d_y = (ymax - ymin) / (n_y - 1)
 
-    xyi = stack((x, y)).T
+    xyi = _stack((x, y)).T
     xyi -= [xmin, ymin]
     xyi /= [d_x, d_y]
     xyi = np.floor(xyi, xyi).T
 
     scotts_factor = len_x ** (-1 / 6)
-    cov = cov_(xyi)
+    cov = _cov(xyi)
     std_devs = np.diag(cov ** 0.5)
     kern_nx, kern_ny = np.round(scotts_factor * 2 * np.pi * std_devs)
 
@@ -400,7 +400,7 @@ def _fast_kde_2d(x, y, gridsize=(128, 128), circular=False):
     y_y = np.arange(kern_ny) - kern_ny / 2
     x_x, y_y = np.meshgrid(x_x, y_y)
 
-    kernel = stack((x_x.flatten(), y_y.flatten()))
+    kernel = _stack((x_x.flatten(), y_y.flatten()))
     kernel = np.dot(inv_cov, kernel) * kernel
     kernel = np.exp(-kernel.sum(axis=0) / 2)
     kernel = kernel.reshape((int(kern_ny), int(kern_nx)))

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -360,7 +360,7 @@ def _cov(data):
         c_c *= np.true_divide(1, fact)
         return c_c.squeeze()
     else:
-        raise ValueError("{} dimension arrays are not supported".format(data.ndimn))
+        raise ValueError("{} dimension arrays are not supported".format(data.ndim))
 
 
 @conditional_jit(cache=True)
@@ -422,7 +422,7 @@ def _fast_kde_2d(x, y, gridsize=(128, 128), circular=False):
     x_x, y_y = np.meshgrid(x_x, y_y)
 
     kernel = _stack(x_x.flatten(), y_y.flatten())
-    kernel = np.dot(inv_cov, kernel) * kernel
+    kernel = _dot(inv_cov, kernel) * kernel
     kernel = np.exp(-kernel.sum(axis=0) / 2)
     kernel = kernel.reshape((int(kern_ny), int(kern_nx)))
 

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -344,7 +344,7 @@ def _cov(data):
 
 @conditional_jit(cache=True)
 def _stack(x, y):
-    return np.vstack((x, y))
+    return np.vstack(tuple(x, y))
 
 
 def _fast_kde_2d(x, y, gridsize=(128, 128), circular=False):
@@ -384,7 +384,7 @@ def _fast_kde_2d(x, y, gridsize=(128, 128), circular=False):
     d_x = (xmax - xmin) / (n_x - 1)
     d_y = (ymax - ymin) / (n_y - 1)
 
-    xyi = _stack((x, y)).T
+    xyi = _stack(x, y).T
     xyi -= [xmin, ymin]
     xyi /= [d_x, d_y]
     xyi = np.floor(xyi, xyi).T
@@ -400,7 +400,7 @@ def _fast_kde_2d(x, y, gridsize=(128, 128), circular=False):
     y_y = np.arange(kern_ny) - kern_ny / 2
     x_x, y_y = np.meshgrid(x_x, y_y)
 
-    kernel = _stack((x_x.flatten(), y_y.flatten()))
+    kernel = _stack(x_x.flatten(), y_y.flatten())
     kernel = np.dot(inv_cov, kernel) * kernel
     kernel = np.exp(-kernel.sum(axis=0) / 2)
     kernel = kernel.reshape((int(kern_ny), int(kern_nx)))

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -339,7 +339,7 @@ def _histogram(x, n_bins, range_hist=None):
 
 def _cov_1d(x):
     x = x - x.mean(axis=0)
-    fact = x.shape[1] - 1
+    fact = x.shape[0] - 1
     by_hand = np.dot(x.T, x.conj()) / fact
     return np.array(by_hand)
 
@@ -348,7 +348,7 @@ def _cov(data):
     if data.ndim == 1:
         return _cov_1d(data)
     elif data.ndim == 2:
-        x = data
+        x = data.astype(float)
         avg, _ = np.average(x, axis=1, weights=None, returned=True)
         fact = x.shape[1] - 1
         if fact <= 0:

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -390,7 +390,7 @@ def _fast_kde_2d(x, y, gridsize=(128, 128), circular=False):
     xyi = np.floor(xyi, xyi).T
 
     scotts_factor = len_x ** (-1 / 6)
-    if np.shape(xyi)[0] <= 10000:
+    if np.shape(xyi)[0] < 10000:
         cov = _cov(xyi)
     else:
         cov = np.cov(xyi)

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -390,7 +390,10 @@ def _fast_kde_2d(x, y, gridsize=(128, 128), circular=False):
     xyi = np.floor(xyi, xyi).T
 
     scotts_factor = len_x ** (-1 / 6)
-    cov = _cov(xyi)
+    if np.shape(xyi)[0] <= 10000:
+        cov = _cov(xyi)
+    else:
+        cov = np.cov(xyi)
     std_devs = np.diag(cov ** 0.5)
     kern_nx, kern_ny = np.round(scotts_factor * 2 * np.pi * std_devs)
 

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -339,9 +339,8 @@ def _histogram(x, n_bins, range_hist=None):
 
 def _cov_1d(x):
     x = x - x.mean(axis=0)
-    fact = x.shape[0] - 1
-    by_hand = np.dot(x.T, x.conj()) / fact
-    return np.array(by_hand)
+    ddof = x.shape[0] - 1
+    return np.dot(x.T, x.conj()) / ddof
 
 
 def _cov(data):
@@ -350,15 +349,14 @@ def _cov(data):
     elif data.ndim == 2:
         x = data.astype(float)
         avg, _ = np.average(x, axis=1, weights=None, returned=True)
-        fact = x.shape[1] - 1
-        if fact <= 0:
+        ddof = x.shape[1] - 1
+        if ddof <= 0:
             warnings.warn("Degrees of freedom <= 0 for slice", RuntimeWarning, stacklevel=2)
-            fact = 0.0
+            ddof = 0.0
         x -= avg[:, None]
-        x_t = x.T
-        c_c = _dot(x, x_t.conj())
-        c_c *= np.true_divide(1, fact)
-        return c_c.squeeze()
+        prod = _dot(x, x.T.conj())
+        prod *= np.true_divide(1, ddof)
+        return prod.squeeze()
     else:
         raise ValueError("{} dimension arrays are not supported".format(data.ndim))
 

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -356,9 +356,9 @@ def _cov(data):
             fact = 0.0
         x -= avg[:, None]
         x_t = x.T
-        c = _dot(x, x_t.conj())
-        c *= np.true_divide(1, fact)
-        return c.squeeze()
+        c_c = _dot(x, x_t.conj())
+        c_c *= np.true_divide(1, fact)
+        return c_c.squeeze()
     else:
         raise ValueError("{} dimension arrays are not supported".format(data.ndimn))
 
@@ -411,10 +411,7 @@ def _fast_kde_2d(x, y, gridsize=(128, 128), circular=False):
     xyi = np.floor(xyi, xyi).T
 
     scotts_factor = len_x ** (-1 / 6)
-    if xyi.ndim == 1:
-        cov = _cov_1d(xyi)
-    elif xyi.ndim == 2:
-        cov = _cov_2d(xyi)
+    cov = _cov(xyi)
     std_devs = np.diag(cov ** 0.5)
     kern_nx, kern_ny = np.round(scotts_factor * 2 * np.pi * std_devs)
 

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -344,21 +344,23 @@ def _cov_1d(x):
     return np.array(by_hand)
 
 
-def _cov_2d(m):
-    assert m.ndimn == 2
-    x = m
-    avg, _ = np.average(x, axis=1, weights=None, returned=True)
-    fact = x.shape[1] - 1
-
-    if fact <= 0:
-        warnings.warn("Degrees of freedom <= 0 for slice", RuntimeWarning, stacklevel=2)
-        fact = 0.0
-
-    x -= avg[:, None]
-    x_t = x.T
-    c = _dot(x, x_t.conj())
-    c *= np.true_divide(1, fact)
-    return c.squeeze()
+def _cov(data):
+    if data.ndimn == 1:
+        return _cov_1d(data)
+    elif data.ndimn == 2:
+        x = data
+        avg, _ = np.average(x, axis=1, weights=None, returned=True)
+        fact = x.shape[1] - 1
+        if fact <= 0:
+            warnings.warn("Degrees of freedom <= 0 for slice", RuntimeWarning, stacklevel=2)
+            fact = 0.0
+        x -= avg[:, None]
+        x_t = x.T
+        c = _dot(x, x_t.conj())
+        c *= np.true_divide(1, fact)
+        return c.squeeze()
+    else:
+        raise ValueError("{} dimension arrays are not supported".format(data.ndimn))
 
 
 @conditional_jit(cache=True)

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -331,10 +331,20 @@ def _fast_kde(x, cumulative=False, bw=4.5, xmin=None, xmax=None):
     return density, xmin, xmax
 
 
-@conditional_jit
+@conditional_jit(cache=True)
 def _histogram(x, n_bins, range_hist=None):
     grid, _ = np.histogram(x, bins=n_bins, range=range_hist)
     return grid
+
+
+@conditional_jit(cache=True)
+def cov_(data):
+    return np.cov(data)
+
+
+@conditional_jit(cache=True)
+def stack(x, y):
+    return np.vstack((x, y))
 
 
 def _fast_kde_2d(x, y, gridsize=(128, 128), circular=False):
@@ -374,13 +384,13 @@ def _fast_kde_2d(x, y, gridsize=(128, 128), circular=False):
     d_x = (xmax - xmin) / (n_x - 1)
     d_y = (ymax - ymin) / (n_y - 1)
 
-    xyi = np.vstack((x, y)).T
+    xyi = stack((x, y)).T
     xyi -= [xmin, ymin]
     xyi /= [d_x, d_y]
     xyi = np.floor(xyi, xyi).T
 
     scotts_factor = len_x ** (-1 / 6)
-    cov = np.cov(xyi)
+    cov = cov_(xyi)
     std_devs = np.diag(cov ** 0.5)
     kern_nx, kern_ny = np.round(scotts_factor * 2 * np.pi * std_devs)
 
@@ -390,7 +400,7 @@ def _fast_kde_2d(x, y, gridsize=(128, 128), circular=False):
     y_y = np.arange(kern_ny) - kern_ny / 2
     x_x, y_y = np.meshgrid(x_x, y_y)
 
-    kernel = np.vstack((x_x.flatten(), y_y.flatten()))
+    kernel = stack((x_x.flatten(), y_y.flatten()))
     kernel = np.dot(inv_cov, kernel) * kernel
     kernel = np.exp(-kernel.sum(axis=0) / 2)
     kernel = kernel.reshape((int(kern_ny), int(kern_nx)))

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -344,7 +344,7 @@ def _cov(data):
 
 @conditional_jit(cache=True)
 def _stack(x, y):
-    return np.vstack(tuple(x, y))
+    return np.vstack((x, y))
 
 
 def _fast_kde_2d(x, y, gridsize=(128, 128), circular=False):

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -6,7 +6,7 @@ from scipy.signal import gaussian, convolve, convolve2d  # pylint: disable=no-na
 from scipy.sparse import coo_matrix
 import xarray as xr
 from ..data import InferenceData
-from ..utils import conditional_jit
+from ..utils import conditional_jit, _stack
 from .plot_utils import _scale_fig_size
 
 
@@ -340,11 +340,6 @@ def _histogram(x, n_bins, range_hist=None):
 @conditional_jit(cache=True)
 def _cov(data):
     return np.cov(data)
-
-
-@conditional_jit(cache=True)
-def _stack(x, y):
-    return np.vstack((x, y))
 
 
 def _fast_kde_2d(x, y, gridsize=(128, 128), circular=False):

--- a/arviz/plots/khatplot.py
+++ b/arviz/plots/khatplot.py
@@ -15,7 +15,7 @@ from .plot_utils import (
     set_xticklabels,
 )
 from ..stats import ELPDData
-from ..stats.stats_utils import histogram
+from ..utils import conditional_jit
 
 
 def plot_khat(
@@ -229,7 +229,7 @@ def plot_khat(
     if show_bins:
         bin_edges = np.array([ymin, 0.5, 0.7, 1, ymax])
         bin_edges = bin_edges[(bin_edges >= ymin) & (bin_edges <= ymax)]
-        hist = histogram(khats, bin_edges)
+        hist, _ = _khat_histogram(khats, bin_edges)
         for idx, count in enumerate(hist):
             ax.text(
                 (n_data_points - 1 + xmax) / 2,
@@ -303,3 +303,8 @@ def _make_hover_annotation(fig, ax, sc_plot, coord_labels, rgba_c, hover_format)
                     fig.canvas.draw_idle()
 
     fig.canvas.mpl_connect("motion_notify_event", hover)
+
+
+@conditional_jit
+def _khat_histogram(data, bin_edges):
+    return np.histogram(data, bins=bin_edges)

--- a/arviz/plots/khatplot.py
+++ b/arviz/plots/khatplot.py
@@ -15,6 +15,7 @@ from .plot_utils import (
     set_xticklabels,
 )
 from ..stats import ELPDData
+from ..stats.stats_utils import histogram
 
 
 def plot_khat(
@@ -228,7 +229,7 @@ def plot_khat(
     if show_bins:
         bin_edges = np.array([ymin, 0.5, 0.7, 1, ymax])
         bin_edges = bin_edges[(bin_edges >= ymin) & (bin_edges <= ymax)]
-        hist, _ = np.histogram(khats, bin_edges)
+        hist = histogram(khats, bin_edges)
         for idx, count in enumerate(hist):
             ax.text(
                 (n_data_points - 1 + xmax) / 2,

--- a/arviz/plots/parallelplot.py
+++ b/arviz/plots/parallelplot.py
@@ -101,7 +101,7 @@ def plot_parallel(
         if norm_method == "normal":
             mean = np.mean(_posterior, axis=1)
             if _posterior.ndim <= 2:
-                standard_deviation = np.sqrt(_numba_var(svar, np.var,_posterior, axis=1))
+                standard_deviation = np.sqrt(_numba_var(svar, np.var, _posterior, axis=1))
             else:
                 standard_deviation = np.std(_posterior, axis=1)
             for i in range(0, np.shape(mean)[0]):

--- a/arviz/plots/parallelplot.py
+++ b/arviz/plots/parallelplot.py
@@ -5,7 +5,8 @@ import numpy as np
 from scipy.stats.mstats import rankdata
 from ..data import convert_to_dataset
 from .plot_utils import _scale_fig_size, xarray_to_ndarray, get_coords
-from ..utils import _var_names
+from ..utils import _var_names, _numba_var
+from ..stats.stats_utils import stats_variance_2d as svar
 
 
 def plot_parallel(
@@ -99,7 +100,10 @@ def plot_parallel(
     if norm_method is not None:
         if norm_method == "normal":
             mean = np.mean(_posterior, axis=1)
-            standard_deviation = np.std(_posterior, axis=1)
+            if _posterior.ndim <= 2:
+                standard_deviation = np.sqrt(_numba_var(svar, np.var, axis=1))
+            else:
+                standard_deviation = np.std(_posterior, axis=1)
             for i in range(0, np.shape(mean)[0]):
                 _posterior[i, :] = (_posterior[i, :] - mean[i]) / standard_deviation[i]
         elif norm_method == "minmax":

--- a/arviz/plots/parallelplot.py
+++ b/arviz/plots/parallelplot.py
@@ -101,7 +101,7 @@ def plot_parallel(
         if norm_method == "normal":
             mean = np.mean(_posterior, axis=1)
             if _posterior.ndim <= 2:
-                standard_deviation = np.sqrt(_numba_var(svar, np.var, axis=1))
+                standard_deviation = np.sqrt(_numba_var(svar, np.var,_posterior, axis=1))
             else:
                 standard_deviation = np.std(_posterior, axis=1)
             for i in range(0, np.shape(mean)[0]):

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -236,7 +236,7 @@ def make_label(var_name, selection, position="below"):
     return "{}{}{}".format(var_name, sep, sel)
 
 
-@conditional_jit(cache=True)
+@conditional_jit(forceobj=True)
 def purge_duplicates(list_in):
     """Remove duplicates from list while preserving order.
 
@@ -256,12 +256,10 @@ def purge_duplicates(list_in):
     return _list
 
 
-@conditional_jit(cache=True)
 def _dims(data, var_name, skip_dims):
     return [dim for dim in data[var_name].dims if dim not in skip_dims]
 
 
-@conditional_jit(cache=True)
 def _zip_dims(new_dims, vals):
     return [{k: v for k, v in zip(new_dims, prod)} for prod in product(*vals)]
 

--- a/arviz/plots/rankplot.py
+++ b/arviz/plots/rankplot.py
@@ -10,7 +10,7 @@ from .plot_utils import (
     _create_axes_grid,
     make_label,
 )
-from ..utils import _var_names
+from ..utils import _var_names, conditional_jit
 
 
 def _sturges_formula(dataset, mult=1):
@@ -120,7 +120,7 @@ def plot_rank(data, var_names=None, coords=None, bins=None, ref_line=True, figsi
         ranks = scipy.stats.rankdata(var_data).reshape(var_data.shape)
         all_counts = []
         for row in ranks:
-            counts, bin_ary = np.histogram(row, bins=bins, range=(0, ranks.size))
+            counts, bin_ary = _rank_hist(row, bins=bins, range=(0, ranks.size))
             all_counts.append(counts)
         all_counts = np.array(all_counts)
         gap = all_counts.max() * 1.05
@@ -153,3 +153,8 @@ def plot_rank(data, var_names=None, coords=None, bins=None, ref_line=True, figsi
         ax.set_title(make_label(var_name, selection), fontsize=titlesize)
 
     return axes
+
+
+@conditional_jit
+def _rank_hist(data, bins, range):
+    return np.histogram(data, bins, range)

--- a/arviz/plots/rankplot.py
+++ b/arviz/plots/rankplot.py
@@ -120,7 +120,7 @@ def plot_rank(data, var_names=None, coords=None, bins=None, ref_line=True, figsi
         ranks = scipy.stats.rankdata(var_data).reshape(var_data.shape)
         all_counts = []
         for row in ranks:
-            counts, bin_ary = _rank_hist(row, bins=bins, ranks.size)
+            counts, bin_ary = _rank_hist(row, bins, ranks.size)
             all_counts.append(counts)
         all_counts = np.array(all_counts)
         gap = all_counts.max() * 1.05

--- a/arviz/plots/rankplot.py
+++ b/arviz/plots/rankplot.py
@@ -120,7 +120,7 @@ def plot_rank(data, var_names=None, coords=None, bins=None, ref_line=True, figsi
         ranks = scipy.stats.rankdata(var_data).reshape(var_data.shape)
         all_counts = []
         for row in ranks:
-            counts, bin_ary = _rank_hist(row, bins=bins, range=(0, ranks.size))
+            counts, bin_ary = _rank_hist(row, bins=bins, ranks.size)
             all_counts.append(counts)
         all_counts = np.array(all_counts)
         gap = all_counts.max() * 1.05
@@ -156,5 +156,5 @@ def plot_rank(data, var_names=None, coords=None, bins=None, ref_line=True, figsi
 
 
 @conditional_jit
-def _rank_hist(data, bins, range):
-    return np.histogram(data, bins, range)
+def _rank_hist(data, bins, size):
+    return np.histogram(data, bins, range=(0, size))

--- a/arviz/stats/diagnostics.py
+++ b/arviz/stats/diagnostics.py
@@ -616,6 +616,10 @@ def _z_scale(ary):
     return z
 
 
+def _stack(x, y):
+    return np.vstack((x, y))
+
+
 def _split_chains(ary):
     """Split and stack chains."""
     ary = np.asarray(ary)
@@ -625,7 +629,7 @@ def _split_chains(ary):
         ary = np.atleast_2d(ary)
         _, n_draw = ary.shape
     half = n_draw // 2
-    return np.vstack((ary[:, :half], ary[:, -half:]))
+    return _stack(ary[:, :half], ary[:, -half:])
 
 
 def _z_fold(ary):
@@ -1038,7 +1042,7 @@ def _multichain_statistics(ary):
     """
     ary = np.atleast_2d(ary)
     if _not_valid(ary, shape_kwargs=dict(min_draws=4, min_chains=1)):
-        return (np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan)
+        return np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan
     # ess mean
     ess_mean_value = _ess_mean(ary)
 

--- a/arviz/stats/diagnostics.py
+++ b/arviz/stats/diagnostics.py
@@ -550,7 +550,8 @@ def ks_summary(pareto_tail_indices):
     """
     _numba_flag = Numba.numba_flag
     if _numba_flag:
-        kcounts = histogram(pareto_tail_indices)
+        bins = np.asarray([-np.Inf, 0.5, 0.7, 1, np.Inf])
+        kcounts, _ = histogram(pareto_tail_indices, bins)
     else:
         kcounts, _ = np.histogram(pareto_tail_indices, bins=[-np.Inf, 0.5, 0.7, 1, np.Inf])
     kprop = kcounts / len(pareto_tail_indices) * 100

--- a/arviz/stats/diagnostics.py
+++ b/arviz/stats/diagnostics.py
@@ -16,7 +16,7 @@ from .stats_utils import (
     histogram,
 )
 from ..data import convert_to_dataset
-from ..utils import _var_names, conditional_jit, conditional_vect, Numba, _numba_var
+from ..utils import _var_names, conditional_jit, conditional_vect, Numba, _numba_var, _stack
 
 __all__ = ["bfmi", "effective_sample_size", "ess", "rhat", "mcse", "geweke"]
 
@@ -615,10 +615,6 @@ def _z_scale(ary):
     z = stats.norm.ppf((rank - 0.5) / size)
     z = z.reshape(ary.shape)
     return z
-
-
-def _stack(x, y):
-    return np.vstack((x, y))
 
 
 def _split_chains(ary):

--- a/arviz/stats/stats_utils.py
+++ b/arviz/stats/stats_utils.py
@@ -470,6 +470,8 @@ def stats_variance_2d(data, ddof=0, axis=1):
 
 
 @conditional_jit
-def histogram(data, bins=[-np.Inf, 0.5, 0.7, 1, np.Inf]):
+def histogram(data, bins=None):
+    if bins is None:
+        bins = [-np.Inf, 0.5, 0.7, 1, np.Inf]
     kcounts, _ = np.histogram(data, bins=bins)
     return kcounts

--- a/arviz/stats/stats_utils.py
+++ b/arviz/stats/stats_utils.py
@@ -470,6 +470,6 @@ def stats_variance_2d(data, ddof=0, axis=1):
 
 
 @conditional_jit
-def histogram(data):
-    kcounts, _ = np.histogram(data, bins=[-np.Inf, 0.5, 0.7, 1, np.Inf])
+def histogram(data, bins=[-np.Inf, 0.5, 0.7, 1, np.Inf]):
+    kcounts, _ = np.histogram(data, bins=bins)
     return kcounts

--- a/arviz/stats/stats_utils.py
+++ b/arviz/stats/stats_utils.py
@@ -429,7 +429,8 @@ class ELPDData(pd.Series):  # pylint: disable=too-many-ancestors
             base += "\n\nThere has been a warning during the calculation. Please check the results."
 
         if kind == "loo" and "pareto_k" in self:
-            counts = histogram(self.pareto_k)
+            bins = np.asarray([-np.Inf, 0.5, 0.7, 1, np.Inf])
+            counts, _ = histogram(self.pareto_k.values, bins)
             extended = POINTWISE_LOO_FMT.format(max(4, len(str(np.max(counts)))))
             extended = extended.format(
                 "Count", "Pct.", *[*counts, *(counts / np.sum(counts) * 100)]
@@ -470,8 +471,5 @@ def stats_variance_2d(data, ddof=0, axis=1):
 
 
 @conditional_jit
-def histogram(data, bins=None):
-    if bins is None:
-        bins = [-np.Inf, 0.5, 0.7, 1, np.Inf]
-    kcounts, _ = np.histogram(data, bins=bins)
-    return kcounts
+def histogram(data, bins):
+    return np.histogram(data, bins=bins)

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -384,7 +384,7 @@ def test_cov():
 def test_stack():
     x = np.random.randn(100, 100, 5)
     y = np.random.randn(100, 100, 5)
-    assert np.allclose(_stack(x, y), np.stack((x, y)))
+    assert np.allclose(_stack(x, y), np.vstack((x, y)))
 
 
 @pytest.mark.parametrize(

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -401,7 +401,7 @@ def test_plot_kde_cumulative(continuous_model, kwargs):
     assert axes
 
 
-def plot_kde_2d():
+def test_plot_kde_2d():
     s_x = np.random.randn(100, 100)
     s_y = np.random.randn(100, 100)
     l_x = np.random.randn(10000, 1000)

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -34,6 +34,7 @@ from ..plots import (
     plot_loo_pit,
     plot_mcse,
 )
+from ..plots.kdeplot import cov_, stack
 
 np.random.seed(0)
 os.environ["ARVIZ_LOAD"] = "EAGER"
@@ -373,6 +374,17 @@ def test_plot_joint_bad(models):
 def test_plot_kde(continuous_model, kwargs):
     axes = plot_kde(continuous_model["x"], continuous_model["y"], **kwargs)
     assert axes
+
+
+def test_cov():
+    x = np.random.rand(100, 100)
+    assert np.allclose(cov_(x), np.cov(x))
+
+
+def test_stack():
+    x = np.random.randn(100, 100, 5)
+    y = np.random.randn(100, 100, 5)
+    assert np.allclose(stack(x, y), np.stack((x, y)))
 
 
 @pytest.mark.parametrize(

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -399,17 +399,6 @@ def test_plot_kde_cumulative(continuous_model, kwargs):
     assert axes
 
 
-def test_plot_kde_2d():
-    s_x = np.random.randn(100, 100)
-    s_y = np.random.randn(100, 100)
-    l_x = np.random.randn(10000, 1000)
-    l_y = np.random.randn(10000, 1000)
-    axes = plot_kde(s_x, s_y)
-    assert axes
-    axes = plot_kde(l_x, l_y)
-    assert axes
-
-
 @pytest.mark.parametrize("kwargs", [{"kind": "hist"}, {"kind": "dist"}])
 def test_plot_dist(continuous_model, kwargs):
     axes = plot_dist(continuous_model["x"], **kwargs)

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -34,7 +34,7 @@ from ..plots import (
     plot_loo_pit,
     plot_mcse,
 )
-from ..plots.kdeplot import cov_, stack
+from ..plots.kdeplot import _cov, _stack
 
 np.random.seed(0)
 os.environ["ARVIZ_LOAD"] = "EAGER"
@@ -378,13 +378,13 @@ def test_plot_kde(continuous_model, kwargs):
 
 def test_cov():
     x = np.random.rand(100, 100)
-    assert np.allclose(cov_(x), np.cov(x))
+    assert np.allclose(_cov(x), np.cov(x))
 
 
 def test_stack():
     x = np.random.randn(100, 100, 5)
     y = np.random.randn(100, 100, 5)
-    assert np.allclose(stack(x, y), np.stack((x, y)))
+    assert np.allclose(_stack(x, y), np.stack((x, y)))
 
 
 @pytest.mark.parametrize(

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -376,9 +376,13 @@ def test_plot_kde(continuous_model, kwargs):
     assert axes
 
 
-def test_cov():
-    x = np.random.rand(100, 100)
-    assert np.allclose(_cov(x), np.cov(x))
+@pytest.mark.parametrize("x", (np.random.randn(8), np.random.randn(8, 8), np.random.randn(8, 8, 8)))
+def test_cov(x):
+    if x.ndim <= 2:
+        assert np.allclose(_cov(x), np.cov(x))
+    else:
+        with pytest.raises(ValueError):
+            _cov(x)
 
 
 @pytest.mark.parametrize(

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -401,6 +401,17 @@ def test_plot_kde_cumulative(continuous_model, kwargs):
     assert axes
 
 
+def plot_kde_2d():
+    s_x = np.random.randn(100, 100)
+    s_y = np.random.randn(100, 100)
+    l_x = np.random.randn(10000, 1000)
+    l_y = np.random.randn(10000, 1000)
+    axes = plot_kde(s_x, s_y)
+    assert axes
+    axes = plot_kde(l_x, l_y)
+    assert axes
+
+
 @pytest.mark.parametrize("kwargs", [{"kind": "hist"}, {"kind": "dist"}])
 def test_plot_dist(continuous_model, kwargs):
     axes = plot_dist(continuous_model["x"], **kwargs)

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -381,12 +381,6 @@ def test_cov():
     assert np.allclose(_cov(x), np.cov(x))
 
 
-def test_stack():
-    x = np.random.randn(100, 100, 5)
-    y = np.random.randn(100, 100, 5)
-    assert np.allclose(_stack(x, y), np.vstack((x, y)))
-
-
 @pytest.mark.parametrize(
     "kwargs",
     [

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -376,7 +376,7 @@ def test_plot_kde(continuous_model, kwargs):
     assert axes
 
 
-@pytest.mark.parametrize("x", (np.random.randn(8), np.random.randn(8, 8), np.random.randn(8, 8, 8)))
+@pytest.mark.parametrize("x", [np.random.randn(8), np.random.randn(8, 8), np.random.randn(8, 8, 8)])
 def test_cov(x):
     if x.ndim <= 2:
         assert np.allclose(_cov(x), np.cov(x))

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -34,7 +34,7 @@ from ..plots import (
     plot_loo_pit,
     plot_mcse,
 )
-from ..plots.kdeplot import _cov, _stack
+from ..plots.kdeplot import _cov
 
 np.random.seed(0)
 os.environ["ARVIZ_LOAD"] = "EAGER"

--- a/arviz/tests/test_stats_utils.py
+++ b/arviz/tests/test_stats_utils.py
@@ -253,6 +253,6 @@ def test_variance_bad_data():
 
 def test_histogram():
     school = load_arviz_data("non_centered_eight").posterior["mu"].values
-    k_count = histogram(school)
+    k_count = histogram(school, bins=np.asarray([-np.Inf, 0.5, 0.7, 1, np.Inf]))
     kcount, _ = np.histogram(school, bins=[-np.Inf, 0.5, 0.7, 1, np.Inf])
     assert np.allclose(k_count, kcount)

--- a/arviz/tests/test_stats_utils.py
+++ b/arviz/tests/test_stats_utils.py
@@ -253,6 +253,6 @@ def test_variance_bad_data():
 
 def test_histogram():
     school = load_arviz_data("non_centered_eight").posterior["mu"].values
-    k_count = histogram(school, bins=np.asarray([-np.Inf, 0.5, 0.7, 1, np.Inf]))
+    k_count, _ = histogram(school, bins=np.asarray([-np.Inf, 0.5, 0.7, 1, np.Inf]))
     kcount, _ = np.histogram(school, bins=[-np.Inf, 0.5, 0.7, 1, np.Inf])
     assert np.allclose(k_count, kcount)

--- a/arviz/tests/test_utils.py
+++ b/arviz/tests/test_utils.py
@@ -7,7 +7,7 @@ import importlib
 import numpy as np
 import pytest
 
-from ..utils import _var_names, format_sig_figs, numba_check, Numba, _numba_var
+from ..utils import _var_names, format_sig_figs, numba_check, Numba, _numba_var, _stack
 from ..data import load_arviz_data, from_dict
 from ..stats.stats_utils import stats_variance_2d as svar
 
@@ -231,3 +231,11 @@ def test_numba_var(axis, ddof):
     assert flag == Numba.numba_flag
     assert np.allclose(with_numba_1, non_numba_1)
     assert np.allclose(with_numba_2, non_numba_2)
+
+
+def test_stack():
+    x = np.random.randn(10, 4, 6)
+    y = np.random.randn(100, 4, 6)
+    assert x.shape[1:] == y.shape[1:]
+    assert np.allclose(np.vstack((x, y)), _stack(x, y))
+    assert _stack

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -282,3 +282,9 @@ def _numba_var(numba_function, standard_numpy_func, data, axis=None, ddof=0):
         return numba_function(data, axis=axis, ddof=ddof)
     else:
         return standard_numpy_func(data, axis=axis, ddof=ddof)
+
+
+@conditional_jit(cache=True)
+def _stack(x, y):
+    assert x.shape[1:] == y.shape[1:]
+    return np.vstack((x, y))

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -284,7 +284,6 @@ def _numba_var(numba_function, standard_numpy_func, data, axis=None, ddof=0):
         return standard_numpy_func(data, axis=axis, ddof=ddof)
 
 
-@conditional_jit(cache=True)
 def _stack(x, y):
     assert x.shape[1:] == y.shape[1:]
     return np.vstack((x, y))

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -85,16 +85,33 @@ class CircStd:
             return circstd(data)
 
 
-class cov:
+class Cov:
     def time_numpy_cov(self):
         try:
-            data = np.random.randn(1000,100)
+            data = np.random.randn(1000, 100)
             import numba
 
             @numba.njit
             def cov():
                 return np.cov(data)
+
         except ImportError:
-            data = np.random.randn(1000,100)
+            data = np.random.randn(1000, 100)
             return np.cov(data)
 
+
+class Stack:
+    def time_stack(self):
+        try:
+            x = np.random.randn(10000, 1000)
+            y = np.random.randn(10000, 1000)
+            import numba
+
+            @numba.njit
+            def stack(x, y):
+                return np.stack((x, y))
+
+        except ImportError:
+            x = np.random.randn(10000, 1000)
+            y = np.random.randn(10000, 1000)
+            return np.stack((x, y))

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -226,7 +226,9 @@ class Fast_KDE_2d:
                     avg, _ = np.average(x, axis=1, weights=None, returned=True)
                     fact = x.shape[1] - 1
                     if fact <= 0:
-                        warnings.warn("Degrees of freedom <= 0 for slice", RuntimeWarning, stacklevel=2)
+                        warnings.warn(
+                            "Degrees of freedom <= 0 for slice", RuntimeWarning, stacklevel=2
+                        )
                         fact = 0.0
                     x -= avg[:, None]
                     x_t = x.T

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -83,3 +83,18 @@ class CircStd:
         except ImportError:
             data = np.random.randn(10000, 1000)
             return circstd(data)
+
+
+class cov:
+    def time_numpy_cov(self):
+        try:
+            data = np.random.randn(1000,100)
+            import numba
+
+            @numba.njit
+            def cov():
+                return np.cov(data)
+        except ImportError:
+            data = np.random.randn(1000,100)
+            return np.cov(data)
+

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -2,6 +2,9 @@
 # See "Writing benchmarks" in the asv docs for more information.
 import numpy as np
 from scipy.stats import circstd
+from scipy.sparse import coo_matrix
+import scipy.signal as ss
+import warnings
 
 
 class Hist:
@@ -85,33 +88,246 @@ class CircStd:
             return circstd(data)
 
 
-class Cov:
-    def time_numpy_cov(self):
+class Fast_Kde_1d:
+    def time_fast_kde(self):
+
         try:
-            data = np.random.randn(1000, 100)
+            x = np.random.randn(10000, 100)
+            import numba
+
+            def _fast_kde(x, cumulative=False, bw=4.5, xmin=None, xmax=None):
+                x = np.asarray(x, dtype=float)
+                x = x[np.isfinite(x)]
+                if x.size == 0:
+                    warnings.warn("kde plot failed, you may want to check your data")
+                    return np.array([np.nan]), np.nan, np.nan
+
+                len_x = len(x)
+                n_points = 200 if (xmin or xmax) is None else 500
+
+                if xmin is None:
+                    xmin = np.min(x)
+                if xmax is None:
+                    xmax = np.max(x)
+
+                assert np.min(x) >= xmin
+                assert np.max(x) <= xmax
+
+                log_len_x = np.log(len_x) * bw
+
+                n_bins = min(int(len_x ** (1 / 3) * log_len_x * 2), n_points)
+                if n_bins < 2:
+                    warnings.warn("kde plot failed, you may want to check your data")
+                    return np.array([np.nan]), np.nan, np.nan
+
+                d_x = (xmax - xmin) / (n_bins - 1)
+                grid = _histogram(x, n_bins, range_hist=(xmin, xmax))
+
+                scotts_factor = len_x ** (-0.2)
+                kern_nx = int(scotts_factor * 2 * np.pi * log_len_x)
+                kernel = ss.gaussian(kern_nx, scotts_factor * log_len_x)
+
+                npad = min(n_bins, 2 * kern_nx)
+                grid = np.concatenate([grid[npad:0:-1], grid, grid[n_bins : n_bins - npad : -1]])
+                density = ss.convolve(grid, kernel, mode="same", method="direct")[
+                    npad : npad + n_bins
+                ]
+                norm_factor = len_x * d_x * (2 * np.pi * log_len_x ** 2 * scotts_factor ** 2) ** 0.5
+
+                density /= norm_factor
+
+                if cumulative:
+                    density = density.cumsum() / density.sum()
+
+                return density, xmin, xmax
+
+            @numba.njit(cache=True)
+            def _histogram(x, n_bins, range_hist=None):
+                grid, _ = np.histogram(x, bins=n_bins, range=range_hist)
+                return grid
+
+            return _fast_kde(x)
+
+        except ImportError:
+
+            x = np.random.randn(10000, 100)
+
+            def _fast_kde(x, cumulative=False, bw=4.5, xmin=None, xmax=None):
+                x = np.asarray(x, dtype=float)
+                x = x[np.isfinite(x)]
+                if x.size == 0:
+                    warnings.warn("kde plot failed, you may want to check your data")
+                    return np.array([np.nan]), np.nan, np.nan
+
+                len_x = len(x)
+                n_points = 200 if (xmin or xmax) is None else 500
+
+                if xmin is None:
+                    xmin = np.min(x)
+                if xmax is None:
+                    xmax = np.max(x)
+
+                assert np.min(x) >= xmin
+                assert np.max(x) <= xmax
+
+                log_len_x = np.log(len_x) * bw
+
+                n_bins = min(int(len_x ** (1 / 3) * log_len_x * 2), n_points)
+                if n_bins < 2:
+                    warnings.warn("kde plot failed, you may want to check your data")
+                    return np.array([np.nan]), np.nan, np.nan
+
+                d_x = (xmax - xmin) / (n_bins - 1)
+                grid = _histogram(x, n_bins, range_hist=(xmin, xmax))
+
+                scotts_factor = len_x ** (-0.2)
+                kern_nx = int(scotts_factor * 2 * np.pi * log_len_x)
+                kernel = ss.gaussian(kern_nx, scotts_factor * log_len_x)
+
+                npad = min(n_bins, 2 * kern_nx)
+                grid = np.concatenate([grid[npad:0:-1], grid, grid[n_bins : n_bins - npad : -1]])
+                density = ss.convolve(grid, kernel, mode="same", method="direct")[
+                    npad : npad + n_bins
+                ]
+                norm_factor = len_x * d_x * (2 * np.pi * log_len_x ** 2 * scotts_factor ** 2) ** 0.5
+
+                density /= norm_factor
+
+                if cumulative:
+                    density = density.cumsum() / density.sum()
+
+                return density, xmin, xmax
+
+            def _histogram(x, n_bins, range_hist=None):
+                grid, _ = np.histogram(x, bins=n_bins, range=range_hist)
+                return grid
+
+            return _fast_kde(x)
+
+
+class Fast_KDE_2d:
+    def time_fast_kde_2d(self):
+        try:
+            x = np.random.randn(10000, 100)
+            y = np.random.randn(10000, 100)
             import numba
 
             @numba.njit
-            def cov():
+            def _cov(data):
                 return np.cov(data)
 
-        except ImportError:
-            data = np.random.randn(1000, 100)
-            return np.cov(data)
-
-
-class Stack:
-    def time_stack(self):
-        try:
-            x = np.random.randn(10000, 1000)
-            y = np.random.randn(10000, 1000)
-            import numba
-
             @numba.njit
-            def stack(x, y):
-                return np.stack((x, y))
+            def _stack(x, y):
+                return np.vstack((x, y))
+
+            def _fast_kde_2d(x, y, gridsize=(128, 128), circular=False):
+                x = np.asarray(x, dtype=float)
+                x = x[np.isfinite(x)]
+                y = np.asarray(y, dtype=float)
+                y = y[np.isfinite(y)]
+
+                xmin, xmax = x.min(), x.max()
+                ymin, ymax = y.min(), y.max()
+
+                len_x = len(x)
+                weights = np.ones(len_x)
+                n_x, n_y = gridsize
+
+                d_x = (xmax - xmin) / (n_x - 1)
+                d_y = (ymax - ymin) / (n_y - 1)
+
+                xyi = _stack(x, y).T
+                xyi -= [xmin, ymin]
+                xyi /= [d_x, d_y]
+                xyi = np.floor(xyi, xyi).T
+
+                scotts_factor = len_x ** (-1 / 6)
+                cov = _cov(xyi)
+                std_devs = np.diag(cov ** 0.5)
+                kern_nx, kern_ny = np.round(scotts_factor * 2 * np.pi * std_devs)
+
+                inv_cov = np.linalg.inv(cov * scotts_factor ** 2)
+
+                x_x = np.arange(kern_nx) - kern_nx / 2
+                y_y = np.arange(kern_ny) - kern_ny / 2
+                x_x, y_y = np.meshgrid(x_x, y_y)
+
+                kernel = _stack(x_x.flatten(), y_y.flatten())
+                kernel = np.dot(inv_cov, kernel) * kernel
+                kernel = np.exp(-kernel.sum(axis=0) / 2)
+                kernel = kernel.reshape((int(kern_ny), int(kern_nx)))
+
+                boundary = "wrap" if circular else "symm"
+
+                grid = coo_matrix((weights, xyi), shape=(n_x, n_y)).toarray()
+                grid = ss.convolve2d(grid, kernel, mode="same", boundary=boundary)
+
+                norm_factor = np.linalg.det(2 * np.pi * cov * scotts_factor ** 2)
+                norm_factor = len_x * d_x * d_y * norm_factor ** 0.5
+
+                grid /= norm_factor
+
+                return grid, xmin, xmax, ymin, ymax
+
+            return _fast_kde_2d(x, y)
 
         except ImportError:
-            x = np.random.randn(10000, 1000)
-            y = np.random.randn(10000, 1000)
-            return np.stack((x, y))
+            x = np.random.randn(10000, 100)
+            y = np.random.randn(10000, 100)
+
+            def _cov(data):
+                return np.cov(data)
+
+            def _stack(x, y):
+                return np.vstack((x, y))
+
+            def _fast_kde_2d(x, y, gridsize=(128, 128), circular=False):
+                x = np.asarray(x, dtype=float)
+                x = x[np.isfinite(x)]
+                y = np.asarray(y, dtype=float)
+                y = y[np.isfinite(y)]
+
+                xmin, xmax = x.min(), x.max()
+                ymin, ymax = y.min(), y.max()
+
+                len_x = len(x)
+                weights = np.ones(len_x)
+                n_x, n_y = gridsize
+
+                d_x = (xmax - xmin) / (n_x - 1)
+                d_y = (ymax - ymin) / (n_y - 1)
+
+                xyi = _stack(x, y).T
+                xyi -= [xmin, ymin]
+                xyi /= [d_x, d_y]
+                xyi = np.floor(xyi, xyi).T
+
+                scotts_factor = len_x ** (-1 / 6)
+                cov = _cov(xyi)
+                std_devs = np.diag(cov ** 0.5)
+                kern_nx, kern_ny = np.round(scotts_factor * 2 * np.pi * std_devs)
+
+                inv_cov = np.linalg.inv(cov * scotts_factor ** 2)
+
+                x_x = np.arange(kern_nx) - kern_nx / 2
+                y_y = np.arange(kern_ny) - kern_ny / 2
+                x_x, y_y = np.meshgrid(x_x, y_y)
+
+                kernel = _stack(x_x.flatten(), y_y.flatten())
+                kernel = np.dot(inv_cov, kernel) * kernel
+                kernel = np.exp(-kernel.sum(axis=0) / 2)
+                kernel = kernel.reshape((int(kern_ny), int(kern_nx)))
+
+                boundary = "wrap" if circular else "symm"
+
+                grid = coo_matrix((weights, xyi), shape=(n_x, n_y)).toarray()
+                grid = ss.convolve2d(grid, kernel, mode="same", boundary=boundary)
+
+                norm_factor = np.linalg.det(2 * np.pi * cov * scotts_factor ** 2)
+                norm_factor = len_x * d_x * d_y * norm_factor ** 0.5
+
+                grid /= norm_factor
+
+                return grid, xmin, xmax, ymin, ymax
+
+            return _fast_kde_2d(x, y)


### PR DESCRIPTION
This optimizes `_fast_kde_2d`. `_fast_kde` was already optimized via the `conditional_jit` on `np.histogram` which greatly reduced my work with plots. This should optimize a lot of other plots as many of them are built on top of `plot_kde`. A few minor additions on the remaining plots and plot_utils need to be added. A caveat though, in most of the cases of plots, the bottlenecks are matplotlib plotting methods which are not compatible with numba `no-python` mode. I am however, trying my best to optimize the plots as much as possible :).