### PR TITLE
Update for pyro 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ matrix:
     - name: "Python 3.6 Unit Test"
       python: 3.6
       env: PYTHON_VERSION=3.6 PYSTAN_VERSION=latest PYRO_VERSION=latest EMCEE_VERSION=latest NAME="UNIT"
-    - name: "Python 3.6 Unit Test - PyStan=3 Emcee=2 TF=1"
+    - name: "Python 3.6 Unit Test - PyStan=3 Pyro=0.5.1 Emcee=2 TF=1"
       python: 3.6
-      env: PYTHON_VERSION=3.6 PYSTAN_VERSION=preview PYRO_VERSION=latest EMCEE_VERSION=2 TF_VERSION=1 NAME="UNIT"
+      env: PYTHON_VERSION=3.6 PYSTAN_VERSION=preview PYRO_VERSION=0.5.1 PYTORCH_VERSION=1.3.0 EMCEE_VERSION=2 TF_VERSION=1 NAME="UNIT"
     - name: "Python 3.5 Unit Test"
       python: 3.5
       env: PYTHON_VERSION=3.5 PYSTAN_VERSION=latest PYRO_VERSION=latest EMCEE_VERSION=latest NAME="UNIT"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ matrix:
     - name: "Python 3.6 Unit Test"
       python: 3.6
       env: PYTHON_VERSION=3.6 PYSTAN_VERSION=latest PYRO_VERSION=latest EMCEE_VERSION=latest NAME="UNIT"
-    - name: "Python 3.6 Unit Test - PyStan=3 Pyro=0.2.1 Emcee=2 TF=1"
+    - name: "Python 3.6 Unit Test - PyStan=3 Emcee=2 TF=1"
       python: 3.6
-      env: PYTHON_VERSION=3.6 PYSTAN_VERSION=preview PYRO_VERSION=0.2.1 PYTORCH_VERSION=0.4.1 EMCEE_VERSION=2 TF_VERSION=1 NAME="UNIT"
+      env: PYTHON_VERSION=3.6 PYSTAN_VERSION=preview PYRO_VERSION=latest EMCEE_VERSION=2 TF_VERSION=1 NAME="UNIT"
     - name: "Python 3.5 Unit Test"
       python: 3.5
       env: PYTHON_VERSION=3.5 PYSTAN_VERSION=latest PYRO_VERSION=latest EMCEE_VERSION=latest NAME="UNIT"

--- a/arviz/data/io_pyro.py
+++ b/arviz/data/io_pyro.py
@@ -59,7 +59,7 @@ class PyroConverter:
         divergences = self.posterior.diagnostics()["divergences"]
         diverging = np.zeros((self.nchains, self.ndraws), dtype=np.bool)
         for i, k in enumerate(sorted(divergences)):
-            diverging[i, divergences[k]] = 1
+            diverging[i, divergences[k]] = True
         data = {"diverging": diverging}
         return dict_to_dataset(data, library=self.pyro, coords=self.coords, dims=self.dims)
 
@@ -115,8 +115,6 @@ def from_pyro(posterior=None, *, prior=None, posterior_predictive=None, coords=N
         Prior samples from a Pyro model
     posterior_predictive : dict
         Posterior predictive samples for the posterior
-    observed_data : dict
-        Observed data used in the sampling.
     coords : dict[str] -> list[str]
         Map of dimensions to coordinates
     dims : dict[str] -> list[str]

--- a/arviz/data/io_pyro.py
+++ b/arviz/data/io_pyro.py
@@ -1,14 +1,19 @@
-"""pyro-specific conversion code."""
+"""Pyro-specific conversion code."""
+import logging
+import numpy as np
+
 from .inference_data import InferenceData
-from .base import dict_to_dataset
+from .base import requires, dict_to_dataset
 from .. import utils
+
+_log = logging.getLogger(__name__)
 
 
 class PyroConverter:
     """Encapsulate Pyro specific logic."""
 
-    def __init__(self, *, posterior, prior=None, posterior_predictive=None, observed_data=None, coords=None, dims=None):
-        """Convert pyro data into an InferenceData object.
+    def __init__(self, *, posterior, prior=None, posterior_predictive=None, coords=None, dims=None):
+        """Convert Pyro data into an InferenceData object.
 
         Parameters
         ----------
@@ -18,59 +23,80 @@ class PyroConverter:
             Prior samples from a Pyro model
         posterior_predictive : dict
             Posterior predictive samples for the posterior
-        observed_data : dict
-            Observed data used in the sampling.
         coords : dict[str] -> list[str]
             Map of dimensions to coordinates
         dims : dict[str] -> list[str]
             Map variable names to their coordinates
         """
         self.posterior = posterior
+        self.nchains, self.ndraws = posterior.num_chains, posterior.num_samples
         self.prior = prior
         self.posterior_predictive = posterior_predictive
-        self.observed_data = observed_data
         self.coords = coords
         self.dims = dims
         import pyro
 
         self.pyro = pyro
 
+    @requires("posterior")
     def posterior_to_xarray(self):
         """Convert the posterior to an xarray dataset."""
-        # Do not make pyro a requirement
-        from pyro.infer import EmpiricalMarginal
-
-        try:  # Try pyro>=0.3 release syntax
-            data = {
-                name: utils.expand_dims(samples.enumerate_support().squeeze())
-                if self.posterior.num_chains == 1
-                else samples.enumerate_support().squeeze()
-                for name, samples in self.posterior.marginal(
-                    sites=self.latent_vars
-                ).empirical.items()
-            }
-        except AttributeError:  # Use pyro<0.3 release syntax
-            data = {}
-            for var_name in self.latent_vars:
-                # pylint: disable=no-member
-                samples = EmpiricalMarginal(
-                    self.posterior, sites=var_name
-                ).get_samples_and_weights()[0]
-                samples = samples.numpy().squeeze()
-                data[var_name] = utils.expand_dims(samples)
+        data = self.posterior.get_samples(group_by_chain=True)
+        data = {k: v.detach().cpu().numpy() for k, v in data.items()}
         return dict_to_dataset(data, library=self.pyro, coords=self.coords, dims=self.dims)
+
+    @requires("posterior")
+    def sample_stats_to_xarray(self):
+        """Extract sample_stats from Pyro posterior."""
+        divergences = self.posterior.diagnostics()["divergences"]
+        diverging = np.zeros((self.nchains, self.ndraws), dtype=np.bool)
+        for i, k in enumerate(sorted(divergences)):
+            diverging[i, divergences[k]] = 1
+        data = {"diverging": diverging}
+        return dict_to_dataset(data, library=self.pyro, coords=self.coords, dims=self.dims)
+
+    @requires("posterior_predictive")
+    def posterior_predictive_to_xarray(self):
+        """Convert posterior_predictive samples to xarray."""
+        data = {}
+        for k, ary in self.posterior_predictive.items():
+            ary = ary.detach().cpu().numpy()
+            shape = ary.shape
+            if shape[0] == self.nchains and shape[1] == self.ndraws:
+                data[k] = ary
+            elif shape[0] == self.nchains * self.ndraws:
+                data[k] = ary.reshape((self.nchains, self.ndraws, *shape[1:]))
+            else:
+                data[k] = utils.expand_dims(ary)
+                _log.warning(
+                    "posterior predictive shape not compatible with number of chains and draws. "
+                    "This can mean that some draws or even whole chains are not represented."
+                )
+        return dict_to_dataset(data, library=self.pyro, coords=self.coords, dims=self.dims)
+
+    @requires("prior")
+    def prior_to_xarray(self):
+        """Convert prior samples to xarray."""
+        return dict_to_dataset(
+            {k: utils.expand_dims(v.detach().cpu().numpy()) for k, v in self.prior.items()},
+            library=self.pyro,
+            coords=self.coords,
+            dims=self.dims,
+        )
 
     def to_inference_data(self):
         """Convert all available data to an InferenceData object."""
         return InferenceData(
             **{
                 "posterior": self.posterior_to_xarray(),
-                "observed_data": self.observed_data_to_xarray(),
+                "sample_stats": self.sample_stats_to_xarray(),
+                "posterior_predictive": self.posterior_predictive_to_xarray(),
+                "prior": self.prior_to_xarray(),
             }
         )
 
 
-def from_pyro(posterior=None, *, prior=None, posterior_predictive=None, observed_data=None, coords=None, dims=None):
+def from_pyro(posterior=None, *, prior=None, posterior_predictive=None, coords=None, dims=None):
     """Convert Pyro data into an InferenceData object.
 
     Parameters
@@ -92,7 +118,6 @@ def from_pyro(posterior=None, *, prior=None, posterior_predictive=None, observed
         posterior=posterior,
         prior=prior,
         posterior_predictive=posterior_predictive,
-        observed_data=observed_data,
         coords=coords,
         dims=dims,
     ).to_inference_data()

--- a/arviz/data/io_pyro.py
+++ b/arviz/data/io_pyro.py
@@ -12,7 +12,12 @@ _log = logging.getLogger(__name__)
 class PyroConverter:
     """Encapsulate Pyro specific logic."""
 
-    def __init__(self, *, posterior, prior=None, posterior_predictive=None, coords=None, dims=None):
+    nchains = None  # type: int
+    ndraws = None  # type: int
+
+    def __init__(
+        self, *, posterior=None, prior=None, posterior_predictive=None, coords=None, dims=None
+    ):
         """Convert Pyro data into an InferenceData object.
 
         Parameters
@@ -29,7 +34,10 @@ class PyroConverter:
             Map variable names to their coordinates
         """
         self.posterior = posterior
-        self.nchains, self.ndraws = posterior.num_chains, posterior.num_samples
+        if posterior is not None:
+            self.nchains, self.ndraws = posterior.num_chains, posterior.num_samples
+        else:
+            self.nchains = self.ndraws = 0
         self.prior = prior
         self.posterior_predictive = posterior_predictive
         self.coords = coords

--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -263,7 +263,7 @@ def emcee_schools_model(data, draws, chains):
     return sampler
 
 
-# pylint:disable=no-member,no-value-for-parameter
+# pylint:disable=no-member,no-value-for-parameter,invalid-name
 def _pyro_noncentered_model(J, sigma, y=None):
     import pyro
     import pyro.distributions as dist
@@ -281,8 +281,8 @@ def pyro_noncentered_schools(data, draws, chains):
     import torch
     from pyro.infer import MCMC, NUTS
 
-    y = torch.tensor(data["y"]).float()
-    sigma = torch.tensor(data["sigma"]).float()
+    y = torch.from_numpy(data["y"]).float()
+    sigma = torch.from_numpy(data["sigma"]).float()
 
     nuts_kernel = NUTS(_pyro_noncentered_model, jit_compile=True, ignore_jit_warnings=True)
     posterior = MCMC(nuts_kernel, num_samples=draws, warmup_steps=draws, num_chains=chains)

--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -284,7 +284,7 @@ def pyro_noncentered_schools(data, draws, chains):
     y = torch.from_numpy(data["y"]).float()
     sigma = torch.from_numpy(data["sigma"]).float()
 
-    nuts_kernel = NUTS(_pyro_noncentered_model, jit_compile=True, ignore_jit_warnings=True)
+    nuts_kernel = NUTS(_pyro_noncentered_model)
     posterior = MCMC(nuts_kernel, num_samples=draws, warmup_steps=draws, num_chains=chains)
     posterior.run(data["J"], sigma, y)
 

--- a/arviz/tests/test_data_pyro.py
+++ b/arviz/tests/test_data_pyro.py
@@ -10,7 +10,6 @@ from .helpers import (  # pylint: disable=unused-import
 )
 
 
-@pytest.mark.xfail(reason="Temporary xfail for Pyro tests.")
 class TestDataPyro:
     @pytest.fixture(scope="class")
     def data(self, eight_schools_params, draws, chains):

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,11 +14,11 @@ jobs:
         PYRO_VERSION: "latest"
         EMCEE_VERSION: "latest"
         NAME: "UNIT"
-      Python_36_Unit_Test_PyStan_3_Pyro_0.2.1_Emcee_2_tf_1:
+      Python_36_Unit_Test_PyStan_3_Pyro_0.5.1_Emcee_2_tf_1:
         PYTHON_VERSION: 3.6
         PYSTAN_VERSION: "preview"
-        PYRO_VERSION: 0.2.1
-        PYTORCH_VERSION: 0.4.1
+        PYRO_VERSION: 0.5.1
+        PYTORCH_VERSION: 1.3.0
         EMCEE_VERSION: 2
         TF_VERSION: 1
         NAME: "UNIT"

--- a/doc/notebooks/InferenceDataCookbook.ipynb
+++ b/doc/notebooks/InferenceDataCookbook.ipynb
@@ -426,18 +426,13 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Sample: 100%|██████████| 1000/1000 [00:02<00:00, 361.21it/s, step size=2.00e+00, acc. prob=0.003]\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
        "Inference data with groups:\n",
        "\t> posterior\n",
-       "\t> observed_data"
+       "\t> sample_stats\n",
+       "\t> posterior_predictive\n",
+       "\t> prior"
       ]
      },
      "execution_count": 19,
@@ -450,42 +445,40 @@
     "\n",
     "import pyro\n",
     "import pyro.distributions as dist\n",
-    "import pyro.poutine as poutine\n",
-    "from pyro.infer.mcmc import MCMC, NUTS\n",
+    "from pyro.infer import MCMC, NUTS, Predictive\n",
     "\n",
     "pyro.enable_validation(True)\n",
     "pyro.set_rng_seed(0)\n",
     "\n",
-    "draws = 1000\n",
-    "warmup_steps = 0\n",
+    "draws = 500\n",
+    "chains = 2\n",
     "eight_school_data = {\n",
     "    'J': 8,\n",
-    "    'y': np.array([28., 8., -3., 7., -1., 1., 18., 12.]),\n",
-    "    'sigma': np.array([15., 10., 16., 11., 9., 11., 10., 18.])\n",
+    "    'y': torch.tensor([28., 8., -3., 7., -1., 1., 18., 12.]),\n",
+    "    'sigma': torch.tensor([15., 10., 16., 11., 9., 11., 10., 18.])\n",
     "}\n",
     "\n",
+    "def model(J, sigma, y=None):\n",
+    "    mu = pyro.sample('mu', dist.Normal(0, 5))\n",
+    "    tau = pyro.sample('tau', dist.HalfCauchy(5))\n",
+    "    with pyro.plate('J', J):\n",
+    "        theta_tilde = pyro.sample('theta_tilde', dist.Normal(0, 1))\n",
+    "        theta = mu + tau * theta_tilde\n",
+    "        return pyro.sample(\"obs\", dist.Normal(theta, sigma), obs=y)\n",
     "\n",
-    "def model(sigma):\n",
-    "    eta = pyro.sample('eta', dist.Normal(torch.zeros(eight_school_data['J']), torch.ones(eight_school_data['J'])))\n",
-    "    mu = pyro.sample('mu', dist.Normal(torch.zeros(1), 10 * torch.ones(1)))\n",
-    "    tau = pyro.sample('tau', dist.HalfCauchy(scale=25 * torch.ones(1)))\n",
+    "nuts_kernel = NUTS(model, jit_compile=True, ignore_jit_warnings=True)\n",
+    "mcmc = MCMC(nuts_kernel, num_samples=draws, warmup_steps=draws,\n",
+    "            num_chains=chains, disable_progbar=True)\n",
+    "mcmc.run(**eight_school_data)\n",
+    "posterior_samples = mcmc.get_samples()\n",
+    "posterior_predictive = Predictive(model, posterior_samples).get_samples(\n",
+    "    eight_school_data['J'], eight_school_data['sigma'])\n",
+    "prior = Predictive(model, num_samples=500).get_samples(\n",
+    "    eight_school_data['J'], eight_school_data['sigma'])\n",
     "\n",
-    "    theta = mu + tau * eta\n",
-    "\n",
-    "    return pyro.sample(\"obs\", dist.Normal(theta, sigma))\n",
-    "\n",
-    "\n",
-    "def conditioned_model(model, sigma, y):\n",
-    "    return poutine.condition(model, data={\"obs\": y})(sigma)\n",
-    "\n",
-    "\n",
-    "\n",
-    "nuts_kernel = NUTS(conditioned_model, adapt_step_size=True)\n",
-    "posterior = MCMC(nuts_kernel,\n",
-    "                 num_samples=draws,\n",
-    "                 warmup_steps=warmup_steps).run(model, torch.Tensor(eight_school_data['sigma']), torch.Tensor(eight_school_data['y']))\n",
-    "\n",
-    "pyro_data = az.from_pyro(posterior)\n",
+    "pyro_data = az.from_pyro(mcmc, prior=prior, posterior_predictive=posterior_predictive,\n",
+    "                         coords={'school': np.arange(eight_school_data['J'])},\n",
+    "                         dims={'theta': ['school']})\n",
     "pyro_data"
    ]
   },
@@ -977,5 +970,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ nbsphinx
 numpydoc
 pydocstyle
 pylint
-pyro-ppl
+pyro-ppl>=0.5.1
 tensorflow
 tensorflow-probability
 pytest


### PR DESCRIPTION
Addresses #845. In this PR, I added
+ posterior_predictive
+ diverging stat
+ prior + prior_predictive
and remove `observed_data` because it is not accessible for now (will support it for the next Pyro release).

It is pretty complicated to make it compatible with the old Pyro API so I also drop that support.

cc @OriolAbril 