### PR TITLE
implement plot.max_subplots rcParam in all functions

### DIFF
--- a/arviz/plots/autocorrplot.py
+++ b/arviz/plots/autocorrplot.py
@@ -1,4 +1,5 @@
 """Autocorrelation plot of data."""
+import warnings
 import numpy as np
 
 from ..data import convert_to_dataset
@@ -11,6 +12,7 @@ from .plot_utils import (
     _create_axes_grid,
 )
 from ..utils import _var_names
+from ..rcparams import rcParams
 
 
 def plot_autocorr(
@@ -88,6 +90,16 @@ def plot_autocorr(
         max_lag = min(100, data["draw"].shape[0])
 
     plotters = list(xarray_var_iter(data, var_names, combined))
+    max_plots = rcParams["plot.max_subplots"]
+    max_plots = len(plotters) if max_plots is None else max_plots
+    if len(plotters) > max_plots:
+        warnings.warn(
+            "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "
+            "of variables to plot ({len_plotters}), generating only {max_plots} "
+            "plots".format(max_plots=max_plots, len_plotters=len(plotters)),
+            SyntaxWarning,
+        )
+        plotters = plotters[:max_plots]
     length_plotters = len(plotters)
     rows, cols = default_grid(length_plotters)
 

--- a/arviz/plots/autocorrplot.py
+++ b/arviz/plots/autocorrplot.py
@@ -1,5 +1,4 @@
 """Autocorrelation plot of data."""
-import warnings
 import numpy as np
 
 from ..data import convert_to_dataset
@@ -10,9 +9,9 @@ from .plot_utils import (
     make_label,
     xarray_var_iter,
     _create_axes_grid,
+    filter_plotters_list,
 )
 from ..utils import _var_names
-from ..rcparams import rcParams
 
 
 def plot_autocorr(
@@ -89,17 +88,9 @@ def plot_autocorr(
     if max_lag is None:
         max_lag = min(100, data["draw"].shape[0])
 
-    plotters = list(xarray_var_iter(data, var_names, combined))
-    max_plots = rcParams["plot.max_subplots"]
-    max_plots = len(plotters) if max_plots is None else max_plots
-    if len(plotters) > max_plots:
-        warnings.warn(
-            "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "
-            "of variables to plot ({len_plotters}), generating only {max_plots} "
-            "plots".format(max_plots=max_plots, len_plotters=len(plotters)),
-            SyntaxWarning,
-        )
-        plotters = plotters[:max_plots]
+    plotters = filter_plotters_list(
+        list(xarray_var_iter(data, var_names, combined)), "plot_autocorr"
+    )
     length_plotters = len(plotters)
     rows, cols = default_grid(length_plotters)
 

--- a/arviz/plots/densityplot.py
+++ b/arviz/plots/densityplot.py
@@ -1,4 +1,5 @@
 """KDE and histogram plots for multiple variables."""
+import warnings
 import numpy as np
 
 from ..data import convert_to_dataset
@@ -12,6 +13,7 @@ from .plot_utils import (
     _create_axes_grid,
 )
 from ..utils import _var_names
+from ..rcparams import rcParams
 
 
 # pylint:disable-msg=too-many-function-args
@@ -175,6 +177,25 @@ def plot_density(
             if label not in all_labels:
                 all_labels.append(label)
     length_plotters = max(length_plotters)
+    max_plots = rcParams["plot.max_subplots"]
+    max_plots = length_plotters if max_plots is None else max_plots
+    if length_plotters > max_plots:
+        warnings.warn(
+            "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "
+            "of variables to plot ({len_plotters}), generating only {max_plots} "
+            "plots".format(max_plots=max_plots, len_plotters=length_plotters),
+            SyntaxWarning,
+        )
+        all_labels = all_labels[:max_plots]
+        to_plot = [
+            [
+                (var_name, selection, values)
+                for var_name, selection, values in plotters
+                if make_label(var_name, selection) in all_labels
+            ]
+            for plotters in to_plot
+        ]
+        length_plotters = max_plots
     rows, cols = default_grid(length_plotters, max_cols=3)
 
     (figsize, _, titlesize, xt_labelsize, linewidth, markersize) = _scale_fig_size(

--- a/arviz/plots/densityplot.py
+++ b/arviz/plots/densityplot.py
@@ -182,8 +182,8 @@ def plot_density(
     if length_plotters > max_plots:
         warnings.warn(
             "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "
-            "of variables to plot ({len_plotters}), generating only {max_plots} "
-            "plots".format(max_plots=max_plots, len_plotters=length_plotters),
+            "of variables to plot ({len_plotters}) in plot_density, generating only "
+            "{max_plots} plots".format(max_plots=max_plots, len_plotters=length_plotters),
             SyntaxWarning,
         )
         all_labels = all_labels[:max_plots]

--- a/arviz/plots/elpdplot.py
+++ b/arviz/plots/elpdplot.py
@@ -217,7 +217,7 @@ def plot_elpd(
         if vars_to_plot < numvars:
             warnings.warn(
                 "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "
-                "of resulting pair plots with these variables, generating only a "
+                "of resulting ELPD pairwise plots with these variables, generating only a "
                 "{side}x{side} grid".format(max_plots=max_plots, side=vars_to_plot),
                 SyntaxWarning,
             )

--- a/arviz/plots/elpdplot.py
+++ b/arviz/plots/elpdplot.py
@@ -1,4 +1,5 @@
 """Plot pointwise elpd estimations of inference data."""
+import warnings
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.cm as cm
@@ -209,6 +210,19 @@ def plot_elpd(
             ax.legend(handles=handles, ncol=ncols, title=color)
 
     else:
+        max_plots = (
+            numvars ** 2 if rcParams["plot.max_subplots"] is None else rcParams["plot.max_subplots"]
+        )
+        vars_to_plot = np.sum(np.arange(numvars).cumsum() < max_plots)
+        if vars_to_plot < numvars:
+            warnings.warn(
+                "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "
+                "of resulting pair plots with these variables, generating only a "
+                "{side}x{side} grid".format(max_plots=max_plots, side=vars_to_plot),
+                SyntaxWarning,
+            )
+            numvars = vars_to_plot
+
         (figsize, ax_labelsize, titlesize, xt_labelsize, _, markersize) = _scale_fig_size(
             figsize, textsize, numvars - 2, numvars - 2
         )

--- a/arviz/plots/essplot.py
+++ b/arviz/plots/essplot.py
@@ -1,4 +1,5 @@
 """Plot quantile or local effective sample sizes."""
+import warnings
 import numpy as np
 import xarray as xr
 from scipy.stats import rankdata
@@ -14,6 +15,7 @@ from .plot_utils import (
     get_coords,
 )
 from ..utils import _var_names
+from ..rcparams import rcParams
 
 
 def plot_ess(
@@ -227,6 +229,16 @@ def plot_ess(
         )
 
     plotters = list(xarray_var_iter(ess_dataset, var_names=var_names, skip_dims={"ess_dim"}))
+    max_plots = rcParams["plot.max_subplots"]
+    max_plots = len(plotters) if max_plots is None else max_plots
+    if len(plotters) > max_plots:
+        warnings.warn(
+            "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "
+            "of variables to plot ({len_plotters}), generating only {max_plots} "
+            "plots".format(max_plots=max_plots, len_plotters=len(plotters)),
+            SyntaxWarning,
+        )
+        plotters = plotters[:max_plots]
     length_plotters = len(plotters)
     rows, cols = default_grid(length_plotters)
 

--- a/arviz/plots/essplot.py
+++ b/arviz/plots/essplot.py
@@ -1,5 +1,4 @@
 """Plot quantile or local effective sample sizes."""
-import warnings
 import numpy as np
 import xarray as xr
 from scipy.stats import rankdata
@@ -13,9 +12,9 @@ from .plot_utils import (
     default_grid,
     _create_axes_grid,
     get_coords,
+    filter_plotters_list,
 )
 from ..utils import _var_names
-from ..rcparams import rcParams
 
 
 def plot_ess(
@@ -228,17 +227,9 @@ def plot_ess(
             dim="ess_dim",
         )
 
-    plotters = list(xarray_var_iter(ess_dataset, var_names=var_names, skip_dims={"ess_dim"}))
-    max_plots = rcParams["plot.max_subplots"]
-    max_plots = len(plotters) if max_plots is None else max_plots
-    if len(plotters) > max_plots:
-        warnings.warn(
-            "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "
-            "of variables to plot ({len_plotters}), generating only {max_plots} "
-            "plots".format(max_plots=max_plots, len_plotters=len(plotters)),
-            SyntaxWarning,
-        )
-        plotters = plotters[:max_plots]
+    plotters = filter_plotters_list(
+        list(xarray_var_iter(ess_dataset, var_names=var_names, skip_dims={"ess_dim"})), "plot_ess"
+    )
     length_plotters = len(plotters)
     rows, cols = default_grid(length_plotters)
 

--- a/arviz/plots/mcseplot.py
+++ b/arviz/plots/mcseplot.py
@@ -1,5 +1,4 @@
 """Plot quantile MC standard error."""
-import warnings
 import numpy as np
 import xarray as xr
 from scipy.stats import rankdata
@@ -14,9 +13,9 @@ from .plot_utils import (
     default_grid,
     _create_axes_grid,
     get_coords,
+    filter_plotters_list,
 )
 from ..utils import _var_names
-from ..rcparams import rcParams
 
 
 def plot_mcse(
@@ -115,17 +114,10 @@ def plot_mcse(
         [mcse(data, var_names=var_names, method="quantile", prob=p) for p in probs], dim="mcse_dim"
     )
 
-    plotters = list(xarray_var_iter(mcse_dataset, var_names=var_names, skip_dims={"mcse_dim"}))
-    max_plots = rcParams["plot.max_subplots"]
-    max_plots = len(plotters) if max_plots is None else max_plots
-    if len(plotters) > max_plots:
-        warnings.warn(
-            "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "
-            "of variables to plot ({len_plotters}), generating only {max_plots} "
-            "plots".format(max_plots=max_plots, len_plotters=len(plotters)),
-            SyntaxWarning,
-        )
-        plotters = plotters[:max_plots]
+    plotters = filter_plotters_list(
+        list(xarray_var_iter(mcse_dataset, var_names=var_names, skip_dims={"mcse_dim"})),
+        "plot_mcse",
+    )
     length_plotters = len(plotters)
     rows, cols = default_grid(length_plotters)
 

--- a/arviz/plots/mcseplot.py
+++ b/arviz/plots/mcseplot.py
@@ -1,4 +1,5 @@
 """Plot quantile MC standard error."""
+import warnings
 import numpy as np
 import xarray as xr
 from scipy.stats import rankdata
@@ -15,6 +16,7 @@ from .plot_utils import (
     get_coords,
 )
 from ..utils import _var_names
+from ..rcparams import rcParams
 
 
 def plot_mcse(
@@ -114,6 +116,16 @@ def plot_mcse(
     )
 
     plotters = list(xarray_var_iter(mcse_dataset, var_names=var_names, skip_dims={"mcse_dim"}))
+    max_plots = rcParams["plot.max_subplots"]
+    max_plots = len(plotters) if max_plots is None else max_plots
+    if len(plotters) > max_plots:
+        warnings.warn(
+            "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "
+            "of variables to plot ({len_plotters}), generating only {max_plots} "
+            "plots".format(max_plots=max_plots, len_plotters=len(plotters)),
+            SyntaxWarning,
+        )
+        plotters = plotters[:max_plots]
     length_plotters = len(plotters)
     rows, cols = default_grid(length_plotters)
 

--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -9,6 +9,7 @@ from ..data import convert_to_dataset, convert_to_inference_data
 from .kdeplot import plot_kde
 from .plot_utils import _scale_fig_size, xarray_to_ndarray, get_coords
 from ..utils import _var_names
+from ..rcparams import rcParams
 
 
 def plot_pair(
@@ -206,6 +207,19 @@ def plot_pair(
         ax.tick_params(labelsize=xt_labelsize)
 
     else:
+        max_plots = (
+            numvars ** 2 if rcParams["plot.max_subplots"] is None else rcParams["plot.max_subplots"]
+        )
+        vars_to_plot = np.sum(np.arange(numvars).cumsum() < max_plots)
+        if vars_to_plot < numvars:
+            warnings.warn(
+                "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "
+                "of resulting pair plots with these variables, generating only a "
+                "{side}x{side} grid".format(max_plots=max_plots, side=vars_to_plot),
+                SyntaxWarning,
+            )
+            numvars = vars_to_plot
+
         (figsize, ax_labelsize, _, xt_labelsize, _, _) = _scale_fig_size(
             figsize, textsize, numvars - 2, numvars - 2
         )

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -1,4 +1,5 @@
 """Utilities for plotting."""
+import warnings
 from itertools import product, tee
 
 import numpy as np
@@ -7,6 +8,7 @@ import matplotlib as mpl
 import xarray as xr
 
 from ..utils import conditional_jit
+from ..rcparams import rcParams
 
 
 def make_2d(ary):
@@ -488,3 +490,20 @@ def set_xticklabels(ax, coord_labels):
     else:
         ax.set_xticks(xticks)
         ax.set_xticklabels(coord_labels[xticks])
+
+
+def filter_plotters_list(plotters, plot_kind):
+    """Cut list of plotters so that it is at most of lenght "plot.max_subplots"."""
+    max_plots = rcParams["plot.max_subplots"]
+    max_plots = len(plotters) if max_plots is None else max_plots
+    if len(plotters) > max_plots:
+        warnings.warn(
+            "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "
+            "of variables to plot ({len_plotters}) in {plot_kind}, generating only "
+            "{max_plots} plots".format(
+                max_plots=max_plots, len_plotters=len(plotters), plot_kind=plot_kind
+            ),
+            SyntaxWarning,
+        )
+        return plotters[:max_plots]
+    return plotters

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -1,5 +1,4 @@
 """Plot posterior densities."""
-import warnings
 from typing import Optional
 from numbers import Number
 import numpy as np
@@ -15,9 +14,9 @@ from .plot_utils import (
     default_grid,
     _create_axes_grid,
     get_coords,
+    filter_plotters_list,
 )
 from ..utils import _var_names, format_sig_figs
-from ..rcparams import rcParams
 
 
 def plot_posterior(
@@ -156,17 +155,10 @@ def plot_posterior(
     if coords is None:
         coords = {}
 
-    plotters = list(xarray_var_iter(get_coords(data, coords), var_names=var_names, combined=True))
-    max_plots = rcParams["plot.max_subplots"]
-    max_plots = len(plotters) if max_plots is None else max_plots
-    if len(plotters) > max_plots:
-        warnings.warn(
-            "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "
-            "of variables to plot ({len_plotters}), generating only {max_plots} "
-            "plots".format(max_plots=max_plots, len_plotters=len(plotters)),
-            SyntaxWarning,
-        )
-        plotters = plotters[:max_plots]
+    plotters = filter_plotters_list(
+        list(xarray_var_iter(get_coords(data, coords), var_names=var_names, combined=True)),
+        "plot_posterior",
+    )
     length_plotters = len(plotters)
     rows, cols = default_grid(length_plotters)
 

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -1,4 +1,5 @@
 """Plot posterior densities."""
+import warnings
 from typing import Optional
 from numbers import Number
 import numpy as np
@@ -16,6 +17,7 @@ from .plot_utils import (
     get_coords,
 )
 from ..utils import _var_names, format_sig_figs
+from ..rcparams import rcParams
 
 
 def plot_posterior(
@@ -155,6 +157,16 @@ def plot_posterior(
         coords = {}
 
     plotters = list(xarray_var_iter(get_coords(data, coords), var_names=var_names, combined=True))
+    max_plots = rcParams["plot.max_subplots"]
+    max_plots = len(plotters) if max_plots is None else max_plots
+    if len(plotters) > max_plots:
+        warnings.warn(
+            "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "
+            "of variables to plot ({len_plotters}), generating only {max_plots} "
+            "plots".format(max_plots=max_plots, len_plotters=len(plotters)),
+            SyntaxWarning,
+        )
+        plotters = plotters[:max_plots]
     length_plotters = len(plotters)
     rows, cols = default_grid(length_plotters)
 

--- a/arviz/plots/ppcplot.py
+++ b/arviz/plots/ppcplot.py
@@ -1,4 +1,5 @@
 """Posterior predictive plot."""
+import warnings
 from numbers import Integral
 import platform
 import logging
@@ -14,6 +15,7 @@ from .plot_utils import (
     get_bins,
 )
 from ..utils import _var_names
+from ..rcparams import rcParams
 
 _log = logging.getLogger(__name__)
 
@@ -244,6 +246,17 @@ def plot_ppc(
             combined=True,
         )
     )
+    max_plots = rcParams["plot.max_subplots"]
+    max_plots = len(obs_plotters) if max_plots is None else max_plots
+    if len(obs_plotters) > max_plots:
+        warnings.warn(
+            "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "
+            "of variables to plot ({len_plotters}), generating only {max_plots} "
+            "plots".format(max_plots=max_plots, len_plotters=len(obs_plotters)),
+            SyntaxWarning,
+        )
+        obs_plotters = obs_plotters[:max_plots]
+        pp_plotters = pp_plotters[:max_plots]
     length_plotters = len(obs_plotters)
     rows, cols = default_grid(length_plotters)
 

--- a/arviz/plots/rankplot.py
+++ b/arviz/plots/rankplot.py
@@ -1,5 +1,4 @@
 """Histograms of ranked posterior draws, plotted for each chain."""
-import warnings
 import numpy as np
 import scipy.stats
 
@@ -10,9 +9,9 @@ from .plot_utils import (
     default_grid,
     _create_axes_grid,
     make_label,
+    filter_plotters_list,
 )
 from ..utils import _var_names, conditional_jit
-from ..rcparams import rcParams
 
 
 def _sturges_formula(dataset, mult=1):
@@ -104,17 +103,9 @@ def plot_rank(data, var_names=None, coords=None, bins=None, ref_line=True, figsi
     if coords is not None:
         posterior_data = posterior_data.sel(**coords)
     var_names = _var_names(var_names, posterior_data)
-    plotters = list(xarray_var_iter(posterior_data, var_names=var_names, combined=True))
-    max_plots = rcParams["plot.max_subplots"]
-    max_plots = len(plotters) if max_plots is None else max_plots
-    if len(plotters) > max_plots:
-        warnings.warn(
-            "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "
-            "of variables to plot ({len_plotters}), generating only {max_plots} "
-            "plots".format(max_plots=max_plots, len_plotters=len(plotters)),
-            SyntaxWarning,
-        )
-        plotters = plotters[:max_plots]
+    plotters = filter_plotters_list(
+        list(xarray_var_iter(posterior_data, var_names=var_names, combined=True)), "plot_rank"
+    )
     length_plotters = len(plotters)
 
     if bins is None:

--- a/arviz/plots/rankplot.py
+++ b/arviz/plots/rankplot.py
@@ -1,4 +1,5 @@
 """Histograms of ranked posterior draws, plotted for each chain."""
+import warnings
 import numpy as np
 import scipy.stats
 
@@ -11,6 +12,7 @@ from .plot_utils import (
     make_label,
 )
 from ..utils import _var_names, conditional_jit
+from ..rcparams import rcParams
 
 
 def _sturges_formula(dataset, mult=1):
@@ -103,18 +105,29 @@ def plot_rank(data, var_names=None, coords=None, bins=None, ref_line=True, figsi
         posterior_data = posterior_data.sel(**coords)
     var_names = _var_names(var_names, posterior_data)
     plotters = list(xarray_var_iter(posterior_data, var_names=var_names, combined=True))
+    max_plots = rcParams["plot.max_subplots"]
+    max_plots = len(plotters) if max_plots is None else max_plots
+    if len(plotters) > max_plots:
+        warnings.warn(
+            "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "
+            "of variables to plot ({len_plotters}), generating only {max_plots} "
+            "plots".format(max_plots=max_plots, len_plotters=len(plotters)),
+            SyntaxWarning,
+        )
+        plotters = plotters[:max_plots]
+    length_plotters = len(plotters)
 
     if bins is None:
         # Use double Sturges' formula
         bins = _sturges_formula(posterior_data, mult=2)
 
     if axes is None:
-        rows, cols = default_grid(len(plotters))
+        rows, cols = default_grid(length_plotters)
 
         figsize, ax_labelsize, titlesize, _, _, _ = _scale_fig_size(
             figsize, None, rows=rows, cols=cols
         )
-        _, axes = _create_axes_grid(len(plotters), rows, cols, figsize=figsize, squeeze=False)
+        _, axes = _create_axes_grid(length_plotters, rows, cols, figsize=figsize, squeeze=False)
 
     for ax, (var_name, selection, var_data) in zip(axes.ravel(), plotters):
         ranks = scipy.stats.rankdata(var_data).reshape(var_data.shape)

--- a/arviz/plots/traceplot.py
+++ b/arviz/plots/traceplot.py
@@ -148,12 +148,13 @@ def plot_trace(
     max_plots = rcParams["plot.max_subplots"]
     max_plots = len(plotters) if max_plots is None else max_plots
     if len(plotters) > max_plots:
-        plotters = plotters[:max_plots]
         warnings.warn(
-            "max_plots is smaller than the number of variables to plot "
-            "generating only max_plots traceplots",
+            "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "
+            "of variables to plot ({len_plotters}), generating only {max_plots} "
+            "plots".format(max_plots=max_plots, len_plotters=len(plotters)),
             SyntaxWarning,
         )
+        plotters = plotters[:max_plots]
 
     if figsize is None:
         figsize = (12, len(plotters) * 2)

--- a/arviz/plots/traceplot.py
+++ b/arviz/plots/traceplot.py
@@ -9,6 +9,7 @@ from ..data import convert_to_dataset
 from .distplot import plot_dist
 from .plot_utils import _scale_fig_size, get_bins, xarray_var_iter, make_label, get_coords
 from ..utils import _var_names
+from ..rcparams import rcParams
 
 
 def plot_trace(
@@ -27,7 +28,6 @@ def plot_trace(
     rug_kwargs=None,
     hist_kwargs=None,
     trace_kwargs=None,
-    max_plots=40,
 ):
     """Plot distribution (histogram or kernel density estimates) and sampled values.
 
@@ -145,6 +145,7 @@ def plot_trace(
         skip_dims = set()
 
     plotters = list(xarray_var_iter(data, var_names=var_names, combined=True, skip_dims=skip_dims))
+    max_plots = rcParams["plot.max_subplots"]
     max_plots = len(plotters) if max_plots is None else max_plots
     if len(plotters) > max_plots:
         plotters = plotters[:max_plots]

--- a/arviz/plots/violinplot.py
+++ b/arviz/plots/violinplot.py
@@ -1,14 +1,12 @@
 """Plot posterior traces as violin plot."""
-import warnings
 import matplotlib.pyplot as plt
 import numpy as np
 
 from ..data import convert_to_dataset
 from ..stats import hpd
 from .kdeplot import _fast_kde
-from .plot_utils import get_bins, _scale_fig_size, xarray_var_iter, make_label
+from .plot_utils import get_bins, _scale_fig_size, xarray_var_iter, make_label, filter_plotters_list
 from ..utils import _var_names
-from ..rcparams import rcParams
 
 
 def plot_violin(
@@ -67,17 +65,9 @@ def plot_violin(
     data = convert_to_dataset(data, group="posterior")
     var_names = _var_names(var_names, data)
 
-    plotters = list(xarray_var_iter(data, var_names=var_names, combined=True))
-    max_plots = rcParams["plot.max_subplots"]
-    max_plots = len(plotters) if max_plots is None else max_plots
-    if len(plotters) > max_plots:
-        warnings.warn(
-            "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "
-            "of variables to plot ({len_plotters}), generating only {max_plots} "
-            "plots".format(max_plots=max_plots, len_plotters=len(plotters)),
-            SyntaxWarning,
-        )
-        plotters = plotters[:max_plots]
+    plotters = filter_plotters_list(
+        list(xarray_var_iter(data, var_names=var_names, combined=True)), "plot_violin"
+    )
 
     if kwargs_shade is None:
         kwargs_shade = {}

--- a/arviz/plots/violinplot.py
+++ b/arviz/plots/violinplot.py
@@ -1,4 +1,5 @@
 """Plot posterior traces as violin plot."""
+import warnings
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -7,6 +8,7 @@ from ..stats import hpd
 from .kdeplot import _fast_kde
 from .plot_utils import get_bins, _scale_fig_size, xarray_var_iter, make_label
 from ..utils import _var_names
+from ..rcparams import rcParams
 
 
 def plot_violin(
@@ -66,6 +68,16 @@ def plot_violin(
     var_names = _var_names(var_names, data)
 
     plotters = list(xarray_var_iter(data, var_names=var_names, combined=True))
+    max_plots = rcParams["plot.max_subplots"]
+    max_plots = len(plotters) if max_plots is None else max_plots
+    if len(plotters) > max_plots:
+        warnings.warn(
+            "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "
+            "of variables to plot ({len_plotters}), generating only {max_plots} "
+            "plots".format(max_plots=max_plots, len_plotters=len(plotters)),
+            SyntaxWarning,
+        )
+        plotters = plotters[:max_plots]
 
     if kwargs_shade is None:
         kwargs_shade = {}

--- a/arviz/rcparams.py
+++ b/arviz/rcparams.py
@@ -1,4 +1,4 @@
-"""ArviZ rcparams."""
+"""ArviZ rcparams. Based on matplotlib's implementation."""
 import sys
 import os
 from pathlib import Path

--- a/arviz/tests/test.rcparams
+++ b/arviz/tests/test.rcparams
@@ -1,0 +1,1 @@
+data.load : eager

--- a/arviz/tests/test_plot_utils.py
+++ b/arviz/tests/test_plot_utils.py
@@ -4,7 +4,14 @@ import xarray as xr
 import pytest
 
 from ..data import from_dict
-from ..plots.plot_utils import make_2d, xarray_to_ndarray, xarray_var_iter, get_bins, get_coords, filter_plotters_list
+from ..plots.plot_utils import (
+    make_2d,
+    xarray_to_ndarray,
+    xarray_var_iter,
+    get_bins,
+    get_coords,
+    filter_plotters_list,
+)
 from ..rcparams import rc_context
 
 

--- a/arviz/tests/test_plot_utils.py
+++ b/arviz/tests/test_plot_utils.py
@@ -147,7 +147,7 @@ def test_filter_plotter_list():
 
 def test_filter_plotter_list_warning():
     plotters = list(range(7))
-    with rc_context({"plot.max_subplots": 10}):
+    with rc_context({"plot.max_subplots": 5}):
         with pytest.warns(SyntaxWarning, match="test warning"):
             plotters_filtered = filter_plotters_list(plotters, "test warning")
     assert len(plotters_filtered) == 5

--- a/arviz/tests/test_plot_utils.py
+++ b/arviz/tests/test_plot_utils.py
@@ -4,7 +4,8 @@ import xarray as xr
 import pytest
 
 from ..data import from_dict
-from ..plots.plot_utils import make_2d, xarray_to_ndarray, xarray_var_iter, get_bins, get_coords
+from ..plots.plot_utils import make_2d, xarray_to_ndarray, xarray_var_iter, get_bins, get_coords, filter_plotters_list
+from ..rcparams import rcParams
 
 
 @pytest.fixture(scope="function")
@@ -128,3 +129,18 @@ class TestCoordsExceptions:
 
         with pytest.raises(TypeError):
             get_coords(data, coords)
+
+
+def test_filter_plotter_list():
+    rcParams["plot.max_subplots"] = 10
+    plotters = list(range(7))
+    plotters_filtered = filter_plotters_list(plotters, "")
+    assert plotters == plotters_filtered
+
+
+def test_filter_plotter_list_warning():
+    rcParams["plot.max_subplots"] = 5
+    plotters = list(range(7))
+    with pytest.warns(SyntaxWarning, match="test warning"):
+        plotters_filtered = filter_plotters_list(plotters, "test warning")
+    assert len(plotters_filtered) == 5

--- a/arviz/tests/test_plot_utils.py
+++ b/arviz/tests/test_plot_utils.py
@@ -5,7 +5,7 @@ import pytest
 
 from ..data import from_dict
 from ..plots.plot_utils import make_2d, xarray_to_ndarray, xarray_var_iter, get_bins, get_coords, filter_plotters_list
-from ..rcparams import rcParams
+from ..rcparams import rc_context
 
 
 @pytest.fixture(scope="function")
@@ -132,15 +132,15 @@ class TestCoordsExceptions:
 
 
 def test_filter_plotter_list():
-    rcParams["plot.max_subplots"] = 10
     plotters = list(range(7))
-    plotters_filtered = filter_plotters_list(plotters, "")
+    with rc_context({"plot.max_subplots": 10}):
+        plotters_filtered = filter_plotters_list(plotters, "")
     assert plotters == plotters_filtered
 
 
 def test_filter_plotter_list_warning():
-    rcParams["plot.max_subplots"] = 5
     plotters = list(range(7))
-    with pytest.warns(SyntaxWarning, match="test warning"):
-        plotters_filtered = filter_plotters_list(plotters, "test warning")
+    with rc_context({"plot.max_subplots": 10}):
+        with pytest.warns(SyntaxWarning, match="test warning"):
+            plotters_filtered = filter_plotters_list(plotters, "test warning")
     assert len(plotters_filtered) == 5

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -16,7 +16,7 @@ from .helpers import (  # pylint: disable=unused-import
     multidim_models,
     create_multidimensional_model,
 )
-from ..rcparams import rcParams
+from ..rcparams import rcParams, rc_context
 from ..plots import (
     plot_density,
     plot_trace,
@@ -149,9 +149,10 @@ def test_plot_trace_discrete(discrete_model):
     assert axes.shape
 
 
-def test_plot_trace_max_plots_warning(models):
+def test_plot_trace_max_subplots_warning(models):
     with pytest.warns(SyntaxWarning):
-        axes = plot_trace(models.model_1, max_plots=1)
+        with rc_context(rc={"plot.max_subplots": 1}):
+            axes = plot_trace(models.model_1)
     assert axes.shape
 
 

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -602,7 +602,10 @@ def test_plot_autocorr_short_chain():
 def test_plot_autocorr_uncombined(models):
     axes = plot_autocorr(models.model_1, combined=False)
     assert axes.shape[0] == 1
-    assert axes.shape[1] == 72
+    max_subplots = (
+        np.inf if rcParams["plot.max_subplots"] is None else rcParams["plot.max_subplots"]
+    )
+    assert axes.shape[1] == min(72, max_subplots)
 
 
 def test_plot_autocorr_combined(models):

--- a/arviz/tests/test_rcparams.py
+++ b/arviz/tests/test_rcparams.py
@@ -7,7 +7,8 @@ from xarray.core.indexing import MemoryCachedArray
 
 from ..data import load_arviz_data
 from ..stats import compare
-from ..rcparams import rcParams, rc_context, _validate_positive_int_or_none
+from ..rcparams import rcParams, rc_context, _validate_positive_int_or_none, read_rcfile
+
 from .helpers import models  # pylint: disable=unused-import
 
 
@@ -42,6 +43,14 @@ def test_del_key_error():
 def test_rcparams_find_all():
     data_rcparams = rcParams.find_all("data")
     assert len(data_rcparams)
+
+
+### Test arvizrc.template file is up to date ###
+def test_rctemplate_updated():
+    fname = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../arvizrc.template")
+    rc_pars_template = read_rcfile(fname)
+    assert all(key in rc_pars_template.keys() for key in rcParams.keys())
+    assert all(value == rc_pars_template[key] for key, value in rcParams.items())
 
 
 ### Test validation functions ###

--- a/arviz/tests/test_rcparams.py
+++ b/arviz/tests/test_rcparams.py
@@ -1,4 +1,5 @@
 # pylint: disable=redefined-outer-name
+import os
 import numpy as np
 import pytest
 from xarray.core.indexing import MemoryCachedArray
@@ -6,8 +7,24 @@ from xarray.core.indexing import MemoryCachedArray
 
 from ..data import load_arviz_data
 from ..stats import compare
-from ..rcparams import rcParams, rc_context
+from ..rcparams import rcParams, rc_context, _validate_positive_int_or_none
 from .helpers import models  # pylint: disable=unused-import
+
+
+### Test rcparams classes ###
+def test_rc_context_dict():
+    rcParams["data.load"] = "lazy"
+    with rc_context(rc={"data.load": "eager"}):
+        assert rcParams["data.load"] == "eager"
+    assert rcParams["data.load"] == "lazy"
+
+
+def test_rc_context_file():
+    path = os.path.dirname(os.path.abspath(__file__))
+    rcParams["data.load"] = "lazy"
+    with rc_context(fname=path + "/test.rcparams"):
+        assert rcParams["data.load"] == "eager"
+    assert rcParams["data.load"] == "lazy"
 
 
 def test_bad_key():
@@ -16,6 +33,18 @@ def test_bad_key():
         rcParams["bad_key"] = "nothing"
 
 
+def test_del_key_error():
+    """Check that rcParams keys cannot be deleted."""
+    with pytest.raises(TypeError, match="keys cannot be deleted"):
+        del rcParams["data.load"]
+
+
+def test_rcparams_find_all():
+    data_rcparams = rcParams.find_all("data")
+    assert len(data_rcparams)
+
+
+### Test validation functions ###
 @pytest.mark.parametrize("param", ["data.load", "stats.information_criterion"])
 def test_choice_bad_values(param):
     """Test error messages are correct for rcParams validated with _make_validate_choice."""
@@ -24,13 +53,20 @@ def test_choice_bad_values(param):
         rcParams[param] = "bad_value"
 
 
-def test_rc_context():
-    rcParams["data.load"] = "lazy"
-    with rc_context(rc={"data.load": "eager"}):
-        assert rcParams["data.load"] == "eager"
-    assert rcParams["data.load"] == "lazy"
+@pytest.mark.parametrize(
+    "args",
+    [("Only positive", -1), ("Could not convert", "1.3"), (False, "2"), (False, None), (False, 1)],
+)
+def test_validate_positive_int_or_none(args):
+    raise_error, value = args
+    if raise_error:
+        with pytest.raises(ValueError, match=raise_error):
+            _validate_positive_int_or_none(value)
+    else:
+        _validate_positive_int_or_none(value)
 
 
+### Test integration of rcParams in ArviZ ###
 def test_data_load():
     rcParams["data.load"] = "lazy"
     idata_lazy = load_arviz_data("centered_eight")


### PR DESCRIPTION
Integrates "plot.max_subplots" with all plotting functions. It works on a subplot basis with 3 exceptions:

* In traceplot, the thershold is interpreted as a limit on the variable number, thus, the total number of subplots can be the double of "plot.max_subplots" as there are 2 subplots per variable.
* In plot pair and plot elpd, as they plot on a pairwise basis using a square grid, the limit is implemented truncating on the number of "filled" plots. Some examples: 5 variables to be plotted generate a 4x4 grid, with 1, 2, 3 and 4 plots per row, a total of 10 "filled" plots. Therefore, `"plot.max_subplots"=8` would plot 3 variables, even though they generate 6 "filled" plots because it actually generates 9 subplots.

Comments on improvements on the warning messages are particularly appreciated.