### PR TITLE
Fix warning in ref_val example of plot_posterior

### DIFF
--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -142,7 +142,7 @@ def plot_posterior(
         :context: close-figs
 
         >>> az.plot_posterior(data, ref_val= {"theta": [{"school": "Deerfield", "ref_val": 4},
-                                                        {"school": "Choate", "ref_val": 3}]})
+        ...                                             {"school": "Choate", "ref_val": 3}]})
 
     Show reference values using a list
 


### PR DESCRIPTION
One of the examples in `plot_posterior` related to `ref_val` usage raised an error and the image was not shown.