### PR TITLE
Hpd intervals

### DIFF
--- a/arviz/plots/densityplot.py
+++ b/arviz/plots/densityplot.py
@@ -282,7 +282,7 @@ def _d_helper(
     """
     if vec.dtype.kind == "f":
         if credible_interval != 1:
-            hpd_ = hpd(vec, credible_interval)
+            hpd_ = hpd(vec, credible_interval, multimodal=False)
             new_vec = vec[(vec >= hpd_[0]) & (vec <= hpd_[1])]
         else:
             new_vec = vec
@@ -302,7 +302,7 @@ def _d_helper(
             ax.fill_between(x, density, color=color, alpha=shade)
 
     else:
-        xmin, xmax = hpd(vec, credible_interval)
+        xmin, xmax = hpd(vec, credible_interval, multimodal=False)
         bins = range(xmin, xmax + 2)
         if outline:
             ax.hist(vec, bins=bins, color=color, histtype="step", align="left")

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -568,7 +568,7 @@ class VarHandler:
         """Get data for each treeplot for the variable."""
         for y, _, label, values, color in self.iterator():
             ntiles = np.percentile(values.flatten(), qlist)
-            ntiles[0], ntiles[-1] = hpd(values.flatten(), credible_interval)
+            ntiles[0], ntiles[-1] = hpd(values.flatten(), credible_interval, multimodal=False)
             yield y, label, ntiles, color
 
     def ridgeplot(self, mult, ridgeplot_kind):

--- a/arviz/plots/hpdplot.py
+++ b/arviz/plots/hpdplot.py
@@ -12,7 +12,6 @@ def plot_hpd(
     y,
     credible_interval=0.94,
     color="C1",
-    circular=False,
     smooth=True,
     smooth_kwargs=None,
     fill_kwargs=None,
@@ -32,9 +31,6 @@ def plot_hpd(
         Credible interval to plot. Defaults to 0.94.
     color : str
         Color used for the limits of the HPD interval and fill. Should be a valid matplotlib color
-    circular : bool, optional
-        Whether to compute the hpd taking into account `x` is a circular variable
-        (in the range [-np.pi, np.pi]) or not. Defaults to False (i.e non-circular variables).
     smooth : boolean
         If True the result will be smoothed by first computing a linear interpolation of the data
         over a regular grid and then applying the Savitzky-Golay filter to the interpolated data.
@@ -80,7 +76,7 @@ def plot_hpd(
         new_shape = tuple([-1] + list(x_shape))
         y = y.reshape(new_shape)
 
-    hpd_ = hpd(y, credible_interval=credible_interval, circular=circular)
+    hpd_ = hpd(y, credible_interval=credible_interval, multimodal=False)
 
     if smooth:
         if smooth_kwargs is None:

--- a/arviz/plots/hpdplot.py
+++ b/arviz/plots/hpdplot.py
@@ -12,6 +12,7 @@ def plot_hpd(
     y,
     credible_interval=0.94,
     color="C1",
+    circular=False,
     smooth=True,
     smooth_kwargs=None,
     fill_kwargs=None,
@@ -31,6 +32,9 @@ def plot_hpd(
         Credible interval to plot. Defaults to 0.94.
     color : str
         Color used for the limits of the HPD interval and fill. Should be a valid matplotlib color
+    circular : bool, optional
+        Whether to compute the hpd taking into account `x` is a circular variable
+        (in the range [-np.pi, np.pi]) or not. Defaults to False (i.e non-circular variables).
     smooth : boolean
         If True the result will be smoothed by first computing a linear interpolation of the data
         over a regular grid and then applying the Savitzky-Golay filter to the interpolated data.
@@ -76,7 +80,7 @@ def plot_hpd(
         new_shape = tuple([-1] + list(x_shape))
         y = y.reshape(new_shape)
 
-    hpd_ = hpd(y, credible_interval=credible_interval, multimodal=False)
+    hpd_ = hpd(y, credible_interval=credible_interval, circular=circular, multimodal=False)
 
     if smooth:
         if smooth_kwargs is None:

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -238,6 +238,33 @@ def make_label(var_name, selection, position="below"):
     return "{}{}{}".format(var_name, sep, sel)
 
 
+def format_sig_figs(value, default=None):
+    """Get a default number of significant figures.
+
+    Gives the integer part or `default`, whichever is bigger.
+
+    Examples
+    --------
+    0.1234 --> 0.12
+    1.234  --> 1.2
+    12.34  --> 12
+    123.4  --> 123
+    """
+    if default is None:
+        default = 2
+    if value == 0:
+        return 1
+    return max(int(np.log10(np.abs(value))) + 1, default)
+
+
+def round_num(n, round_to):
+    """
+    Returns a string representing a number with `round_to` significant figures.
+    """
+    sig_figs = format_sig_figs(n, round_to)
+    return "{n:.{sig_figs}g}".format(n=n, sig_figs=sig_figs)
+
+
 @conditional_jit(forceobj=True)
 def purge_duplicates(list_in):
     """Remove duplicates from list while preserving order.

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -259,7 +259,7 @@ def format_sig_figs(value, default=None):
 
 def round_num(n, round_to):
     """
-    Returns a string representing a number with `round_to` significant figures.
+    Return a string representing a number with `round_to` significant figures.
 
     Parameters
     ----------

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -260,6 +260,13 @@ def format_sig_figs(value, default=None):
 def round_num(n, round_to):
     """
     Returns a string representing a number with `round_to` significant figures.
+
+    Parameters
+    ----------
+    n : float
+        number to round
+    round_to : int
+        number of significant figures
     """
     sig_figs = format_sig_figs(n, round_to)
     return "{n:.{sig_figs}g}".format(n=n, sig_figs=sig_figs)

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -15,8 +15,10 @@ from .plot_utils import (
     _create_axes_grid,
     get_coords,
     filter_plotters_list,
+    format_sig_figs,
+    round_num,
 )
-from ..utils import _var_names, format_sig_figs
+from ..utils import _var_names
 
 
 def plot_posterior(
@@ -26,6 +28,7 @@ def plot_posterior(
     figsize=None,
     textsize=None,
     credible_interval=0.94,
+    multimodal=True,
     round_to: Optional[int] = None,
     point_estimate="mean",
     group="posterior",
@@ -55,6 +58,9 @@ def plot_posterior(
         on figsize.
     credible_interval : float, optional
         Credible intervals. Defaults to 0.94. Use None to hide the credible interval
+    multimodal : bool
+        If true (default) it may compute more than one credible interval if the distribution is
+        multimodal and the modes are well separated.
     round_to : int, optional
         Controls formatting of floats. Defaults to 2 or the integer part, whichever is bigger.
     point_estimate: str
@@ -202,6 +208,7 @@ def plot_posterior(
             point_estimate=point_estimate,
             round_to=round_to,
             credible_interval=credible_interval,
+            multimodal=multimodal,
             ref_val=ref_val,
             rope=rope,
             ax_labelsize=ax_labelsize,
@@ -226,6 +233,7 @@ def _plot_posterior_op(
     kind,
     point_estimate,
     credible_interval,
+    multimodal,
     ref_val,
     rope,
     ax_labelsize,
@@ -234,8 +242,6 @@ def _plot_posterior_op(
     **kwargs
 ):  # noqa: D202
     """Artist to draw posterior."""
-
-    significant_fig_func = lambda v: format_sig_figs(v, default=round_to)
 
     def format_as_percent(x, round_to=0):
         return "{0:.{1:d}f}%".format(100 * x, round_to)
@@ -306,7 +312,7 @@ def _plot_posterior_op(
             (plot_height * 0.02, plot_height * 0.02),
             lw=linewidth * 5,
             color="C2",
-            solid_capstyle="round",
+            solid_capstyle="butt",
             zorder=0,
             alpha=0.7,
         )
@@ -330,7 +336,7 @@ def _plot_posterior_op(
                 point_value = mode(values)[0][0]
         elif point_estimate == "median":
             point_value = np.median(values)
-        sig_figs = significant_fig_func(point_value)
+        sig_figs = format_sig_figs(point_value, round_to)
         point_text = "{point_estimate}={point_value:.{sig_figs}g}".format(
             point_estimate=point_estimate, point_value=point_value, sig_figs=sig_figs
         )
@@ -345,40 +351,39 @@ def _plot_posterior_op(
     def display_hpd():
         # np.ndarray with 2 entries, min and max
         # pylint: disable=line-too-long
-        hpd_intervals = hpd(values, credible_interval=credible_interval)  # type: np.ndarray
+        hpd_intervals = hpd(
+            values, credible_interval=credible_interval, multimodal=multimodal
+        )  # type: np.ndarray
 
-        def round_num(n: float) -> str:
-            sig_figs = significant_fig_func(n)
-            return "{n:.{sig_figs}g}".format(n=n, sig_figs=sig_figs)
-
-        ax.plot(
-            hpd_intervals,
-            (plot_height * 0.02, plot_height * 0.02),
-            lw=linewidth * 2,
-            color="k",
-            solid_capstyle="round",
-        )
-        ax.text(
-            hpd_intervals[0],
-            plot_height * 0.07,
-            round_num(hpd_intervals[0]),
-            size=ax_labelsize,
-            horizontalalignment="center",
-        )
-        ax.text(
-            hpd_intervals[1],
-            plot_height * 0.07,
-            round_num(hpd_intervals[1]),
-            size=ax_labelsize,
-            horizontalalignment="center",
-        )
-        ax.text(
-            (hpd_intervals[0] + hpd_intervals[1]) / 2,
-            plot_height * 0.3,
-            format_as_percent(credible_interval) + " HPD",
-            size=ax_labelsize,
-            horizontalalignment="center",
-        )
+        for hpdi in hpd_intervals:
+            ax.plot(
+                hpdi,
+                (plot_height * 0.02, plot_height * 0.02),
+                lw=linewidth * 2,
+                color="k",
+                solid_capstyle="butt",
+            )
+            ax.text(
+                hpdi[0],
+                plot_height * 0.07,
+                round_num(hpdi[0], round_to),
+                size=ax_labelsize,
+                horizontalalignment="center",
+            )
+            ax.text(
+                hpdi[1],
+                plot_height * 0.07,
+                round_num(hpdi[1], round_to),
+                size=ax_labelsize,
+                horizontalalignment="center",
+            )
+            ax.text(
+                (hpdi[0] + hpdi[1]) / 2,
+                plot_height * 0.3,
+                format_as_percent(credible_interval) + " HPD",
+                size=ax_labelsize,
+                horizontalalignment="center",
+            )
 
     def format_axes():
         ax.yaxis.set_ticks([])

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -28,7 +28,7 @@ def plot_posterior(
     figsize=None,
     textsize=None,
     credible_interval=0.94,
-    multimodal=True,
+    multimodal=False,
     round_to: Optional[int] = None,
     point_estimate="mean",
     group="posterior",

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -355,7 +355,7 @@ def _plot_posterior_op(
             values, credible_interval=credible_interval, multimodal=multimodal
         )  # type: np.ndarray
 
-        for hpdi in hpd_intervals:
+        for hpdi in np.atleast_2d(hpd_intervals):
             ax.plot(
                 hpdi,
                 (plot_height * 0.02, plot_height * 0.02),

--- a/arviz/plots/violinplot.py
+++ b/arviz/plots/violinplot.py
@@ -95,7 +95,7 @@ def plot_violin(
             _violinplot(val, shade, bw, ax[axind], **kwargs_shade)
 
         per = np.percentile(val, [25, 75, 50])
-        hpd_intervals = hpd(val, credible_interval)
+        hpd_intervals = hpd(val, credible_interval, multimodal=False)
 
         if quartiles:
             ax[axind].plot([0, 0], per[:2], lw=linewidth * 3, color="k", solid_capstyle="round")

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -315,7 +315,7 @@ def hpd(ary, credible_interval=0.94, circular=False, multimodal=False):
 
     Parameters
     ----------
-    x : Numpy array
+    ary : Numpy array
         An array containing posterior samples
     credible_interval : float, optional
         Credible interval to compute. Defaults to 0.94.

--- a/arviz/tests/test_plot_utils.py
+++ b/arviz/tests/test_plot_utils.py
@@ -11,8 +11,24 @@ from ..plots.plot_utils import (
     get_bins,
     get_coords,
     filter_plotters_list,
+    format_sig_figs,
 )
 from ..rcparams import rc_context
+
+
+@pytest.mark.parametrize(
+    "value, default, expected",
+    [
+        (123.456, 2, 3),
+        (-123.456, 3, 3),
+        (-123.456, 4, 4),
+        (12.3456, 2, 2),
+        (1.23456, 2, 2),
+        (0.123456, 2, 2),
+    ],
+)
+def test_format_sig_figs(value, default, expected):
+    assert format_sig_figs(value, default=default) == expected
 
 
 @pytest.fixture(scope="function")

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -723,7 +723,7 @@ def test_plot_compare_no_ic(models):
 @pytest.mark.parametrize(
     "kwargs",
     [
-        {"color": "0.5", "circular": True},
+        {"color": "0.5"},
         {"fill_kwargs": {"alpha": 0}},
         {"plot_kwargs": {"alpha": 0}},
         {"smooth_kwargs": {"window_length": 33, "polyorder": 5, "mode": "mirror"}},

--- a/arviz/tests/test_plots.py
+++ b/arviz/tests/test_plots.py
@@ -723,7 +723,7 @@ def test_plot_compare_no_ic(models):
 @pytest.mark.parametrize(
     "kwargs",
     [
-        {"color": "0.5"},
+        {"color": "0.5", "circular": True},
         {"fill_kwargs": {"alpha": 0}},
         {"plot_kwargs": {"alpha": 0}},
         {"smooth_kwargs": {"window_length": 33, "polyorder": 5, "mode": "mirror"}},

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -44,13 +44,7 @@ def non_centered_eight():
 def test_hpd():
     normal_sample = np.random.randn(5000000)
     interval = hpd(normal_sample)
-    assert_array_almost_equal(interval, [-1.88, 1.88], 2)
-
-
-def test_hpd_bad_ci():
-    normal_sample = np.random.randn(10)
-    with pytest.raises(ValueError):
-        hpd(normal_sample, credible_interval=2)
+    assert_array_almost_equal(interval[0], [-1.9, 1.9], 1)
 
 
 def test_r2_score():

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -44,7 +44,13 @@ def non_centered_eight():
 def test_hpd():
     normal_sample = np.random.randn(5000000)
     interval = hpd(normal_sample)
-    assert_array_almost_equal(interval[0], [-1.9, 1.9], 1)
+    assert_array_almost_equal(interval, [-1.88, 1.88], 2)
+
+
+def test_hpd_bad_ci():
+    normal_sample = np.random.randn(10)
+    with pytest.raises(ValueError):
+        hpd(normal_sample, credible_interval=2)
 
 
 def test_r2_score():

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -47,6 +47,20 @@ def test_hpd():
     assert_array_almost_equal(interval, [-1.88, 1.88], 2)
 
 
+def test_hpd_multimodal():
+    normal_sample = np.concatenate(
+        (np.random.normal(-4, 1, 2500000), np.random.normal(2, 0.5, 2500000))
+    )
+    intervals = hpd(normal_sample, multimodal=True)
+    assert_array_almost_equal(intervals, [[-5.8, -2.2], [0.9, 3.1]], 1)
+
+
+def test_hpd_circular():
+    normal_sample = np.random.vonmises(np.pi, 1, 5000000)
+    interval = hpd(normal_sample, circular=True)
+    assert_array_almost_equal(interval, [0.6, -0.6], 1)
+
+
 def test_hpd_bad_ci():
     normal_sample = np.random.randn(10)
     with pytest.raises(ValueError):

--- a/arviz/tests/test_utils.py
+++ b/arviz/tests/test_utils.py
@@ -7,17 +7,7 @@ import importlib
 import numpy as np
 import pytest
 
-from ..utils import (
-    _var_names,
-    format_sig_figs,
-    numba_check,
-    Numba,
-    _numba_var,
-    _stack,
-    one_de,
-    two_de,
-    expand_dims,
-)
+from ..utils import _var_names, numba_check, Numba, _numba_var, _stack, one_de, two_de, expand_dims
 from ..data import load_arviz_data, from_dict
 from ..stats.stats_utils import stats_variance_2d as svar
 
@@ -151,21 +141,6 @@ def test_conditional_jit_numba_decorator_keyword(monkeypatch):
     function_results, wrapper_result = placeholder_func()
     assert wrapper_result == {"keyword_argument": "A keyword argument"}
     assert function_results == "output"
-
-
-@pytest.mark.parametrize(
-    "value, default, expected",
-    [
-        (123.456, 2, 3),
-        (-123.456, 3, 3),
-        (-123.456, 4, 4),
-        (12.3456, 2, 2),
-        (1.23456, 2, 2),
-        (0.123456, 2, 2),
-    ],
-)
-def test_format_sig_figs(value, default, expected):
-    assert format_sig_figs(value, default=default) == expected
 
 
 def test_conditional_vect_numba_decorator():

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -191,25 +191,6 @@ def conditional_jit(_func=None, **kwargs):
         return functools.wraps(_func)(lazy_numba)
 
 
-def format_sig_figs(value, default=None):
-    """Get a default number of significant figures.
-
-    Gives the integer part or `default`, whichever is bigger.
-
-    Examples
-    --------
-    0.1234 --> 0.12
-    1.234  --> 1.2
-    12.34  --> 12
-    123.4  --> 123
-    """
-    if default is None:
-        default = 2
-    if value == 0:
-        return 1
-    return max(int(np.log10(np.abs(value))) + 1, default)
-
-
 def conditional_vect(function=None, **kwargs):  # noqa: D202
     """Use numba's vectorize decorator if numba is installed.
 


### PR DESCRIPTION
Introduces a new argument `multimodal` to `az.hpd`, if `True` (defaults) it may compute more than 1 hpd interval if the distribution is multimodal and the modes are _well separated_. For `plot_posterior` `multimodal = True` by default and we may get something like:
![lala](https://user-images.githubusercontent.com/1338958/66260361-1ed59280-e794-11e9-9167-00f45e878508.png)

if `multimodal = False` (or the older behaviour)

![lele](https://user-images.githubusercontent.com/1338958/66260363-239a4680-e794-11e9-8c27-517f430e4a9d.png)


For all other functions/plots, like `summary`,`plot_forest` etc  `multimodal = False`, mainly because at the moment I am not sure how to handle more than one interval.