### PR TITLE
fix how pymc3 is specified in extras_require

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 emcee
-git+https://github.com/pymc-devs/pymc3
+pymc3 @ git+https://github.com/pymc-devs/pymc3
 ghp-import
 pystan
 cmdstanpy


### PR DESCRIPTION
This is related to #804