### PR TITLE
Numba Ahead of Time Compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,10 @@ target/
 .idea/
 
 saved_animations/
+
+bin/
+get-pip.py
+lib64
+pyvenv.cfg
+share/
+

--- a/arviz/aot.py
+++ b/arviz/aot.py
@@ -1,6 +1,6 @@
-from numba.pycc import CC
 import numpy as np
 import numba
+from numba.pycc import CC
 
 module = CC("numba_compilations")
 

--- a/arviz/aot.py
+++ b/arviz/aot.py
@@ -1,3 +1,4 @@
+"""Numba Ahead of Time compilation script."""
 import numpy as np
 import numba
 from numba.pycc import CC

--- a/arviz/aot.py
+++ b/arviz/aot.py
@@ -2,7 +2,7 @@ from numba.pycc import CC
 import numba
 import numpy as np
 
-module = CC('numba-compilations')
+module = CC("numba-compilations")
 
 
 @numba.njit
@@ -16,7 +16,7 @@ def stats_variance_1d(data, ddof=0):
     return var
 
 
-@module.export('stats_variance_2d', 'f8[:](f8[:],i8,i8)')
+@module.export("stats_variance_2d", "f8[:](f8[:],i8,i8)")
 def stats_variance_2d(data, ddof=0, axis=1):
     if data.ndim == 1:
         return stats_variance_1d(data, ddof=ddof)
@@ -34,29 +34,29 @@ def stats_variance_2d(data, ddof=0, axis=1):
 
 
 # Remember to flatten the array before when using this method
-@module.export('histogram_stats', 'f8[:](f8[:],f8[:]')
+@module.export("histogram_stats", "f8[:](f8[:],f8[:]")
 def histogram_stats(data, bins):
     return np.histogram(data, bins=bins)[0]
 
 
 # Remember to flatten the array before when using this method
-@module.export('histogram_kde', 'f8[:](f8[:],i8,(f8,f8)')
+@module.export("histogram_kde", "f8[:](f8[:],i8,(f8,f8)")
 def histogram_plots(x, n_bins, range_hist=None):
     grid, _ = np.histogram(x, bins=n_bins, range=range_hist)
     return grid
 
 
-@module.export('dot', 'f8[:], f8[:]')
-@module.export('dot', 'f8[:,:], f8[:,:]')
+@module.export("dot", "f8[:], f8[:]")
+@module.export("dot", "f8[:,:], f8[:,:]")
 def dot(x, y):
     return np.dot(x, y)
 
 
-#Alter the
-@module.export('full', 'f8[:](i8)')
-@module.export('full', 'f8[:,:](i8,i8)')
-@module.export('full', 'f8[:,:,:](i8,i8,i8')
-@module.export('full', 'f8[:,:,:,:](i8,i8,i8,i8')
+# Alter the
+@module.export("full", "f8[:](i8)")
+@module.export("full", "f8[:,:](i8,i8)")
+@module.export("full", "f8[:,:,:](i8,i8,i8")
+@module.export("full", "f8[:,:,:,:](i8,i8,i8,i8")
 def full(shape):
     """Jitting numpy full."""
     return np.full(shape, np.nan)

--- a/arviz/aot.py
+++ b/arviz/aot.py
@@ -1,0 +1,40 @@
+from numba.pycc import CC
+import numba
+import numpy as np
+
+module = CC('numba-compilations')
+
+
+@numba.njit
+def stats_variance_1d(data, ddof=0):
+    a_a, b_b = 0, 0
+    for i in data:
+        a_a = a_a + i
+        b_b = b_b + i * i
+    var = b_b / (len(data)) - ((a_a / (len(data))) ** 2)
+    var = var * (len(data) / (len(data) - ddof))
+    return var
+
+
+@module.export('stats_variance_2d', 'f8[:](f8[:],i8,i8)')
+def stats_variance_2d(data, ddof=0, axis=1):
+    if data.ndim == 1:
+        return stats_variance_1d(data, ddof=ddof)
+    a_a, b_b = data.shape
+    if axis == 1:
+        var = np.zeros(a_a)
+        for i in range(a_a):
+            var[i] = stats_variance_1d(data[i], ddof=ddof)
+        return var
+    else:
+        var = np.zeros(b_b)
+        for i in range(b_b):
+            var[i] = stats_variance_1d(data[:, i], ddof=ddof)
+        return var
+
+
+# Remember to flatten the array before when using this method
+@module.export('histogram_stats', 'f8[:](f8[:],f8[:]')
+@module.export('histogram_stats', 'f8[:](i8[:],f8[:]')
+def histogram_stats(data, bins):
+    return np.histogram(data, bins=bins)[0]

--- a/arviz/aot.py
+++ b/arviz/aot.py
@@ -51,3 +51,12 @@ def histogram_plots(x, n_bins, range_hist=None):
 def dot(x, y):
     return np.dot(x, y)
 
+
+#Alter the
+@module.export('full', 'f8[:](i8)')
+@module.export('full', 'f8[:,:](i8,i8)')
+@module.export('full', 'f8[:,:,:](i8,i8,i8')
+@module.export('full', 'f8[:,:,:,:](i8,i8,i8,i8')
+def full(shape):
+    """Jitting numpy full."""
+    return np.full(shape, np.nan)

--- a/arviz/aot.py
+++ b/arviz/aot.py
@@ -1,11 +1,11 @@
 from numba.pycc import CC
-import numba
 import numpy as np
+import numba
 
 module = CC("numba-compilations")
 
 
-@numba.njit
+@module.export("stats_variance_1d", "(f8[:],i8)")
 def stats_variance_1d(data, ddof=0):
     a_a, b_b = 0, 0
     for i in data:
@@ -16,33 +16,47 @@ def stats_variance_1d(data, ddof=0):
     return var
 
 
-@module.export("stats_variance_2d", "f8[:](f8[:],i8,i8)")
+@numba.njit
+def stats_variance_1d_2d(data, ddof=0):
+    a_a, b_b = 0, 0
+    for i in data:
+        a_a = a_a + i
+        b_b = b_b + i * i
+    var = b_b / (len(data)) - ((a_a / (len(data))) ** 2)
+    var = var * (len(data) / (len(data) - ddof))
+    return var
+
+
+@module.export("stats_variance_2d", "f8[:](f8[:,:],i8,i8)")
 def stats_variance_2d(data, ddof=0, axis=1):
-    if data.ndim == 1:
-        return stats_variance_1d(data, ddof=ddof)
     a_a, b_b = data.shape
     if axis == 1:
         var = np.zeros(a_a)
         for i in range(a_a):
-            var[i] = stats_variance_1d(data[i], ddof=ddof)
+            var[i] = stats_variance_1d_2d(data[i], ddof=ddof)
         return var
     else:
         var = np.zeros(b_b)
         for i in range(b_b):
-            var[i] = stats_variance_1d(data[:, i], ddof=ddof)
+            var[i] = stats_variance_1d_2d(data[:, i], ddof=ddof)
         return var
 
 
 # Remember to flatten the array before when using this method
-@module.export("histogram_stats", "f8[:](f8[:],f8[:]")
+@module.export("histogram_stats", "i8[:](f8[:],f8[:])")
+@module.export("histogram_stats", "f8[:](f8[:],f8[:])")
+@module.export("histogram_stats", "f8[:](f8[:],i8[:])")
+@module.export("histogram_stats", "f8[:](f8[:],f8)")
+@module.export("histogram_stats", "f8[:](f8[:],i8)")
 def histogram_stats(data, bins):
-    return np.histogram(data, bins=bins)[0]
+    grid, _ = np.histogram(data, bins=bins)
+    return grid
 
 
 # Remember to flatten the array before when using this method
-@module.export("histogram_kde", "f8[:](f8[:],i8,(f8,f8)")
-def histogram_plots(x, n_bins, range_hist=None):
-    grid, _ = np.histogram(x, bins=n_bins, range=range_hist)
+@module.export("histogram_kde", "f8[:](f8[:],i8,f8,f8)")
+def histogram_plots(x, n_bins, xmax, xmin):
+    grid, _ = np.histogram(x, bins=n_bins, range=(xmax, xmin))
     return grid
 
 
@@ -60,3 +74,7 @@ def dot(x, y):
 def full(shape):
     """Jitting numpy full."""
     return np.full(shape, np.nan)
+
+
+if __name__ == "__main__":
+    module.compile()

--- a/arviz/aot.py
+++ b/arviz/aot.py
@@ -6,7 +6,7 @@ module = CC("numba-compilations")
 
 
 @module.export("stats_variance_1d", "(f8[:],i8)")
-def stats_variance_1d(data, ddof=0):
+def stats_variance_1d(data, ddof=0):  # perform type conversion before calling the function.
     a_a, b_b = 0, 0
     for i in data:
         a_a = a_a + i
@@ -27,7 +27,7 @@ def stats_variance_1d_2d(data, ddof=0):
     return var
 
 
-@module.export("stats_variance_2d", "f8[:](f8[:,:],i8,i8)")
+@module.export("stats_variance_2d", "f8[:](f8[:,:],i8,i8)")  # perform type conversion before calling the function.
 def stats_variance_2d(data, ddof=0, axis=1):
     a_a, b_b = data.shape
     if axis == 1:

--- a/arviz/aot.py
+++ b/arviz/aot.py
@@ -3,10 +3,10 @@ import numpy as np
 import numba
 from numba.pycc import CC
 
-module = CC("numba_compilations")
+MODULE = CC("numba_compilations")
 
 
-@module.export("stats_variance_1d", "(f8[:],i8)")
+@MODULE.export("stats_variance_1d", "(f8[:],i8)")
 def stats_variance_1d(data, ddof=0):
     """Pre compiled method to get 1d variance."""
     a_a, b_b = 0, 0
@@ -29,7 +29,7 @@ def _stats_variance_1d_2d(data, ddof=0):
     return var
 
 
-@module.export("stats_variance_2d", "f8[:](f8[:,:],i8,i8)")
+@MODULE.export("stats_variance_2d", "f8[:](f8[:,:],i8,i8)")
 def stats_variance_2d(data, ddof=0, axis=1):
     """Pre compiled method to get 2d variance."""
     a_a, b_b = data.shape
@@ -46,4 +46,4 @@ def stats_variance_2d(data, ddof=0, axis=1):
 
 
 if __name__ == "__main__":
-    module.compile()
+    MODULE.compile()

--- a/arviz/aot.py
+++ b/arviz/aot.py
@@ -42,41 +42,5 @@ def stats_variance_2d(data, ddof=0, axis=1):
         return var
 
 
-# Remember to flatten the array before when using this method
-@module.export("histogram_stats", "i8[:](i8[:],i8[:])")
-@module.export("histogram_stats", "f8[:](f8[:],f8[:])")
-@module.export("histogram_stats", "f8[:](f8[:],i8[:])")
-@module.export("histogram_stats", "f8[:](f8[:],f8)")
-@module.export("histogram_stats", "f8[:](f8[:],i8)")
-def histogram_stats(data, bins):
-    grid, _ = np.histogram(data, bins=bins)
-    return grid
-
-
-# Remember to flatten the array before when using this method
-@module.export("histogram_kde", "i8[:](i8[:],i8,i8,i8)")
-@module.export("histogram_kde", "f8[:](f8[:],i8,f8,f8)")
-@module.export("histogram_kde", "f8[:](f8[:],f8[:],f8,f8)")
-def histogram_plots(x, n_bins, xmax, xmin):
-    grid, _ = np.histogram(x, bins=n_bins, range=(xmax, xmin))
-    return grid
-
-
-@module.export("dot", "f8[:], f8[:]")
-@module.export("dot", "f8[:,:], f8[:,:]")
-def dot(x, y):
-    return np.dot(x, y)
-
-
-# Alter the
-@module.export("full", "f8[:](i8)")
-@module.export("full", "f8[:,:](i8,i8)")
-@module.export("full", "f8[:,:,:](i8,i8,i8)")
-@module.export("full", "f8[:,:,:,:](i8,i8,i8,i8)")
-def full(shape):
-    """Jitting numpy full."""
-    return np.full(shape, np.nan)
-
-
 if __name__ == "__main__":
     module.compile()

--- a/arviz/aot.py
+++ b/arviz/aot.py
@@ -35,6 +35,19 @@ def stats_variance_2d(data, ddof=0, axis=1):
 
 # Remember to flatten the array before when using this method
 @module.export('histogram_stats', 'f8[:](f8[:],f8[:]')
-@module.export('histogram_stats', 'f8[:](i8[:],f8[:]')
 def histogram_stats(data, bins):
     return np.histogram(data, bins=bins)[0]
+
+
+# Remember to flatten the array before when using this method
+@module.export('histogram_kde', 'f8[:](f8[:],i8,(f8,f8)')
+def histogram_plots(x, n_bins, range_hist=None):
+    grid, _ = np.histogram(x, bins=n_bins, range=range_hist)
+    return grid
+
+
+@module.export('dot', 'f8[:], f8[:]')
+@module.export('dot', 'f8[:,:], f8[:,:]')
+def dot(x, y):
+    return np.dot(x, y)
+

--- a/arviz/aot.py
+++ b/arviz/aot.py
@@ -56,6 +56,7 @@ def histogram_stats(data, bins):
 # Remember to flatten the array before when using this method
 @module.export("histogram_kde", "i8[:](i8[:],i8,i8,i8)")
 @module.export("histogram_kde", "f8[:](f8[:],i8,f8,f8)")
+@module.export("histogram_kde", "f8[:](f8[:],f8[:],f8,f8)")
 def histogram_plots(x, n_bins, xmax, xmin):
     grid, _ = np.histogram(x, bins=n_bins, range=(xmax, xmin))
     return grid

--- a/arviz/aot.py
+++ b/arviz/aot.py
@@ -2,11 +2,10 @@ from numba.pycc import CC
 import numpy as np
 import numba
 
-module = CC("numba-compilations")
-
+module = CC("numba_compilations")
 
 @module.export("stats_variance_1d", "(f8[:],i8)")
-def stats_variance_1d(data, ddof=0):  # perform type conversion before calling the function.
+def stats_variance_1d(data, ddof=0):
     a_a, b_b = 0, 0
     for i in data:
         a_a = a_a + i
@@ -27,7 +26,7 @@ def stats_variance_1d_2d(data, ddof=0):
     return var
 
 
-@module.export("stats_variance_2d", "f8[:](f8[:,:],i8,i8)")  # perform type conversion before calling the function.
+@module.export("stats_variance_2d", "f8[:](f8[:,:],i8,i8)")
 def stats_variance_2d(data, ddof=0, axis=1):
     a_a, b_b = data.shape
     if axis == 1:

--- a/arviz/aot.py
+++ b/arviz/aot.py
@@ -43,7 +43,7 @@ def stats_variance_2d(data, ddof=0, axis=1):
 
 
 # Remember to flatten the array before when using this method
-@module.export("histogram_stats", "i8[:](f8[:],f8[:])")
+@module.export("histogram_stats", "i8[:](i8[:],i8[:])")
 @module.export("histogram_stats", "f8[:](f8[:],f8[:])")
 @module.export("histogram_stats", "f8[:](f8[:],i8[:])")
 @module.export("histogram_stats", "f8[:](f8[:],f8)")
@@ -54,6 +54,7 @@ def histogram_stats(data, bins):
 
 
 # Remember to flatten the array before when using this method
+@module.export("histogram_kde", "i8[:](i8[:],i8,i8,i8)")
 @module.export("histogram_kde", "f8[:](f8[:],i8,f8,f8)")
 def histogram_plots(x, n_bins, xmax, xmin):
     grid, _ = np.histogram(x, bins=n_bins, range=(xmax, xmin))
@@ -69,8 +70,8 @@ def dot(x, y):
 # Alter the
 @module.export("full", "f8[:](i8)")
 @module.export("full", "f8[:,:](i8,i8)")
-@module.export("full", "f8[:,:,:](i8,i8,i8")
-@module.export("full", "f8[:,:,:,:](i8,i8,i8,i8")
+@module.export("full", "f8[:,:,:](i8,i8,i8)")
+@module.export("full", "f8[:,:,:,:](i8,i8,i8,i8)")
 def full(shape):
     """Jitting numpy full."""
     return np.full(shape, np.nan)

--- a/arviz/aot.py
+++ b/arviz/aot.py
@@ -4,8 +4,10 @@ import numba
 
 module = CC("numba_compilations")
 
+
 @module.export("stats_variance_1d", "(f8[:],i8)")
 def stats_variance_1d(data, ddof=0):
+    """Pre compiled method to get 1d variance."""
     a_a, b_b = 0, 0
     for i in data:
         a_a = a_a + i
@@ -16,7 +18,7 @@ def stats_variance_1d(data, ddof=0):
 
 
 @numba.njit
-def stats_variance_1d_2d(data, ddof=0):
+def _stats_variance_1d_2d(data, ddof=0):
     a_a, b_b = 0, 0
     for i in data:
         a_a = a_a + i
@@ -28,16 +30,17 @@ def stats_variance_1d_2d(data, ddof=0):
 
 @module.export("stats_variance_2d", "f8[:](f8[:,:],i8,i8)")
 def stats_variance_2d(data, ddof=0, axis=1):
+    """Pre compiled method to get 2d variance."""
     a_a, b_b = data.shape
     if axis == 1:
         var = np.zeros(a_a)
         for i in range(a_a):
-            var[i] = stats_variance_1d_2d(data[i], ddof=ddof)
+            var[i] = _stats_variance_1d_2d(data[i], ddof=ddof)
         return var
     else:
         var = np.zeros(b_b)
         for i in range(b_b):
-            var[i] = stats_variance_1d_2d(data[:, i], ddof=ddof)
+            var[i] = _stats_variance_1d_2d(data[:, i], ddof=ddof)
         return var
 
 

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -340,7 +340,7 @@ def _histogram(x, n_bins, range_hist=None):
 def _cov_1d(x):
     x = x - x.mean(axis=0)
     ddof = x.shape[0] - 1
-    return np.dot(x.T, x.conj()) / ddof
+    return _dot(x.T, x.conj()) / ddof
 
 
 def _cov(data):


### PR DESCRIPTION
Working on precompiling numba methods. Using Numba AOT instead of jit would make me undo several changes that I have made across the duration of GSoC which might lead to nasty breaks in the code. Therefore, my plan is to include both AOT and JIT in the code for now and implement the changes gradually as the mentors see fit.