### PR TITLE
Fix issue with rug values in plot_ess and plot_mcse

### DIFF
--- a/arviz/plots/essplot.py
+++ b/arviz/plots/essplot.py
@@ -1,6 +1,7 @@
 """Plot quantile or local effective sample sizes."""
 import numpy as np
 import xarray as xr
+from scipy.stats import rankdata
 
 from ..data import convert_to_dataset
 from ..stats import ess
@@ -296,7 +297,7 @@ def plot_ess(
 
             values = data[var_name].sel(**selection).values.flatten()
             mask = idata.sample_stats[rug_kind].values.flatten()
-            values = np.argsort(values)[mask]
+            values = rankdata(values)[mask]
             rug_space = np.max(x) * rug_kwargs.pop("space")
             rug_x, rug_y = values / (len(mask) - 1), np.zeros_like(values) - rug_space
             ax_.plot(rug_x, rug_y, **rug_kwargs)

--- a/arviz/plots/mcseplot.py
+++ b/arviz/plots/mcseplot.py
@@ -1,6 +1,7 @@
 """Plot quantile MC standard error."""
 import numpy as np
 import xarray as xr
+from scipy.stats import rankdata
 
 from ..data import convert_to_dataset
 from ..stats import mcse
@@ -194,7 +195,7 @@ def plot_mcse(
             rug_kwargs.setdefault("markersize", rug_kwargs.pop("ms", 2 * _markersize))
 
             mask = idata.sample_stats[rug_kind].values.flatten()
-            values = np.argsort(values)[mask]
+            values = rankdata(values)[mask]
             y_min, y_max = ax_.get_ylim()
             y_min = y_min if errorbar else 0
             rug_space = (y_max - y_min) * rug_kwargs.pop("space")


### PR DESCRIPTION
I don't know why I thought `argsort` could be used for ranking data. Today I have realized that the rug values were not placed where they were supposed to be. Now they are.

![image](https://user-images.githubusercontent.com/23738400/62208034-001ede00-b396-11e9-96ce-e00467d40854.png)

![image](https://user-images.githubusercontent.com/23738400/62208052-0745ec00-b396-11e9-9983-700d8bf6bd67.png)
