### PR TITLE
preallocate potentially large arrays

### DIFF
--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -265,10 +265,10 @@ def _zip_dims(new_dims, vals):
 
 
 def xarray_sel_iter(data, var_names=None, combined=False, skip_dims=None, reverse_selections=False):
-    """Convert xarray data to an iterator over vectors.
+    """Convert xarray data to an iterator over variable names and selections.
 
-    Iterates over each var_name and all of its coordinates, returning the 1d
-    data.
+    Iterates over each var_name and all of its coordinates, returning the variable
+    names and selections that allow properly obtain the data from ``data`` as desired.
 
     Parameters
     ----------
@@ -293,7 +293,6 @@ def xarray_sel_iter(data, var_names=None, combined=False, skip_dims=None, revers
         The string is the variable name, the dictionary are coordinate names to values,.
         To get the values of the variable at these coordinates, do
         ``data[var_name].sel(**selection)``.
-        and the array are the values of the variable at those coordinates.
     """
     if skip_dims is None:
         skip_dims = set()

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -322,7 +322,6 @@ def xarray_sel_iter(data, var_names=None, combined=False, skip_dims=None, revers
                 yield var_name, selection
 
 
-
 def xarray_var_iter(data, var_names=None, combined=False, skip_dims=None, reverse_selections=False):
     """Convert xarray data to an iterator over vectors.
 
@@ -361,7 +360,7 @@ def xarray_var_iter(data, var_names=None, combined=False, skip_dims=None, revers
         var_names=var_names,
         combined=combined,
         skip_dims=skip_dims,
-        reverse_selections=reverse_selections
+        reverse_selections=reverse_selections,
     ):
         yield var_name, selection, data_to_sel[var_name].sel(**selection).values
 

--- a/arviz/plots/ppcplot.py
+++ b/arviz/plots/ppcplot.py
@@ -380,11 +380,12 @@ def plot_ppc(
 
             else:
                 # run plot_kde manually with one plot call
-                pp_densities = []
-                for vals in pp_sampled_vals:
+                pp_densities = np.empty((2 * len(pp_sampled_vals), pp_sampled_vals[0].size))
+                for idx, vals in enumerate(pp_sampled_vals):
                     vals = np.array([vals]).flatten()
                     pp_x, pp_density = _empirical_cdf(vals)
-                    pp_densities.extend([pp_x, pp_density])
+                    pp_densities[2 * idx] = pp_x
+                    pp_densities[2 * idx + 1] = pp_density
 
                 ax_i.plot(
                     *pp_densities, alpha=alpha, color="C5", drawstyle=drawstyle, linewidth=linewidth

--- a/arviz/plots/ppcplot.py
+++ b/arviz/plots/ppcplot.py
@@ -379,7 +379,6 @@ def plot_ppc(
                 )
 
             else:
-                # run plot_kde manually with one plot call
                 pp_densities = np.empty((2 * len(pp_sampled_vals), pp_sampled_vals[0].size))
                 for idx, vals in enumerate(pp_sampled_vals):
                     vals = np.array([vals]).flatten()

--- a/arviz/plots/rankplot.py
+++ b/arviz/plots/rankplot.py
@@ -118,11 +118,10 @@ def plot_rank(data, var_names=None, coords=None, bins=None, ref_line=True, figsi
 
     for ax, (var_name, selection, var_data) in zip(axes.ravel(), plotters):
         ranks = scipy.stats.rankdata(var_data).reshape(var_data.shape)
-        all_counts = []
-        for row in ranks:
-            counts, bin_ary = _rank_hist(row, bins, ranks.size)
-            all_counts.append(counts)
-        all_counts = np.array(all_counts)
+        bin_ary = np.histogram_bin_edges(ranks, bins=bins, range=(0, ranks.size))
+        all_counts = np.empty((len(ranks), len(bin_ary) - 1))
+        for idx, row in enumerate(ranks):
+            all_counts[idx] = _rank_hist(row, bins=bin_ary)[0]
         gap = all_counts.max() * 1.05
         width = bin_ary[1] - bin_ary[0]
 

--- a/arviz/plots/rankplot.py
+++ b/arviz/plots/rankplot.py
@@ -155,5 +155,5 @@ def plot_rank(data, var_names=None, coords=None, bins=None, ref_line=True, figsi
 
 
 @conditional_jit
-def _rank_hist(data, bins, size):
-    return np.histogram(data, bins, range=(0, size))
+def _rank_hist(data, bins):
+    return np.histogram(data, bins)


### PR DESCRIPTION
As discussed in slack, this PR will try to improve performance (mainly RAM usage, but in some cases, execution time will improve too) by preallocating large arrays instead of having them grow inside loops.