### PR TITLE
Add regression datasets

### DIFF
--- a/arviz/data/datasets.py
+++ b/arviz/data/datasets.py
@@ -102,6 +102,30 @@ fit with PyMC3.
 True weights and intercept are included as deterministic variables.
 """,
     ),
+    "classification1d": RemoteFileMetadata(
+        filename="classification1d.nc",
+        url="https://ndownloader.figshare.com/files/16256678",
+        checksum="1cf3806e72c14001f6864bb69d89747dcc09dd55bcbca50aba04e9939daee5a0",
+        description="""
+A synthetic one dimensional logistic regression dataset with latent slope and
+intercept, passed into a Bernoulli random variable. One hundred data points,
+fit with PyMC3.
+
+True slope and intercept are included as deterministic variables.
+""",
+    ),
+    "classification10d": RemoteFileMetadata(
+        filename="classification10d.nc",
+        url="https://ndownloader.figshare.com/files/16256681",
+        checksum="16c9a45e1e6e0519d573cafc4d266d761ba347e62b6f6a79030aaa8e2fde1367",
+        description="""
+A synthetic multi dimensional (10 dimensions) logistic regression dataset with
+latent weights ("w") and intercept, passed into a Bernoulli random variable.
+Five hundred data points, fit with PyMC3.
+
+True weights and intercept are included as deterministic variables.
+""",
+    ),
 }
 
 

--- a/arviz/data/datasets.py
+++ b/arviz/data/datasets.py
@@ -79,6 +79,29 @@ See https://docs.pymc.io/notebooks/rugby_analytics.html by Peader Coyle
 for more details and references.
 """,
     ),
+    "regression1d": RemoteFileMetadata(
+        filename="regression1d.nc",
+        url="https://ndownloader.figshare.com/files/16254899",
+        checksum="909e8ffe344e196dad2730b1542881ab5729cb0977dd20ba645a532ffa427278",
+        description="""
+A synthetic one dimensional linear regression dataset with latent slope,
+intercept, and noise ("eps"). One hundred data points, fit with PyMC3.
+
+True slope and intercept are included as deterministic variables.
+""",
+    ),
+    "regression10d": RemoteFileMetadata(
+        filename="regression10d.nc",
+        url="https://ndownloader.figshare.com/files/16255736",
+        checksum="c6716ec7e19926ad2a52d6ae4c1d1dd5ddb747e204c0d811757c8e93fcf9f970",
+        description="""
+A synthetic multi-dimensional (10 dimensions) linear regression dataset with
+latent weights ("w"), intercept, and noise ("eps"). Five hundred data points,
+fit with PyMC3.
+
+True weights and intercept are included as deterministic variables.
+""",
+    ),
 }
 
 


### PR DESCRIPTION
This adds two synthetic datasets to figshare, and then to arviz. They are both synthetic datasets, and described in the PR. Fixes #242. 

Will merge before scipy sprints start if there are no objections in the meantime.

![image](https://user-images.githubusercontent.com/2295568/61166983-34248300-a4fd-11e9-9e70-317e9806d5d1.png)
