### PR TITLE
make order of model in compare df explicit

### DIFF
--- a/arviz/plots/compareplot.py
+++ b/arviz/plots/compareplot.py
@@ -9,6 +9,7 @@ def plot_compare(
     insample_dev=True,
     plot_standard_error=True,
     plot_ic_diff=True,
+    order_by_rank=True,
     figsize=None,
     textsize=None,
     plot_kwargs=None,
@@ -28,7 +29,7 @@ def plot_compare(
 
     Parameters
     ----------
-    comp_df: pd.DataFrame
+    comp_df : pd.DataFrame
         Result of the `az.compare()` method
     insample_dev : bool, optional
         Plot in-sample deviance, that is the value of the information criteria without the
@@ -38,6 +39,8 @@ def plot_compare(
     plot_ic_diff : bool, optional
         Plot standard error of the difference in information criteria between each model
          and the top-ranked model. Defaults to True
+    order_by_rank : bool
+        If True (default) ensure the best model is used as reference.
     figsize : tuple, optional
         If None, size is (6, num of models) inches
     textsize: float
@@ -100,6 +103,9 @@ def plot_compare(
             "comp_df must contain one of the following"
             " information criterion: {}".format(_information_criterion)
         )
+
+    if order_by_rank:
+        comp_df.sort_values(by="rank", inplace=True)
 
     if plot_ic_diff:
         yticks_labels[0] = comp_df.index[0]

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -88,8 +88,9 @@ def compare(
 
     Returns
     -------
-    A DataFrame, ordered from lowest to highest IC. The index reflects the key with which the
+    A DataFrame, ordered from best to worst model. The index reflects the key with which the
     models are passed to this function. The columns are:
+    rank : The rank-order of the models. 0 is the best.
     IC : Information Criteria (WAIC or LOO).
         Smaller IC indicates higher out-of-sample predictive fit ("better" model). Default WAIC.
         If `scale == log` higher IC indicates higher out-of-sample predictive fit ("better" model).
@@ -146,7 +147,17 @@ def compare(
         ic_func = waic
         df_comp = pd.DataFrame(
             index=names,
-            columns=["waic", "p_waic", "d_waic", "weight", "se", "dse", "warning", "waic_scale"],
+            columns=[
+                "rank",
+                "waic",
+                "p_waic",
+                "d_waic",
+                "weight",
+                "se",
+                "dse",
+                "warning",
+                "waic_scale",
+            ],
         )
         scale_col = "waic_scale"
 
@@ -154,7 +165,17 @@ def compare(
         ic_func = loo
         df_comp = pd.DataFrame(
             index=names,
-            columns=["loo", "p_loo", "d_loo", "weight", "se", "dse", "warning", "loo_scale"],
+            columns=[
+                "rank",
+                "loo",
+                "p_loo",
+                "d_loo",
+                "weight",
+                "se",
+                "dse",
+                "warning",
+                "loo_scale",
+            ],
         )
         scale_col = "loo_scale"
 
@@ -250,6 +271,7 @@ def compare(
             std_err = ses.loc[val]
             weight = weights[idx]
             df_comp.at[val] = (
+                idx,
                 res[ic],
                 res[p_ic],
                 d_ic,

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -88,8 +88,8 @@ def compare(
 
     Returns
     -------
-    A DataFrame, ordered from best to worst model. The index reflects the key with which the
-    models are passed to this function. The columns are:
+    A DataFrame, ordered from best to worst model (measured by information criteria).
+    The index reflects the key with which the models are passed to this function. The columns are:
     rank : The rank-order of the models. 0 is the best.
     IC : Information Criteria (WAIC or LOO).
         Smaller IC indicates higher out-of-sample predictive fit ("better" model). Default WAIC.


### PR DESCRIPTION
Fix #733

Also in case people do crazy stuff like sorting the compare DataFrame, `plot_compare` will resort the DataFrame by default, so the plot makes sense. 