### PR TITLE
grid lines in plot_forest

### DIFF
--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -208,7 +208,6 @@ def plot_forest(
         idx += 1
 
     for ax in axes:
-        ax.grid(False)
         # Remove ticklines on y-axes
         ax.tick_params(axis="y", left=False, right=False)
 

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -208,6 +208,7 @@ def plot_forest(
         idx += 1
 
     for ax in axes:
+        ax.grid(False, axis="x")
         # Remove ticklines on y-axes
         ax.tick_params(axis="y", left=False, right=False)
 

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -208,7 +208,10 @@ def plot_forest(
         idx += 1
 
     for ax in axes:
-        ax.grid(False, axis="x")
+        if kind == "ridgeplot":
+            ax.grid(False)
+        else:
+            ax.grid(False, axis="y")
         # Remove ticklines on y-axes
         ax.tick_params(axis="y", left=False, right=False)
 


### PR DESCRIPTION
Fixes https://github.com/pymc-devs/pymc3/issues/3515. I am not sure if just like this is enough or if we have strong aesthetic arguments against grid lines in forestplot. It can always be sub-seeded to a `grid` argument defaulting to false.