### PR TITLE
Implement from_numpyro

### DIFF
--- a/arviz/data/__init__.py
+++ b/arviz/data/__init__.py
@@ -11,6 +11,7 @@ from .io_pymc3 import from_pymc3
 from .io_pystan import from_pystan
 from .io_emcee import from_emcee
 from .io_pyro import from_pyro
+from .io_numpyro import from_numpyro
 from .io_tfp import from_tfp
 
 __all__ = [
@@ -30,6 +31,7 @@ __all__ = [
     "from_cmdstanpy",
     "from_dict",
     "from_pyro",
+    "from_numpyro",
     "from_tfp",
     "from_netcdf",
     "to_netcdf",

--- a/arviz/data/converters.py
+++ b/arviz/data/converters.py
@@ -7,6 +7,7 @@ from .base import dict_to_dataset
 from .io_cmdstan import from_cmdstan
 from .io_cmdstanpy import from_cmdstanpy
 from .io_emcee import from_emcee
+from .io_numpyro import from_numpyro
 from .io_pymc3 import from_pymc3
 from .io_pyro import from_pyro
 from .io_pystan import from_pystan
@@ -84,6 +85,8 @@ def convert_to_inference_data(obj, *, group="posterior", coords=None, dims=None,
         return from_emcee(sampler=kwargs.pop(group), **kwargs)
     elif obj.__class__.__name__ == "MCMC" and obj.__class__.__module__.startswith("pyro"):
         return from_pyro(posterior=kwargs.pop(group), **kwargs)
+    elif obj.__class__.__name__ == "MCMC" and obj.__class__.__module__.startswith("numpyro"):
+        return from_numpyro(posterior=kwargs.pop(group), **kwargs)
 
     # Cases that convert to xarray
     if isinstance(obj, xr.Dataset):
@@ -108,6 +111,7 @@ def convert_to_inference_data(obj, *, group="posterior", coords=None, dims=None,
             "pymc3 trace",
             "emcee fit",
             "pyro mcmc fit",
+            "numpyro mcmc fit",
             "cmdstan fit csv",
             "cmdstanpy fit",
         )

--- a/arviz/data/io_numpyro.py
+++ b/arviz/data/io_numpyro.py
@@ -1,0 +1,127 @@
+"""NumPyro-specific conversion code."""
+import numpy as np
+
+from .inference_data import InferenceData
+from .base import requires, dict_to_dataset
+from .. import utils
+
+
+class NumPyroConverter:
+    """Encapsulate NumPyro specific logic."""
+
+    def __init__(self, *, posterior, prior=None, posterior_predictive=None, coords=None, dims=None):
+        """Convert NumPyro data into an InferenceData object.
+
+        Parameters
+        ----------
+        posterior : numpyro.mcmc.MCMC
+            Fitted MCMC object from NumPyro
+        coords : dict[str] -> list[str]
+            Map of dimensions to coordinates
+        dims : dict[str] -> list[str]
+            Map variable names to their coordinates
+        """
+        import jax, numpyro
+        self.posterior = posterior
+        self.prior = jax.device_get(prior)
+        self.posterior_predictive = jax.device_get(posterior_predictive)
+        self.coords = coords
+        self.dims = dims
+        self.numpyro = numpyro
+
+        posterior_fields = jax.device_get(posterior._samples)
+        # handle the case we run MCMC with a general potential_fn
+        # (instead of a NumPyro model) whose args is not a dictionary
+        # (e.g. f(x) = x ** 2)
+        samples = posterior_fields['z']
+        tree_flatten_samples = jax.tree_util.tree_flatten(samples)[0]
+        if not isinstance(samples, dict):
+            posterior_fields['z'] = {
+                'Param:{}'.format(i): jax.device_get(v)
+                for i, v in enumerate(tree_flatten_samples)
+            }
+        self._posterior_fields = posterior_fields
+        self.nchains, self.ndraws = tree_flatten_samples[0].shape[:2]
+
+    @requires("posterior")
+    def posterior_to_xarray(self):
+        """Convert the posterior to an xarray dataset."""
+        data = self._posterior_fields['z']
+        return dict_to_dataset(data, library=self.numpyro, coords=self.coords, dims=self.dims)
+
+    @requires("posterior")
+    def sample_stats_to_xarray(self):
+        """Extract sample_stats from NumPyro posterior."""
+        data = {k: v.copy() for k, v in self._posterior_fields.items()
+                if k != 'z' and isinstance(v, np.ndarray)}
+        # TODO: extract log_likelihood using NumPyro predictive utilities
+        return dict_to_dataset(data, library=self.numpyro, coords=self.coords, dims=self.dims)
+
+    @requires("posterior_predictive")
+    def posterior_predictive_to_xarray(self):
+        """Convert posterior_predictive samples to xarray."""
+        data = {}
+        for k, ary in self.posterior_predictive.items():
+            shape = ary.shape
+            if shape[0] == self.nchains and shape[1] == self.ndraws:
+                data[k] = ary
+            elif shape[0] == self.nchains * self.ndraws:
+                data[k] = ary.reshape((self.nchains, self.ndraws, *shape[1:]))
+            else:
+                data[k] = utils.expand_dims(ary)
+                _log.warning(
+                    "posterior predictive shape not compatible with number of chains and draws. "
+                    "This can mean that some draws or even whole chains are not represented."
+                )
+        return dict_to_dataset(data, library=self.numpyro, coords=self.coords, dims=self.dims)
+
+    @requires("prior")
+    def prior_to_xarray(self):
+        """Convert prior samples to xarray."""
+        return dict_to_dataset(
+            {k: utils.expand_dims(v) for k, v in self.prior.items()},
+            library=self.numpyro,
+            coords=self.coords,
+            dims=self.dims,
+        )
+
+    def to_inference_data(self):
+        """Convert all available data to an InferenceData object.
+
+        Note that if groups can not be created (i.e., there is no `trace`, so
+        the `posterior` and `sample_stats` can not be extracted), then the InferenceData
+        will not have those groups.
+        """
+        return InferenceData(
+            **{
+                "posterior": self.posterior_to_xarray(),
+                "sample_stats": self.sample_stats_to_xarray(),
+                "posterior_predictive": self.posterior_predictive_to_xarray(),
+                "prior": self.prior_to_xarray(),
+            }
+        )
+
+
+def from_numpyro(posterior=None, *, prior=None, posterior_predictive=None, coords=None, dims=None):
+    """Convert NumPyro data into an InferenceData object.
+
+    Parameters
+    ----------
+    posterior : numpyro.mcmc.MCMC
+        Fitted MCMC object from NumPyro
+    prior: dict
+        Prior samples from a NumPyro model
+    posterior_predictive : dict
+        Posterior predictive samples for the posterior
+    coords : dict[str] -> list[str]
+        Map of dimensions to coordinates
+    dims : dict[str] -> list[str]
+        Map variable names to their coordinates
+    """
+    return NumPyroConverter(
+        posterior=posterior,
+        prior=prior,
+        posterior_predictive=posterior_predictive,
+        coords=coords,
+        dims=dims,
+    ).to_inference_data()

--- a/arviz/data/io_numpyro.py
+++ b/arviz/data/io_numpyro.py
@@ -16,6 +16,10 @@ class NumPyroConverter:
         ----------
         posterior : numpyro.mcmc.MCMC
             Fitted MCMC object from NumPyro
+        prior: dict
+            Prior samples from a NumPyro model
+        posterior_predictive : dict
+            Posterior predictive samples for the posterior
         coords : dict[str] -> list[str]
             Map of dimensions to coordinates
         dims : dict[str] -> list[str]

--- a/arviz/data/io_numpyro.py
+++ b/arviz/data/io_numpyro.py
@@ -96,6 +96,8 @@ class NumPyroConverter:
         the `posterior` and `sample_stats` can not be extracted), then the InferenceData
         will not have those groups.
         """
+        # TODO: implement observed_data_to_xarray when model args, kwargs are stored
+        # in the next version of NumPyro
         return InferenceData(
             **{
                 "posterior": self.posterior_to_xarray(),

--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -315,6 +315,25 @@ def pyro_centered_schools(data, draws, chains):
     return posterior
 
 
+def numpyro_schools_model(data, draws, chains):
+    import jax
+    import numpyro
+    import numpyro.distributions as dist
+    from numpyro.mcmc import MCMC, NUTS
+
+    def model():
+        mu = numpyro.sample('mu', dist.Normal(0, 5))
+        tau = numpyro.sample('tau', dist.HalfCauchy(5))
+        # TODO: use numpyro.plate instead of `sample_shape` in future versions of NumPyro
+        theta = numpyro.sample('theta', dist.Normal(mu * np.ones(data['J']), tau))
+        numpyro.sample('obs', dist.Normal(theta, data['sigma']), obs=data['y'])
+
+    mcmc = MCMC(NUTS(model), num_warmup=draws, num_samples=draws,
+                num_chains=chains, chain_method='sequential')
+    mcmc.run(jax.random.PRNGKey(0), collect_fields=('z', 'diverging'))
+    return mcmc
+
+
 def tfp_schools_model(num_schools, treatment_stddevs):
     """Non-centered eight schools model for tfp."""
     import tensorflow_probability.python.edward2 as ed
@@ -461,6 +480,7 @@ def load_cached_models(eight_schools_data, draws, chains, libs=None):
         ("pymc3", pymc3_noncentered_schools),
         ("emcee", emcee_schools_model),
         ("pyro", pyro_centered_schools),
+        ("numpyro", numpyro_schools_model),
     )
     data_directory = os.path.join(here, "saved_models")
     models = {}
@@ -477,6 +497,11 @@ def load_cached_models(eight_schools_data, draws, chains, libs=None):
             # httpstan caches models automatically
             _log.info("Generating and loading stan model")
             models["pystan"] = func(eight_schools_data, draws, chains)
+            continue
+        elif library.__name__ == "numpyro":
+            # NumPyro does not support pickling
+            _log.info("Generating and loading NumPyro model")
+            models["numpyro"] = func(eight_schools_data, draws, chains)
             continue
 
         py_version = sys.version_info

--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -324,7 +324,8 @@ def numpyro_schools_model(data, draws, chains):
     def model():
         mu = numpyro.sample('mu', dist.Normal(0, 5))
         tau = numpyro.sample('tau', dist.HalfCauchy(5))
-        # TODO: use numpyro.plate instead of `sample_shape` in future versions of NumPyro
+        # TODO: use numpyro.plate or `sample_shape` kwargs instead of
+        # multiplying with np.ones(J) in future versions of NumPyro
         theta = numpyro.sample('theta', dist.Normal(mu * np.ones(data['J']), tau))
         numpyro.sample('obs', dist.Normal(theta, data['sigma']), obs=data['y'])
 

--- a/arviz/tests/test_data_numpyro.py
+++ b/arviz/tests/test_data_numpyro.py
@@ -1,0 +1,26 @@
+# pylint: disable=no-member, invalid-name, redefined-outer-name
+import pytest
+
+from ..data.io_numpyro import from_numpyro
+from .helpers import (  # pylint: disable=unused-import
+    chains,
+    draws,
+    eight_schools_params,
+    load_cached_models,
+)
+
+
+class TestDataPyro:
+    @pytest.fixture(scope="class")
+    def data(self, eight_schools_params, draws, chains):
+        class Data:
+            obj = load_cached_models(eight_schools_params, draws, chains, "numpyro")["numpyro"]
+
+        return Data
+
+    def get_inference_data(self, data):
+        return from_numpyro(posterior=data.obj)
+
+    def test_inference_data(self, data):
+        inference_data = self.get_inference_data(data)
+        assert hasattr(inference_data, "posterior")

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -98,6 +98,7 @@ Data
     from_pymc3
     from_pyro
     from_pystan
+    from_numpyro
 
 Utils
 -----

--- a/doc/notebooks/InferenceDataCookbook.ipynb
+++ b/doc/notebooks/InferenceDataCookbook.ipynb
@@ -896,11 +896,65 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "## From NumPyro"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Inference data with groups:\n",
+       "\t> posterior\n",
+       "\t> sample_stats"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import os\n",
+    "# enable 4 CPU cores to draw chains in parallel\n",
+    "os.environ['XLA_FLAGS'] = '--xla_force_host_platform_device_count=4'\n",
+    "\n",
+    "import jax\n",
+    "jax.config.update('jax_platform_name', 'cpu')\n",
+    "\n",
+    "import numpyro\n",
+    "import numpyro.distributions as dist\n",
+    "from numpyro.distributions.constraints import AffineTransform\n",
+    "from numpyro.mcmc import MCMC, NUTS\n",
+    "\n",
+    "eight_school_data = {\n",
+    "    'J': 8,\n",
+    "    'y': np.array([28., 8., -3., 7., -1., 1., 18., 12.]),\n",
+    "    'sigma': np.array([15., 10., 16., 11., 9., 11., 10., 18.])\n",
+    "}\n",
+    "\n",
+    "def model(data):\n",
+    "    mu = numpyro.sample('mu', dist.Normal(0, 5))\n",
+    "    tau = numpyro.sample('tau', dist.HalfCauchy(5))\n",
+    "    # use non-centered reparameterization\n",
+    "    theta = numpyro.sample('theta', dist.TransformedDistribution(\n",
+    "        dist.Normal(np.zeros(data['J']), 1), AffineTransform(mu, tau)))\n",
+    "    numpyro.sample('obs', dist.Normal(theta, data['sigma']), obs=data['y'])\n",
+    "\n",
+    "kernel = NUTS(model)\n",
+    "mcmc = MCMC(kernel, num_warmup=500, num_samples=500, num_chains=4, chain_method='parallel')\n",
+    "mcmc.run(jax.random.PRNGKey(0), eight_school_data, collect_fields=('z', 'num_steps'))\n",
+    "\n",
+    "numpyro_data = az.from_numpyro(mcmc, coords={'school': np.arange(eight_school_data['J'])},\n",
+    "                               dims={'theta': ['school']})\n",
+    "numpyro_data"
+   ]
   }
  ],
  "metadata": {

--- a/doc/notebooks/InferenceDataCookbook.ipynb
+++ b/doc/notebooks/InferenceDataCookbook.ipynb
@@ -912,7 +912,8 @@
       "text/plain": [
        "Inference data with groups:\n",
        "\t> posterior\n",
-       "\t> sample_stats"
+       "\t> sample_stats\n",
+       "\t> posterior_predictive"
       ]
      },
      "execution_count": 17,
@@ -931,6 +932,7 @@
     "import numpyro\n",
     "import numpyro.distributions as dist\n",
     "from numpyro.distributions.constraints import AffineTransform\n",
+    "from numpyro.infer_util import predictive\n",
     "from numpyro.mcmc import MCMC, NUTS\n",
     "\n",
     "eight_school_data = {\n",
@@ -945,13 +947,17 @@
     "    # use non-centered reparameterization\n",
     "    theta = numpyro.sample('theta', dist.TransformedDistribution(\n",
     "        dist.Normal(np.zeros(data['J']), 1), AffineTransform(mu, tau)))\n",
-    "    numpyro.sample('obs', dist.Normal(theta, data['sigma']), obs=data['y'])\n",
+    "    numpyro.sample('y', dist.Normal(theta, data['sigma']), obs=data['y'])\n",
     "\n",
     "kernel = NUTS(model)\n",
     "mcmc = MCMC(kernel, num_warmup=500, num_samples=500, num_chains=4, chain_method='parallel')\n",
     "mcmc.run(jax.random.PRNGKey(0), eight_school_data, collect_fields=('z', 'num_steps'))\n",
+    "posterior_samples = mcmc.get_samples()[0]\n",
+    "posterior_predictive = predictive(\n",
+    "    jax.random.PRNGKey(1), model, posterior_samples, ('y',), eight_school_data)\n",
     "\n",
-    "numpyro_data = az.from_numpyro(mcmc, coords={'school': np.arange(eight_school_data['J'])},\n",
+    "numpyro_data = az.from_numpyro(mcmc, posterior_predictive=posterior_predictive,\n",
+    "                               coords={'school': np.arange(eight_school_data['J'])},\n",
     "                               dims={'theta': ['school']})\n",
     "numpyro_data"
    ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,3 +18,4 @@ sphinx-bootstrap-theme
 sphinx-gallery
 black; python_version == '3.6'
 numba
+numpyro


### PR DESCRIPTION
This PR addresses #810.

I marked some TODOs for future PRs (when NumPyro MCMC object stores model arguments/keywords for the purpose of extracting log_likelihoods, observed_data). Currently, users need to use numpyro.handlers, which is not handy, to obtain these informations.

Currently, the names of [sample stats in NumPyro](https://numpyro.readthedocs.io/en/stable/mcmc.html#numpyro.mcmc.HMCState) are:
+ ``potential_energy``
+ ``num_steps``  (which can be converted to tree depth by using np.log2 function)
+ ``accept_prob``
+ ``mean_accept_prob`` (mean acceptance probability until current iteration during warmup adaptation or sampling)
+ ``diverging``
+ ``adapt_state.step_size``
+ ``adapt_state.inverse_mass_matrix``

Do I need to rename those fields in `sample_stats_to_xarray` function to match arviz conventions?