### PR TITLE
plot_ppc: change mean computation

### DIFF
--- a/arviz/plots/ppcplot.py
+++ b/arviz/plots/ppcplot.py
@@ -304,41 +304,53 @@ def plot_ppc(
                     drawstyle=plot_kwargs["drawstyle"],
                 )
 
+            pp_densities = []
+            pp_xs = []
+            for vals in pp_sampled_vals:
+                vals = np.array([vals]).flatten()
+                if dtype == "f":
+                    pp_density, lower, upper = _fast_kde(vals)
+                    pp_x = np.linspace(lower, upper, len(pp_density))
+                    pp_densities.append(pp_density)
+                    pp_xs.append(pp_x)
+                else:
+                    bins = get_bins(vals)
+                    hist, bin_edges = np.histogram(vals, bins=bins, density=True)
+                    hist = np.concatenate((hist[:1], hist))
+                    pp_densities.append(hist)
+                    pp_xs.append(bin_edges)
+
             if animated:
                 animate, init = _set_animation(
                     pp_sampled_vals, ax_i, dtype=dtype, kind=kind, plot_kwargs=plot_kwargs
                 )
 
             else:
-                # run plot_kde manually with one plot call
-                pp_densities = []
-                for vals in pp_sampled_vals:
-                    vals = np.array([vals]).flatten()
-                    if dtype == "f":
-                        pp_density, lower, upper = _fast_kde(vals)
-                        pp_x = np.linspace(lower, upper, len(pp_density))
-                        pp_densities.extend([pp_x, pp_density])
-                    else:
-                        bins = get_bins(vals)
-                        hist, bin_edges = np.histogram(vals, bins=bins, density=True)
-                        hist = np.concatenate((hist[:1], hist))
-                        pp_densities.extend([bin_edges, hist])
-
-                ax_i.plot(*pp_densities, **plot_kwargs)
+                if dtype == "f":
+                    ax_i.plot(np.transpose(pp_xs), np.transpose(pp_densities), **plot_kwargs)
+                else:
+                    for xs, ys in zip(pp_xs, pp_densities):
+                        ax_i.plot(xs, ys, **plot_kwargs)
 
             if mean:
                 if dtype == "f":
-                    plot_kde(
-                        pp_vals.flatten(),
-                        plot_kwargs={
-                            "color": "C0",
-                            "linestyle": "--",
-                            "linewidth": linewidth,
-                            "zorder": 2,
-                        },
+                    rep = len(pp_densities)
+                    len_density = len(pp_densities[0])
+
+                    new_x = np.linspace(np.min(pp_xs), np.max(pp_xs), len_density)
+                    new_d = np.zeros((rep, len_density))
+                    bins = np.digitize(pp_xs, new_x, right=True)
+                    new_x -= (new_x[1] - new_x[0]) / 2
+                    for i in range(rep):
+                        new_d[i][bins[i]] = pp_densities[i]
+                    ax_i.plot(
+                        new_x,
+                        new_d.mean(0),
+                        color="C0",
+                        linestyle="--",
+                        linewidth=linewidth,
+                        zorder=2,
                         label="Posterior predictive mean {}".format(pp_var_name),
-                        ax=ax_i,
-                        legend=legend,
                     )
                 else:
                     vals = pp_vals.flatten()

--- a/arviz/plots/ppcplot.py
+++ b/arviz/plots/ppcplot.py
@@ -329,8 +329,8 @@ def plot_ppc(
                 if dtype == "f":
                     ax_i.plot(np.transpose(pp_xs), np.transpose(pp_densities), **plot_kwargs)
                 else:
-                    for xs, ys in zip(pp_xs, pp_densities):
-                        ax_i.plot(xs, ys, **plot_kwargs)
+                    for x_s, y_s in zip(pp_xs, pp_densities):
+                        ax_i.plot(x_s, y_s, **plot_kwargs)
 
             if mean:
                 if dtype == "f":
@@ -341,8 +341,8 @@ def plot_ppc(
                     new_d = np.zeros((rep, len_density))
                     bins = np.digitize(pp_xs, new_x, right=True)
                     new_x -= (new_x[1] - new_x[0]) / 2
-                    for i in range(rep):
-                        new_d[i][bins[i]] = pp_densities[i]
+                    for irep in range(rep):
+                        new_d[irep][bins[irep]] = pp_densities[irep]
                     ax_i.plot(
                         new_x,
                         new_d.mean(0),


### PR DESCRIPTION
This changes how we compute the posterior predictive mean when `kind='density'`. Currently we do a KDE using all the posterior predictive samples as input. With this PR we average the (binned) densities. In an ideal world this should be equivalent, but in practice there are some generally (small) differences. 

One problem with the current implementation is that we could have something like this

![image (2)](https://user-images.githubusercontent.com/1338958/62160757-19b71b80-b2eb-11e9-8e72-595963f2fa07.png)

The mean is not _inside_ the _envelope_ defined by the individual pp samples. This picture is from Chris Fonnesbeck.

In the following examples I reproduce the same effect, although with a less obvious effect, please zoom-in or use a very wide screen :-). The blue lines are the pp samples, the orange lines are the mean using the KDE (over all the pp samples) and the green lines are the average of the densities.

![kde_ppc_N](https://user-images.githubusercontent.com/1338958/62160117-9943eb00-b2e9-11e9-8fe3-b7dd0057ee99.png)

This other example shows a Student-T distribution, and how the new method is better at capturing the shape of the distribution.
 
![kde_ppc_T](https://user-images.githubusercontent.com/1338958/62160130-a365e980-b2e9-11e9-927a-a21e982b3388.png)

notice that when the sample size is _really_ low the KDE (orange) looks like a better approximation and when the sample size is larger the averaged densities looks like a better approximation. Hopefully in the future if we implement an adaptive bandwidth estimation or some other more flexible KDE method this issue will go away. 