### PR TITLE
add vlines to rank plot

### DIFF
--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -130,6 +130,28 @@ def get_bins(values):
     return np.arange(x_min, x_max + width + 1, width)
 
 
+def _sturges_formula(dataset, mult=1):
+    """Use Sturges' formula to determine number of bins.
+
+    See https://en.wikipedia.org/wiki/Histogram#Sturges'_formula
+    or https://doi.org/10.1080%2F01621459.1926.10502161
+
+    Parameters
+    ----------
+    dataset: xarray.DataSet
+        Must have the `draw` dimension
+
+    mult: float
+        Used to scale the number of bins up or down. Default is 1 for Sturges' formula.
+
+    Returns
+    -------
+    int
+        Number of bins to use
+    """
+    return int(np.ceil(mult * np.log2(dataset.draw.size)) + 1)
+
+
 def default_grid(n_items, max_cols=4, min_cols=3):  # noqa: D202
     """Make a grid for subplots.
 

--- a/arviz/plots/rankplot.py
+++ b/arviz/plots/rankplot.py
@@ -10,67 +10,62 @@ from .plot_utils import (
     _create_axes_grid,
     make_label,
     filter_plotters_list,
+    _sturges_formula,
 )
 from ..utils import _var_names
 from ..stats.stats_utils import histogram
 
 
-def _sturges_formula(dataset, mult=1):
-    """Use Sturges' formula to determine number of bins.
-
-    See https://en.wikipedia.org/wiki/Histogram#Sturges'_formula
-    or https://doi.org/10.1080%2F01621459.1926.10502161
-
-    Parameters
-    ----------
-    dataset: xarray.DataSet
-        Must have the `draw` dimension
-
-    mult: float
-        Used to scale the number of bins up or down. Default is 1 for Sturges' formula.
-
-    Returns
-    -------
-    int
-        Number of bins to use
-    """
-    return int(np.ceil(mult * np.log2(dataset.draw.size)) + 1)
-
-
-def plot_rank(data, var_names=None, coords=None, bins=None, ref_line=True, figsize=None, axes=None):
+def plot_rank(
+    data,
+    var_names=None,
+    coords=None,
+    bins=None,
+    kind="bars",
+    colors="cycle",
+    ref_line=True,
+    labels=True,
+    figsize=None,
+    axes=None,
+):
     """Plot rank order statistics of chains.
 
-    From the paper: Rank plots are histograms of the ranked posterior
-    draws (ranked over all chains) plotted separately for each chain.
-    If all of the chains are targeting the same posterior, we expect
-    the ranks in each chain to be uniform, whereas if one chain has a
-    different location or scale parameter, this will be reflected in
-    the deviation from uniformity. If rank plots of all chains look
-    similar, this indicates good mixing of the chains.
+    From the paper: Rank plots are histograms of the ranked posterior draws (ranked over all
+    chains) plotted separately for each chain.
+    If all of the chains are targeting the same posterior, we expect the ranks in each chain to be
+    uniform, whereas if one chain has a different location or scale parameter, this will be
+    reflected in the deviation from uniformity. If rank plots of all chains look similar, this
+    indicates good mixing of the chains.
 
-    This plot was introduced by Aki Vehtari, Andrew Gelman, Daniel
-    Simpson, Bob Carpenter, Paul-Christian Burkner (2019):
-    Rank-normalization, folding, and localization: An improved R-hat
-    for assessing convergence of MCMC.
-    arXiv preprint https://arxiv.org/abs/1903.08008
+    This plot was introduced by Aki Vehtari, Andrew Gelman, Daniel Simpson, Bob Carpenter,
+    Paul-Christian Burkner (2019): Rank-normalization, folding, and localization: An improved R-hat
+    for assessing convergence of MCMC. arXiv preprint https://arxiv.org/abs/1903.08008
 
 
     Parameters
     ----------
     data : obj
-        Any object that can be converted to an az.InferenceData object
-        Refer to documentation of az.convert_to_dataset for details
+        Any object that can be converted to an az.InferenceData object. Refer to documentation of
+        az.convert_to_dataset for details
     var_names : string or list of variable names
         Variables to be plotted
     coords : mapping, optional
         Coordinates of var_names to be plotted. Passed to `Dataset.sel`
     bins : None or passed to np.histogram
-        Binning strategy used for histogram. By default uses twice the
-        result of Sturges' formula. See `np.histogram` documenation for
-        other available arguments.
+        Binning strategy used for histogram. By default uses twice the result of Sturges' formula.
+        See `np.histogram` documenation for, other available arguments.
+    kind : string
+        If bars (defaults), ranks are represented as stacked histograms (one per chain). If vlines
+        ranks are represented as vertical lines above or below `ref_line`.
+    colors : string or list of strings
+        List with valid matplotlib colors, one color per model. Alternative a string can be passed.
+        If the string is `cycle`, it will automatically choose a color per model from matplolib's
+        cycle. If a single color is passed, e.g. 'k', 'C2' or 'red' this color will be used for all
+        models. Defaults to `cycle`.
     ref_line : boolean
-        Whether to include a dashed line showing where a uniform
-        distribution would lie
+        Whether to include a dashed line showing where a uniform distribution would lie
+    labels : bool
+        wheter to plot or not the x and y labels, defaults to True
     figsize : tuple
         Figure size. If None it will be defined automatically.
     ax : axes
@@ -120,8 +115,16 @@ def plot_rank(data, var_names=None, coords=None, bins=None, ref_line=True, figsi
             figsize, None, rows=rows, cols=cols
         )
         _, axes = _create_axes_grid(length_plotters, rows, cols, figsize=figsize, squeeze=False)
+    else:
+        figsize, ax_labelsize, titlesize, _, _, _ = _scale_fig_size(figsize, None)
 
-    for ax, (var_name, selection, var_data) in zip(axes.ravel(), plotters):
+    chains = len(posterior_data.chain)
+    if colors == "cycle":
+        colors = ["C{}".format(idx % 10) for idx in range(chains)]
+    elif isinstance(colors, str):
+        colors = [colors] * chains
+
+    for ax, (var_name, selection, var_data) in zip(np.ravel(axes), plotters):
         ranks = scipy.stats.rankdata(var_data).reshape(var_data.shape)
         bin_ary = np.histogram_bin_edges(ranks, bins=bins, range=(0, ranks.size))
         all_counts = np.empty((len(ranks), len(bin_ary) - 1))
@@ -134,26 +137,37 @@ def plot_rank(data, var_names=None, coords=None, bins=None, ref_line=True, figsi
         bin_ary = (bin_ary[1:] + bin_ary[:-1]) / 2
 
         y_ticks = []
-        for idx, counts in enumerate(all_counts):
-            y_ticks.append(idx * gap)
+        if kind == "bars":
+            for idx, counts in enumerate(all_counts):
+                y_ticks.append(idx * gap)
+                ax.bar(
+                    bin_ary,
+                    counts,
+                    bottom=y_ticks[-1],
+                    width=width,
+                    align="center",
+                    color=colors[idx],
+                    edgecolor=ax.get_facecolor(),
+                )
+                if ref_line:
+                    ax.axhline(y=y_ticks[-1] + counts.mean(), linestyle="--", color="k")
+            if labels:
+                ax.set_ylabel("Chain", fontsize=ax_labelsize)
+        elif kind == "vlines":
+            ymin = np.full(len(all_counts), all_counts.mean())
+            for idx, counts in enumerate(all_counts):
+                ax.plot(bin_ary, counts, "o", color=colors[idx])
+                ax.vlines(bin_ary, ymin, counts, lw=2, color=colors[idx])
+            ax.set_ylim(0, all_counts.mean() * 2)
             if ref_line:
-                # Line where data is uniform
-                ax.axhline(y=y_ticks[-1] + counts.mean(), linestyle="--", color="C1")
-            # fake an x-axis
-            ax.axhline(y=y_ticks[-1], color="k", lw=1)
-            ax.bar(
-                bin_ary,
-                counts,
-                bottom=y_ticks[-1],
-                width=width,
-                align="center",
-                color="C0",
-                edgecolor=ax.get_facecolor(),
-            )
-        ax.set_xlabel("Rank (all chains)", fontsize=ax_labelsize)
-        ax.set_ylabel("Chain", fontsize=ax_labelsize)
-        ax.set_yticks(y_ticks)
-        ax.set_yticklabels(np.arange(len(y_ticks)))
-        ax.set_title(make_label(var_name, selection), fontsize=titlesize)
+                ax.axhline(y=all_counts.mean(), linestyle="--", color="k")
+
+        if labels:
+            ax.set_xlabel("Rank (all chains)", fontsize=ax_labelsize)
+            ax.set_yticks(y_ticks)
+            ax.set_yticklabels(np.arange(len(y_ticks)))
+            ax.set_title(make_label(var_name, selection), fontsize=titlesize)
+        else:
+            ax.set_yticks([])
 
     return axes

--- a/arviz/plots/rankplot.py
+++ b/arviz/plots/rankplot.py
@@ -105,7 +105,6 @@ def plot_rank(
     length_plotters = len(plotters)
 
     if bins is None:
-        # Use double Sturges' formula
         bins = _sturges_formula(posterior_data, mult=2)
 
     if axes is None:

--- a/arviz/plots/rankplot.py
+++ b/arviz/plots/rankplot.py
@@ -94,6 +94,18 @@ def plot_rank(
         >>> import arviz as az
         >>> data = az.load_arviz_data('centered_eight')
         >>> az.plot_rank(data, var_names='tau')
+
+    Use vlines to compare results for centered vs noncentered models
+
+    .. plot::
+        :context: close-figs
+
+        >>> import arviz as az
+        >>> centered_data = az.load_arviz_data('centered_eight')
+        >>> noncentered_data = az.load_arviz_data('noncentered_eight')
+        >>> ax = plt.subplots(1, 2, figsize=(12, 3))
+        >>> az.plot_rank(centered_data, var_names="mu", kind='vlines', axes=ax[0])
+        >>> az.plot_rank(noncentered_data, var_names="mu", kind='vlines', axes=ax[1]
     """
     posterior_data = convert_to_dataset(data, group="posterior")
     if coords is not None:

--- a/arviz/tests/test_plots_matplotlib.py
+++ b/arviz/tests/test_plots_matplotlib.py
@@ -639,7 +639,7 @@ def test_plot_autocorr_var_names(models, var_names):
         {"var_names": ("mu", "tau"), "coords": {"theta_dim_0": [0, 1]}},
         {"var_names": "mu", "ref_line": True},
         {"var_names": "mu", "ref_line": False},
-        {"var_names": "mu", "kind":"vlines"},
+        {"var_names": "mu", "kind": "vlines"},
     ],
 )
 def test_plot_rank(models, kwargs):

--- a/arviz/tests/test_plots_matplotlib.py
+++ b/arviz/tests/test_plots_matplotlib.py
@@ -639,6 +639,7 @@ def test_plot_autocorr_var_names(models, var_names):
         {"var_names": ("mu", "tau"), "coords": {"theta_dim_0": [0, 1]}},
         {"var_names": "mu", "ref_line": True},
         {"var_names": "mu", "ref_line": False},
+        {"var_names": "mu", "kind":"vlines"},
     ],
 )
 def test_plot_rank(models, kwargs):


### PR DESCRIPTION
... and few other minor changes.



`kind = "bars"`
![00](https://user-images.githubusercontent.com/1338958/68683057-eb311980-0544-11ea-87a9-3a522bf15211.png)


`kind = "vlines"`
![01](https://user-images.githubusercontent.com/1338958/68683063-ee2c0a00-0544-11ea-80e5-d36d0066fe3e.png)


When using `vlines` we have `ax.set_ylim(0, all_counts.mean() * 2)`, that is the height is 2 times the value of `ref_line`. This makes easier to see if a deviation is "large" or not.

in a next PR I would like to add the ranks (probably with the vlines as default) to trace plot, something like this:

![non-centered](https://user-images.githubusercontent.com/1338958/68682543-0ea79480-0544-11ea-80fe-c732a8ea8a5b.png)

or with `bars`

![non-centered](https://user-images.githubusercontent.com/1338958/68682664-40b8f680-0544-11ea-8bc9-0f7a4018580b.png)


