### PR TITLE
Modify pytorch installation in create env script

### DIFF
--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -10,7 +10,7 @@ command -v conda >/dev/null 2>&1 || {
 # if no python specified, use Travis version, or else 3.6
 PYTHON_VERSION=${PYTHON_VERSION:-${TRAVIS_PYTHON_VERSION:-3.6}}
 PYSTAN_VERSION=${PYSTAN_VERSION:-latest}
-PYTORCH_VERSION=${PYTORCH_VERSION:-1.1.0}
+PYTORCH_VERSION=${PYTORCH_VERSION:-latest}
 PYRO_VERSION=${PYRO_VERSION:-latest}
 EMCEE_VERSION=${EMCEE_VERSION:-2}
 
@@ -46,7 +46,11 @@ pip install --upgrade pip
 
 # Pyro install with pip is ~511MB. These binaries are ~91MB, somehow, and do not
 # break the build. The link can be determined from the pytorch and the python version
-pip --no-cache-dir install "https://download.pytorch.org/whl/cpu/torch-${PYTORCH_VERSION}-cp${PYTHON_VERSION//./}-cp${PYTHON_VERSION//./}m-linux_x86_64.whl"
+if [ "$PYTORCH_VERSION" = "latest" ]; then
+    pip --no-cache-dir install torch torchvision -f https://download.pytorch.org/whl/cpu/torch_stable.html
+else
+    pip --no-cache-dir install torch==${PYTORCH_VERSION} torchvision -f https://download.pytorch.org/whl/cpu/torch_stable.html
+fi
 
 if [ "$PYSTAN_VERSION" = "latest" ]; then
   pip --no-cache-dir install pystan


### PR DESCRIPTION
~~This should fix pytorch installation.~~ Problem was not actually with pytorch installation, but I think the changes are still useful.

I have seen that version 1.2.0 has just been released, and with it, recommended method shown in their website has been modified too. In my opinion, now it is quite more sensible and it should install cpu wheel of latest version automatically, so pytorch_version env variable will only be used for old versions and we will always be running tests on latest pytorch, no need to update it manuallly from time to time. We may have the same trouble as with tfp if pyro and pytorch releases are not coordinated though.