### PR TITLE
Fix docstring for posteriorplot

### DIFF
--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -126,14 +126,14 @@ def plot_posterior(
     .. plot::
         :context: close-figs
 
-        >>> az.plot_posterior(data, var_names=['mu', 'theta_tilde'], ref_val=0)
+        >>> az.plot_posterior(data, var_names=['mu', 'theta'], ref_val=0)
 
     Show point estimate of distribution
 
     .. plot::
         :context: close-figs
 
-        >>> az.plot_posterior(data, var_names=['mu', 'theta_tilde'], point_estimate='mode')
+        >>> az.plot_posterior(data, var_names=['mu', 'theta'], point_estimate='mode')
 
     Plot posterior as a histogram
 


### PR DESCRIPTION
This fixes two warnings in the docs. It was pointed out that the documentation is currently borked, so I may merge this if tests pass in hopes of fixing the docs. If that doesn't work, I can do it manually.


![image](https://user-images.githubusercontent.com/2295568/64301977-43e5a400-cf4f-11e9-8dbc-18e9d4d0ebad.png)
