### PR TITLE
Add ax argument to plot_ppc

### DIFF
--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -548,13 +548,17 @@ def test_plot_ppc_ax(models, kind, fig_ax):
     axes = plot_ppc(models.model_1, kind=kind, ax=ax)
     assert axes[0] is ax
 
+
 def test_plot_ppc_bad_ax(models, fig_ax):
     _, ax = fig_ax
     _, ax2 = plt.subplots(1, 2)
     with pytest.raises(ValueError, match="same figure"):
-        plot_ppc(models.model_1, ax=[ax, *ax2], flatten=[], coords={"obs_dim": [1, 2, 3]}, animated=True)
+        plot_ppc(
+            models.model_1, ax=[ax, *ax2], flatten=[], coords={"obs_dim": [1, 2, 3]}, animated=True
+        )
     with pytest.raises(ValueError, match="2 axes"):
         plot_ppc(models.model_1, ax=ax2)
+
 
 @pytest.mark.parametrize("var_names", (None, "mu", ["mu", "tau"]))
 def test_plot_violin(models, var_names):

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -541,6 +541,21 @@ def test_plot_ppc_bad(models, kind):
         plot_ppc(models.model_1, num_pp_samples="bad_val")
 
 
+@pytest.mark.parametrize("kind", ["density", "cumulative", "scatter"])
+def test_plot_ppc_ax(models, kind, fig_ax):
+    """Test ax argument of plot_ppc."""
+    _, ax = fig_ax
+    axes = plot_ppc(models.model_1, kind=kind, ax=ax)
+    assert axes[0] is ax
+
+def test_plot_ppc_bad_ax(models, fig_ax):
+    _, ax = fig_ax
+    _, ax2 = plt.subplots(1, 2)
+    with pytest.raises(ValueError, match="same figure"):
+        plot_ppc(models.model_1, ax=[ax, *ax2], flatten=[], coords={"obs_dim": [1, 2, 3]}, animated=True)
+    with pytest.raises(ValueError, match="2 axes"):
+        plot_ppc(models.model_1, ax=ax2)
+
 @pytest.mark.parametrize("var_names", (None, "mu", ["mu", "tau"]))
 def test_plot_violin(models, var_names):
     axes = plot_violin(models.model_1, var_names=var_names)


### PR DESCRIPTION
Add `ax` argument to `plot_ppc`. I have added checks for the number of axes and for having all axes in the same figure when `animated=Ture` in `plot_ppc` and tests to assert both the new argument and the checks work.