### PR TITLE
fix from_pymc bug for multivariate observations

### DIFF
--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -52,7 +52,7 @@ class PyMC3Converter:
             return None, None
         else:
             if self.dims is not None:
-                coord_name = self.dims.get(model.observed_RVs[0].name)
+                coord_name = self.dims.get("log_likelihood", self.dims.get(model.observed_RVs[0].name))
             else:
                 coord_name = None
 

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -52,7 +52,9 @@ class PyMC3Converter:
             return None, None
         else:
             if self.dims is not None:
-                coord_name = self.dims.get("log_likelihood", self.dims.get(model.observed_RVs[0].name))
+                coord_name = self.dims.get(
+                    "log_likelihood", self.dims.get(model.observed_RVs[0].name)
+                )
             else:
                 coord_name = None
 


### PR DESCRIPTION
`from_pymc` would overwrite the "log_likelihood" dimensions defined in "dims" parameter, which in multivariate cases where the shape of the observations and of the log likelihood is different gives an error of wrong number of dimensions. 

I have left using the same dims as the observed data as a default, which in most cases is the case, but giving preference to "log_likelihood" dimensions defined in the dims argument in case they are present.

I am not sure if there should be a test for this, I can add one.