### PR TITLE
Update CmdStanPy fit class name

### DIFF
--- a/arviz/data/converters.py
+++ b/arviz/data/converters.py
@@ -67,14 +67,14 @@ def convert_to_inference_data(obj, *, group="posterior", coords=None, dims=None,
         else:
             return InferenceData.from_netcdf(obj)
     elif (
-        obj.__class__.__name__ in {"StanFit4Model", "RunSet"}
+        obj.__class__.__name__ in {"StanFit4Model", "StanFit"}
         or obj.__class__.__module__ == "stan.fit"
     ):
         if group == "sample_stats":
             kwargs["posterior"] = kwargs.pop(group)
         elif group == "sample_stats_prior":
             kwargs["prior"] = kwargs.pop(group)
-        if obj.__class__.__name__ == "RunSet":
+        if obj.__class__.__name__ == "StanFit":
             return from_cmdstanpy(**kwargs)
         else:  # pystan or pystan3
             return from_pystan(**kwargs)

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -93,6 +93,7 @@ Data
     to_netcdf
     from_netcdf
     from_cmdstan
+    from_cmdstanpy
     from_dict
     from_emcee
     from_pymc3


### PR DESCRIPTION
Small fix, this should only affect the convert functions and the `from_cmdstanpy` already works.

    RunSet --> StanFit

CmdStanPy is now in pypi https://pypi.org/project/cmdstanpy/