### PR TITLE
Add var name in LOO-PIT legend [GSOC]

### DIFF
--- a/arviz/plots/loopitplot.py
+++ b/arviz/plots/loopitplot.py
@@ -3,6 +3,7 @@ import numpy as np
 import scipy.stats as stats
 import matplotlib.pyplot as plt
 from matplotlib.colors import to_rgb, rgb_to_hsv, hsv_to_rgb
+from xarray import DataArray
 
 from ..stats import loo_pit as _loo_pit
 from .plot_utils import _scale_fig_size
@@ -131,15 +132,14 @@ def plot_loo_pit(
         plot_kwargs = {}
     plot_kwargs["color"] = color
     plot_kwargs.setdefault("linewidth", linewidth * 1.4)
-    if idata is None:
-        try:
-            label = ("{} LOO-PIT ECDF" if ecdf else "{} LOO-PIT").format(y.name)
-        except AttributeError:
-            label = "LOO-PIT ECDF" if ecdf else "LOO-PIT"
-    elif isinstance(y, str):
+    if isinstance(y, str):
         label = ("{} LOO-PIT ECDF" if ecdf else "{} LOO-PIT").format(y)
+    elif isinstance(y, DataArray):
+            label = ("{} LOO-PIT ECDF" if ecdf else "{} LOO-PIT").format(y.name)
     elif isinstance(y_hat, str):
         label = ("{} LOO-PIT ECDF" if ecdf else "{} LOO-PIT").format(y_hat)
+    elif isinstance(y_hat, DataArray):
+        label = ("{} LOO-PIT ECDF" if ecdf else "{} LOO-PIT").format(y_hat.name)
     else:
         label = "LOO-PIT ECDF" if ecdf else "LOO-PIT"
 

--- a/arviz/plots/loopitplot.py
+++ b/arviz/plots/loopitplot.py
@@ -143,7 +143,6 @@ def plot_loo_pit(
     else:
         label = "LOO-PIT ECDF" if ecdf else "LOO-PIT"
 
-
     plot_kwargs.setdefault("label", label)
     plot_kwargs.setdefault("zorder", 5)
 
@@ -155,7 +154,6 @@ def plot_loo_pit(
     plot_unif_kwargs.setdefault("color", hsv_to_rgb(light_color))
     plot_unif_kwargs.setdefault("alpha", 0.5)
     plot_unif_kwargs.setdefault("linewidth", 0.6 * linewidth)
-
 
     if ecdf:
         loo_pit.sort()

--- a/arviz/plots/loopitplot.py
+++ b/arviz/plots/loopitplot.py
@@ -124,11 +124,27 @@ def plot_loo_pit(
     if ax is None:
         _, ax = plt.subplots(1, 1, figsize=figsize, constrained_layout=True)
 
+    loo_pit = _loo_pit(idata=idata, y=y, y_hat=y_hat, log_weights=log_weights)
+    loo_pit = loo_pit.flatten() if isinstance(loo_pit, np.ndarray) else loo_pit.values.flatten()
+
     if plot_kwargs is None:
         plot_kwargs = {}
     plot_kwargs["color"] = color
     plot_kwargs.setdefault("linewidth", linewidth * 1.4)
-    plot_kwargs.setdefault("label", "LOO-PIT ECDF" if ecdf else "LOO-PIT")
+    if idata is None:
+        try:
+            label = ("{} LOO-PIT ECDF" if ecdf else "{} LOO-PIT").format(y.name)
+        except AttributeError:
+            label = "LOO-PIT ECDF" if ecdf else "LOO-PIT"
+    elif isinstance(y, str):
+        label = ("{} LOO-PIT ECDF" if ecdf else "{} LOO-PIT").format(y)
+    elif isinstance(y_hat, str):
+        label = ("{} LOO-PIT ECDF" if ecdf else "{} LOO-PIT").format(y_hat)
+    else:
+        label = "LOO-PIT ECDF" if ecdf else "LOO-PIT"
+
+
+    plot_kwargs.setdefault("label", label)
     plot_kwargs.setdefault("zorder", 5)
 
     if plot_unif_kwargs is None:
@@ -140,8 +156,6 @@ def plot_loo_pit(
     plot_unif_kwargs.setdefault("alpha", 0.5)
     plot_unif_kwargs.setdefault("linewidth", 0.6 * linewidth)
 
-    loo_pit = _loo_pit(idata=idata, y=y, y_hat=y_hat, log_weights=log_weights)
-    loo_pit = loo_pit.flatten() if isinstance(loo_pit, np.ndarray) else loo_pit.values.flatten()
 
     if ecdf:
         loo_pit.sort()

--- a/arviz/plots/loopitplot.py
+++ b/arviz/plots/loopitplot.py
@@ -135,7 +135,7 @@ def plot_loo_pit(
     if isinstance(y, str):
         label = ("{} LOO-PIT ECDF" if ecdf else "{} LOO-PIT").format(y)
     elif isinstance(y, DataArray):
-            label = ("{} LOO-PIT ECDF" if ecdf else "{} LOO-PIT").format(y.name)
+        label = ("{} LOO-PIT ECDF" if ecdf else "{} LOO-PIT").format(y.name)
     elif isinstance(y_hat, str):
         label = ("{} LOO-PIT ECDF" if ecdf else "{} LOO-PIT").format(y_hat)
     elif isinstance(y_hat, DataArray):

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -1010,13 +1010,16 @@ def test_plot_loo_pit_incompatible_args(models):
         plot_loo_pit(idata=models.model_1, y="y", ecdf=True, use_hpd=True)
 
 
-@pytest.mark.parametrize("args", [
-    {"y": "str"},
-    {"y": "DataArray", "y_hat": "str"},
-    {"y": "ndarray", "y_hat": "str"},
-    {"y": "ndarray", "y_hat": "DataArray"},
-    {"y": "ndarray", "y_hat": "ndarray"},
-])
+@pytest.mark.parametrize(
+    "args",
+    [
+        {"y": "str"},
+        {"y": "DataArray", "y_hat": "str"},
+        {"y": "ndarray", "y_hat": "str"},
+        {"y": "ndarray", "y_hat": "DataArray"},
+        {"y": "ndarray", "y_hat": "ndarray"},
+    ],
+)
 def test_plot_loo_pit_label(models, args):
     assert_name = args["y"] != "ndarray" or args.get("y_hat") != "ndarray"
 
@@ -1041,6 +1044,7 @@ def test_plot_loo_pit_label(models, args):
         assert "y" in ax.get_legend_handles_labels()[1][0]
     else:
         assert "y" not in ax.get_legend_handles_labels()[1][0]
+
 
 @pytest.mark.parametrize(
     "kwargs",

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -1010,6 +1010,38 @@ def test_plot_loo_pit_incompatible_args(models):
         plot_loo_pit(idata=models.model_1, y="y", ecdf=True, use_hpd=True)
 
 
+@pytest.mark.parametrize("args", [
+    {"y": "str"},
+    {"y": "DataArray", "y_hat": "str"},
+    {"y": "ndarray", "y_hat": "str"},
+    {"y": "ndarray", "y_hat": "DataArray"},
+    {"y": "ndarray", "y_hat": "ndarray"},
+])
+def test_plot_loo_pit_label(models, args):
+    assert_name = args["y"] != "ndarray" or args.get("y_hat") != "ndarray"
+
+    if args["y"] == "str":
+        y = "y"
+    elif args["y"] == "DataArray":
+        y = models.model_1.observed_data.y
+    elif args["y"] == "ndarray":
+        y = models.model_1.observed_data.y.values
+
+    if args.get("y_hat") == "str":
+        y_hat = "y"
+    elif args.get("y_hat") == "DataArray":
+        y_hat = models.model_1.posterior_predictive.y.stack(samples=("chain", "draw"))
+    elif args.get("y_hat") == "ndarray":
+        y_hat = models.model_1.posterior_predictive.y.stack(samples=("chain", "draw")).values
+    else:
+        y_hat = None
+
+    ax = plot_loo_pit(idata=models.model_1, y=y, y_hat=y_hat)
+    if assert_name:
+        assert "y" in ax.get_legend_handles_labels()[1][0]
+    else:
+        assert "y" not in ax.get_legend_handles_labels()[1][0]
+
 @pytest.mark.parametrize(
     "kwargs",
     [


### PR DESCRIPTION
At first I decided to not include the variable name in the LOO-PIT plot, but I am changing my mind. I have not followed plot_ppc and used the var_name as xlabel, because unlike there, the x values are not variable values. I am inclined towards adding the name in the legend, but the title could also be an option. Now it looks like this, it is a minor change.

![image](https://user-images.githubusercontent.com/23738400/62305690-b828b580-b480-11e9-9cca-84014dfdd0d5.png)
