### PR TITLE
Add line break fix for warning

### DIFF
--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -974,10 +974,9 @@ def waic(data, pointwise=False, scale="deviance"):
     warn_mg = False
     if np.any(vars_lpd > 0.4):
         warnings.warn(
-            """For one or more samples the posterior variance of the log predictive
-        densities exceeds 0.4. This could be indication of WAIC starting to fail see
-        http://arxiv.org/abs/1507.04544 for details
-        """
+            ("For one or more samples the posterior variance of the log predictive "
+             "densities exceeds 0.4. This could be indication of WAIC starting to fail. \n"
+             "See http://arxiv.org/abs/1507.04544 for details")
         )
         warn_mg = True
 

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -974,9 +974,11 @@ def waic(data, pointwise=False, scale="deviance"):
     warn_mg = False
     if np.any(vars_lpd > 0.4):
         warnings.warn(
-            ("For one or more samples the posterior variance of the log predictive "
-             "densities exceeds 0.4. This could be indication of WAIC starting to fail. \n"
-             "See http://arxiv.org/abs/1507.04544 for details")
+            (
+                "For one or more samples the posterior variance of the log predictive "
+                "densities exceeds 0.4. This could be indication of WAIC starting to fail. \n"
+                "See http://arxiv.org/abs/1507.04544 for details"
+            )
         )
         warn_mg = True
 


### PR DESCRIPTION
I didn't like the warning message having a bunch of line breaks like this

![image](https://user-images.githubusercontent.com/7213793/61649548-8c2e5880-ac66-11e9-92b3-ab9a71b7901a.png)

So I made some changes
