### PR TITLE
[WIP] simple mpld3 demo

### DIFF
--- a/arviz/plots/distplot.py
+++ b/arviz/plots/distplot.py
@@ -115,7 +115,7 @@ def plot_dist(
         plot_kwargs.setdefault("color", color)
         legend = label is not None
 
-        plot_kde(
+        _, line = plot_kde(
             values,
             values2,
             cumulative=cumulative,
@@ -134,7 +134,7 @@ def plot_dist(
             contour_kwargs=contour_kwargs,
             ax=ax,
         )
-    return ax
+    return ax, line
 
 
 def _histplot_op(values, values2, rotated, ax, hist_kwargs):

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -225,10 +225,10 @@ def plot_kde(
         else:
             fill_kwargs.setdefault("alpha", 0)
             if fill_kwargs.get("alpha") == 0:
-                ax.plot(x, density, label=label, **plot_kwargs)
+                line = ax.plot(x, density, label=label, **plot_kwargs)
                 fill_func(fill_x, fill_y, **fill_kwargs)
             else:
-                ax.plot(x, density, **plot_kwargs)
+                line = ax.plot(x, density, **plot_kwargs)
                 fill_func(fill_x, fill_y, label=label, **fill_kwargs)
         if legend and label:
             ax.legend()
@@ -259,7 +259,7 @@ def plot_kde(
         else:
             ax.pcolormesh(x_x, y_y, density, **pcolormesh_kwargs)
 
-    return ax
+    return ax, line
 
 
 def _fast_kde(x, cumulative=False, bw=4.5, xmin=None, xmax=None):


### PR DESCRIPTION
This is an example of using mpld3, so far it seems simple things are simple to do. Like writing in a notebook `mpld3.display()` after a plot gives you a simple interactive plot (just zooming and panning) similar to what you get with `%matplotlib notebook`. You can also (un)comment `mpld3.display()` to switch between the interactive and static version of the plot. 

Here I am using a mpld3 plugin `InteractiveLegendPlugin` this requires just a few changes to the code, but surely I am breaking stuff so more changes are needed. It seems plugins are easy to write assuming you know javascript and D3. 

Still not sure about how easy will be to do more complex stuff like choosing a portion of the trace and getting the density/histogram for that portion.

Attached you will find a html file showing an example of a interactive traceplot.

[lolo.zip](https://github.com/arviz-devs/arviz/files/3809568/lolo.zip)
