### PR TITLE
Remove effective sample size from docs

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -64,7 +64,6 @@ Diagnostics
     bfmi
     geweke
     ess
-    effective_sample_size
     rhat
     mcse
 


### PR DESCRIPTION
`az.effective_sample_size` was removed in #770, but it was still listed in the api section of the docs. 