### PR TITLE
fix #772

### DIFF
--- a/arviz/plots/ppcplot.py
+++ b/arviz/plots/ppcplot.py
@@ -191,9 +191,10 @@ def plot_ppc(
     posterior_predictive = data.posterior_predictive
 
     if var_names is None:
-        var_names = observed.data_vars
+        var_names = list(observed.data_vars)
     var_names = _var_names(var_names, observed)
     pp_var_names = [data_pairs.get(var, var) for var in var_names]
+    pp_var_names = _var_names(pp_var_names, posterior_predictive)
 
     if flatten_pp is None and flatten is None:
         flatten_pp = list(posterior_predictive.dims.keys())

--- a/arviz/tests/test_utils.py
+++ b/arviz/tests/test_utils.py
@@ -48,6 +48,11 @@ def test_var_names_warning():
         assert _var_names(var_names, data) == expected
 
 
+def test_var_names_key_error(data):
+    with pytest.raises(KeyError, match="bad_var_name"):
+        _var_names(("theta", "tau", "bad_var_name"), data)
+
+
 @pytest.fixture(scope="function")
 def utils_with_numba_import_fail(monkeypatch):
     """Patch numba in utils so when its imported it raises ImportError"""

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -33,13 +33,6 @@ def _var_names(var_names, data):
         else:
             all_vars = list(data.data_vars)
 
-        existent_vars = np.isin(var_names, all_vars)
-        if not np.all(existent_vars):
-            raise KeyError(
-                "{} var names are not present in dataset".format(
-                    np.array(var_names)[~existent_vars]
-                )
-            )
         excluded_vars = [i[1:] for i in var_names if i.startswith("~") and i not in all_vars]
 
         all_vars_tilde = [i for i in all_vars if i.startswith("~")]
@@ -55,6 +48,14 @@ def _var_names(var_names, data):
 
         if excluded_vars:
             var_names = [i for i in all_vars if i not in excluded_vars]
+
+        existent_vars = np.isin(var_names, all_vars)
+        if not np.all(existent_vars):
+            raise KeyError(
+                "{} var names are not present in dataset".format(
+                    np.array(var_names)[~existent_vars]
+                )
+            )
 
     return var_names
 

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -33,6 +33,13 @@ def _var_names(var_names, data):
         else:
             all_vars = list(data.data_vars)
 
+        existent_vars = np.isin(var_names, all_vars)
+        if not np.all(existent_vars):
+            raise KeyError(
+                "{} var names are not present in dataset".format(
+                    np.array(var_names)[~existent_vars]
+                )
+            )
         excluded_vars = [i[1:] for i in var_names if i.startswith("~") and i not in all_vars]
 
         all_vars_tilde = [i for i in all_vars if i.startswith("~")]


### PR DESCRIPTION
This fix should work for all functions as they all use `_var_names` at some point. Now the error in `summary` will be risen here in `_var_names` and will highlight all non present variables, and the plotting functions will raise an error.