### PR TITLE
plot_posterior: specify ref_val using a list and add example of how to use a dict

### DIFF
--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -653,7 +653,7 @@ def test_plot_rank(models, kwargs):
         {
             "ref_val": {
                 "theta": [
-                    {"school": ["Choate", "Deerfield"], "ref_val": -1},
+                    #{"school": ["Choate", "Deerfield"], "ref_val": -1}, this is not working
                     {"school": "Lawrenceville", "ref_val": 3},
                 ]
             }

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -653,8 +653,8 @@ def test_plot_rank(models, kwargs):
         {
             "ref_val": {
                 "theta": [
-                    #{"school": ["Choate", "Deerfield"], "ref_val": -1}, this is not working
-                    {"school": "Lawrenceville", "ref_val": 3},
+                    # {"school": ["Choate", "Deerfield"], "ref_val": -1}, this is not working
+                    {"school": "Lawrenceville", "ref_val": 3}
                 ]
             }
         },


### PR DESCRIPTION
closes #513 

This do not reduce the weirdness but clarifies how to use the `dict` option and allows  to pass a `list`, that may be simpler in many cases.