### PR TITLE
Add InferenceData class to docs

### DIFF
--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -13,9 +13,9 @@ from ..rcparams import rcParams
 class InferenceData:
     """Container for inference data storage using xarray.
 
-    For a detailed introduction on ``InferenceData`` objects and its usage, see
-    :doc:`/notebooks/XarrayforArviZ`. This page is provides help and documentation
-    on ``InferenceData`` methods and its low level implementation.
+    For a detailed introduction to ``InferenceData`` objects and their usage, see
+    :doc:`/notebooks/XarrayforArviZ`. This page provides help and documentation
+    on ``InferenceData`` methods and their low level implementation.
     """
 
     def __init__(self, **kwargs):
@@ -174,7 +174,7 @@ class InferenceData:
         -------
         InferenceData
             A new InferenceData object by default.
-            When `inplace==True` perform selection inplace and return `None`
+            When `inplace==True` perform selection in place and return `None`
 
         Examples
         --------

--- a/arviz/data/io_emcee.py
+++ b/arviz/data/io_emcee.py
@@ -316,13 +316,15 @@ def from_emcee(
         >>> sampler.run_mcmc(pos, draws);
 
     And convert the sampler to an InferenceData object. As emcee does not store variable
-    names, they must be passed to the converter in order to have them:
+    names, they must be passed to the converter in order to have them. It can also be useful
+    to perform a burn in cut to the MCMC samples (see :meth:`arviz.InferenceData.sel` for
+    more details):
 
     .. plot::
         :context: close-figs
 
         >>> var_names = ['mu', 'tau']+['eta{}'.format(i) for i in range(J)]
-        >>> emcee_data = az.from_emcee(sampler, var_names=var_names)
+        >>> emcee_data = az.from_emcee(sampler, var_names=var_names).sel(draw=slice(100, None))
 
     From an InferenceData object, ArviZ's native data structure, the posterior plot
     of the first 3 variables can be done in one line:

--- a/doc/_templates/class_members.rst
+++ b/doc/_templates/class_members.rst
@@ -1,0 +1,30 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+
+   {% block methods %}
+   {% if methods %}
+
+   .. rubric:: Methods
+
+   .. autosummary::
+      :toctree:
+
+   {% for item in methods %}
+      {{ objname }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: Attributes
+
+   .. autosummary::
+   {% for item in attributes %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -84,8 +84,13 @@ Data
 ----
 
 .. autosummary::
-    :toctree: generated/
+   :toctree: generated/
+   :template: class_members.rst
 
+   InferenceData
+
+.. autosummary::
+    :toctree: generated/
 
     convert_to_inference_data
     load_arviz_data

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -80,6 +80,8 @@ Stats utils
     make_ufunc
     wrap_xarray_ufunc
 
+.. _data_api:
+
 Data
 ----
 


### PR DESCRIPTION
Fixes #711. 

This PR adds an entrance to the API section named InferenceData which links to the following page:

![image](https://user-images.githubusercontent.com/23738400/66272831-c921e880-e86e-11e9-8ad6-22005b720147.png)

At the same time, each entrance listed in the Methods section links to a page for each method. The one for `sel` looks like this:

![image](https://user-images.githubusercontent.com/23738400/66272860-fff7fe80-e86e-11e9-96c5-a6e4e8ff7bed.png)

This is achieved using the `class_members` template (as opposite to the `class` template used for `Numba` or `interactive_backend` classes). It also extends the documentation on `InferenceData` and its `__init__` and `sel` mehtods.