### PR TITLE
Don't require posterior in loo if not used. Also make errors more dispassionate.

### DIFF
--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -484,14 +484,12 @@ def loo(data, pointwise=False, reff=None, scale="deviance"):
 
     """
     inference_data = convert_to_inference_data(data)
-    for group in ("posterior", "sample_stats"):
-        if not hasattr(inference_data, group):
-            raise TypeError(
-                "Must be able to extract a {group} group from data!".format(group=group)
-            )
+    if not hasattr(inference_data, "sample_stats"):
+        raise TypeError(
+            "Must be able to extract a sample_stats group from data!"
+        )
     if "log_likelihood" not in inference_data.sample_stats:
         raise TypeError("Data must include log_likelihood in sample_stats")
-    posterior = inference_data.posterior
     log_likelihood = inference_data.sample_stats.log_likelihood
     log_likelihood = log_likelihood.stack(sample=("chain", "draw"))
     shape = log_likelihood.shape
@@ -508,6 +506,11 @@ def loo(data, pointwise=False, reff=None, scale="deviance"):
         raise TypeError('Valid scale values are "deviance", "log", "negative_log"')
 
     if reff is None:
+        if not hasattr(inference_data, "posterior"):
+            raise TypeError(
+                "Must be able to extract a posterior group from data!"
+            )
+        posterior = inference_data.posterior
         n_chains = len(posterior.chain)
         if n_chains == 1:
             reff = 1.0

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -485,9 +485,7 @@ def loo(data, pointwise=False, reff=None, scale="deviance"):
     """
     inference_data = convert_to_inference_data(data)
     if not hasattr(inference_data, "sample_stats"):
-        raise TypeError(
-            "Must be able to extract a sample_stats group from data!"
-        )
+        raise TypeError("Must be able to extract a sample_stats group from data!")
     if "log_likelihood" not in inference_data.sample_stats:
         raise TypeError("Data must include log_likelihood in sample_stats")
     log_likelihood = inference_data.sample_stats.log_likelihood
@@ -507,9 +505,7 @@ def loo(data, pointwise=False, reff=None, scale="deviance"):
 
     if reff is None:
         if not hasattr(inference_data, "posterior"):
-            raise TypeError(
-                "Must be able to extract a posterior group from data!"
-            )
+            raise TypeError("Must be able to extract a posterior group from data!")
         posterior = inference_data.posterior
         n_chains = len(posterior.chain)
         if n_chains == 1:

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -485,7 +485,7 @@ def loo(data, pointwise=False, reff=None, scale="deviance"):
     """
     inference_data = convert_to_inference_data(data)
     if not hasattr(inference_data, "sample_stats"):
-        raise TypeError("Must be able to extract a sample_stats group from data!")
+        raise TypeError("Must be able to extract a sample_stats group from data.")
     if "log_likelihood" not in inference_data.sample_stats:
         raise TypeError("Data must include log_likelihood in sample_stats")
     log_likelihood = inference_data.sample_stats.log_likelihood
@@ -505,7 +505,7 @@ def loo(data, pointwise=False, reff=None, scale="deviance"):
 
     if reff is None:
         if not hasattr(inference_data, "posterior"):
-            raise TypeError("Must be able to extract a posterior group from data!")
+            raise TypeError("Must be able to extract a posterior group from data.")
         posterior = inference_data.posterior
         n_chains = len(posterior.chain)
         if n_chains == 1:
@@ -892,12 +892,12 @@ def summary(
 
     fmt_group = ("wide", "long", "xarray")
     if not isinstance(fmt, str) or (fmt.lower() not in fmt_group):
-        raise TypeError("Invalid format: '{}'! Formatting options are: {}".format(fmt, fmt_group))
+        raise TypeError("Invalid format: '{}'. Formatting options are: {}".format(fmt, fmt_group))
 
     unpack_order_group = ("C", "F")
     if not isinstance(order, str) or (order.upper() not in unpack_order_group):
         raise TypeError(
-            "Invalid order: '{}'! Unpacking options are: {}".format(order, unpack_order_group)
+            "Invalid order: '{}'. Unpacking options are: {}".format(order, unpack_order_group)
         )
 
     alpha = 1 - credible_interval
@@ -1132,7 +1132,7 @@ def waic(data, pointwise=False, scale="deviance"):
     for group in ("sample_stats",):
         if not hasattr(inference_data, group):
             raise TypeError(
-                "Must be able to extract a {group} group from data!".format(group=group)
+                "Must be able to extract a {group} group from data.".format(group=group)
             )
     if "log_likelihood" not in inference_data.sample_stats:
         raise TypeError("Data must include log_likelihood in sample_stats")

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -320,6 +320,7 @@ def test_loo_bad_scale(centered_eight):
     with pytest.raises(TypeError):
         loo(centered_eight, scale="bad_scale")
 
+
 def test_loo_bad_no_posterior_reff(centered_eight):
     loo(centered_eight, reff=None)
     centered_eight = deepcopy(centered_eight)
@@ -327,6 +328,7 @@ def test_loo_bad_no_posterior_reff(centered_eight):
     with pytest.raises(TypeError):
         loo(centered_eight, reff=None)
     loo(centered_eight, reff=0.7)
+
 
 def test_loo_warning(centered_eight):
     centered_eight = deepcopy(centered_eight)

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -320,6 +320,13 @@ def test_loo_bad_scale(centered_eight):
     with pytest.raises(TypeError):
         loo(centered_eight, scale="bad_scale")
 
+def test_loo_bad_no_posterior_reff(centered_eight):
+    loo(centered_eight, reff=None)
+    centered_eight = deepcopy(centered_eight)
+    del centered_eight.sample_stats["posterior"]
+    with pytest.raises(TypeError):
+        loo(centered_eight, reff=None)
+    loo(centered_eight, reff=0.7)
 
 def test_loo_warning(centered_eight):
     centered_eight = deepcopy(centered_eight)

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -323,7 +323,7 @@ def test_loo_bad_scale(centered_eight):
 def test_loo_bad_no_posterior_reff(centered_eight):
     loo(centered_eight, reff=None)
     centered_eight = deepcopy(centered_eight)
-    del centered_eight.sample_stats["posterior"]
+    del centered_eight.posterior
     with pytest.raises(TypeError):
         loo(centered_eight, reff=None)
     loo(centered_eight, reff=0.7)


### PR DESCRIPTION
`loo` currently checks if `posterior` is in the `InferenceData` near the beginning of the method, even though it is only needed if `reff` is not provided. This PR makes it so `posterior` is only required if `reff` is not provided.