### PR TITLE
Add more parameters to rcparams

### DIFF
--- a/arviz/rcparams.py
+++ b/arviz/rcparams.py
@@ -44,10 +44,28 @@ def _validate_positive_int_or_none(value):
         return _validate_positive_int(value)
 
 
+def _validate_float(value):
+    """Validate value is a float."""
+    try:
+        value = float(value)
+    except ValueError:
+        raise ValueError("Could not convert to float")
+    return value
+
+
+def _validate_probability(value):
+    """Validate a probability: a float between 0 and 1."""
+    value = _validate_float(value)
+    if (value < 0) or (value > 1):
+        raise ValueError("Only values between 0 and 1 are valid.")
+    return value
+
+
 defaultParams = {  # pylint: disable=invalid-name
     "data.load": ("lazy", _make_validate_choice(("lazy", "eager"))),
-    "plot.max_subplots": (40, _validate_positive_int_or_none),
     "plot.backend": ("matplotlib", _make_validate_choice(("matplotlib", "bokeh"))),
+    "plot.max_subplots": (40, _validate_positive_int_or_none),
+    "stats.credible_interval": (0.94, _validate_probability),
     "stats.information_criterion": ("waic", _make_validate_choice(("waic", "loo"))),
 }
 

--- a/arviz/rcparams.py
+++ b/arviz/rcparams.py
@@ -11,17 +11,32 @@ from collections import MutableMapping
 _log = logging.getLogger(__name__)
 
 
-def _make_validate_choice(accepted_values, allow_none=False):
-    """Validate value is in accepted_values."""
+def _make_validate_choice(accepted_values, allow_none=False, typeof=str):
+    """Validate value is in accepted_values.
+
+    Parameters
+    ----------
+    accepted_values : iterable
+        Iterable containing all accepted_values.
+    allow_none: boolean, optional
+        Whether to accept ``None`` in addition to the values in ``accepted_values``.
+    typeof: type, optional
+        Type the values should be converted to.
+    """
     # no blank lines allowed after function docstring by pydocstyle,
     # but black requires white line before function
 
     def validate_choice(value):
         if allow_none and (value is None or isinstance(value, str) and value.lower() == "none"):
             return None
-        value = str(value)
-        if value.lower() in accepted_values:
-            return value.lower()
+        try:
+            value = typeof(value)
+        except (ValueError, TypeError):
+            raise ValueError("Could not convert to {}".format(typeof.__name__))
+        if isinstance(value, str):
+            value = value.lower()
+        if value in accepted_values:
+            return value
         raise ValueError(
             "{} is not one of {}{}".format(
                 value, accepted_values, " nor None" if allow_none else ""
@@ -69,16 +84,17 @@ def _validate_probability(value):
 
 
 defaultParams = {  # pylint: disable=invalid-name
-    "data.load": ("lazy", _make_validate_choice(("lazy", "eager"))),
-    "plot.backend": ("matplotlib", _make_validate_choice(("matplotlib", "bokeh"))),
+    "data.load": ("lazy", _make_validate_choice({"lazy", "eager"})),
+    "data.index_origin": (0, _make_validate_choice({0, 1}, typeof=int)),
+    "plot.backend": ("matplotlib", _make_validate_choice({"matplotlib", "bokeh"})),
     "plot.max_subplots": (40, _validate_positive_int_or_none),
     "plot.point_estimate": (
         "mean",
-        _make_validate_choice(("mean", "median", "mode"), allow_none=True),
+        _make_validate_choice({"mean", "median", "mode"}, allow_none=True),
     ),
     "stats.credible_interval": (0.94, _validate_probability),
-    "stats.information_criterion": ("waic", _make_validate_choice(("waic", "loo"))),
-    "stats.ic_scale": ("deviance", _make_validate_choice(("deviance", "log", "negative_log"))),
+    "stats.information_criterion": ("waic", _make_validate_choice({"waic", "loo"})),
+    "stats.ic_scale": ("deviance", _make_validate_choice({"deviance", "log", "negative_log"})),
 }
 
 

--- a/arviz/rcparams.py
+++ b/arviz/rcparams.py
@@ -47,6 +47,7 @@ def _validate_positive_int_or_none(value):
 defaultParams = {  # pylint: disable=invalid-name
     "data.load": ("lazy", _make_validate_choice(("lazy", "eager"))),
     "plot.max_subplots": (40, _validate_positive_int_or_none),
+    "plot.backend": ("matplotlib", _make_validate_choice(("matplotlib", "bokeh"))),
     "stats.information_criterion": ("waic", _make_validate_choice(("waic", "loo"))),
 }
 

--- a/arviz/tests/test_rcparams.py
+++ b/arviz/tests/test_rcparams.py
@@ -7,7 +7,13 @@ from xarray.core.indexing import MemoryCachedArray
 
 from ..data import load_arviz_data
 from ..stats import compare
-from ..rcparams import rcParams, rc_context, _validate_positive_int_or_none, read_rcfile
+from ..rcparams import (
+    rcParams,
+    rc_context,
+    _validate_positive_int_or_none,
+    _validate_probability,
+    read_rcfile,
+)
 
 from .helpers import models  # pylint: disable=unused-import
 
@@ -49,8 +55,8 @@ def test_rcparams_find_all():
 def test_rctemplate_updated():
     fname = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../arvizrc.template")
     rc_pars_template = read_rcfile(fname)
-    assert all(key in rc_pars_template.keys() for key in rcParams.keys())
-    assert all(value == rc_pars_template[key] for key, value in rcParams.items())
+    assert all([key in rc_pars_template.keys() for key in rcParams.keys()])
+    assert all([value == rc_pars_template[key] for key, value in rcParams.items()])
 
 
 ### Test validation functions ###
@@ -72,7 +78,29 @@ def test_validate_positive_int_or_none(args):
         with pytest.raises(ValueError, match=raise_error):
             _validate_positive_int_or_none(value)
     else:
-        _validate_positive_int_or_none(value)
+        value = _validate_positive_int_or_none(value)
+        assert isinstance(value, int) or value is None
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ("Only.+between 0 and 1", -1),
+        ("Only.+between 0 and 1", "1.3"),
+        ("not convert to float", "word"),
+        (False, "0.6"),
+        (False, 0),
+        (False, 1),
+    ],
+)
+def test_validate_probability(args):
+    raise_error, value = args
+    if raise_error:
+        with pytest.raises(ValueError, match=raise_error):
+            _validate_probability(value)
+    else:
+        value = _validate_probability(value)
+        assert isinstance(value, float)
 
 
 ### Test integration of rcParams in ArviZ ###

--- a/arviz/tests/test_rcparams.py
+++ b/arviz/tests/test_rcparams.py
@@ -10,6 +10,7 @@ from ..stats import compare
 from ..rcparams import (
     rcParams,
     rc_context,
+    _make_validate_choice,
     _validate_positive_int_or_none,
     _validate_probability,
     read_rcfile,
@@ -66,6 +67,21 @@ def test_choice_bad_values(param):
     msg = "{}: bad_value is not one of".format(param.replace(".", r"\."))
     with pytest.raises(ValueError, match=msg):
         rcParams[param] = "bad_value"
+
+
+@pytest.mark.parametrize(
+    "args", [("not one.+nor None", 0), (False, None), (False, "accepted")],
+)
+def test_validate_choice_none(args):
+    accepted_values = ("accepted", "good", "arviz")
+    validate_choice = _make_validate_choice(accepted_values, allow_none=True)
+    raise_error, value = args
+    if raise_error:
+        with pytest.raises(ValueError, match=raise_error):
+            validate_choice(value)
+    else:
+        value = validate_choice(value)
+        assert value in accepted_values or value is None
 
 
 @pytest.mark.parametrize(

--- a/arviz/tests/test_rcparams.py
+++ b/arviz/tests/test_rcparams.py
@@ -69,13 +69,17 @@ def test_choice_bad_values(param):
         rcParams[param] = "bad_value"
 
 
+@pytest.mark.parametrize("allow_none", (True, False))
+@pytest.mark.parametrize("typeof", (str, int))
 @pytest.mark.parametrize(
-    "args", [("not one.+nor None", 0), (False, None), (False, "accepted")],
+    "args", [("not one", 10), (False, None), (False, 4)],
 )
-def test_validate_choice_none(args):
-    accepted_values = ("accepted", "good", "arviz")
-    validate_choice = _make_validate_choice(accepted_values, allow_none=True)
+def test_make_validate_choice(args, allow_none, typeof):
+    accepted_values = set(typeof(value) for value in (0, 1, 4, 6))
+    validate_choice = _make_validate_choice(accepted_values, allow_none=allow_none, typeof=typeof)
     raise_error, value = args
+    if value is None and not allow_none:
+        raise_error = "not one of" if typeof == str else "Could not convert"
     if raise_error:
         with pytest.raises(ValueError, match=raise_error):
             validate_choice(value)

--- a/arvizrc.template
+++ b/arvizrc.template
@@ -8,6 +8,7 @@ data.load                    : lazy  # Sets the default data loading mode.
 ### PLOT  ###
 # rcParams related with plotting functions
 plot.max_subplots            : 40    # Maximum number of subplots.
+plot.backend                 : matplotlib  # Plotting backend.
 
 ### STATS ###
 # rcParams related with statistical and diagnostic functions

--- a/arvizrc.template
+++ b/arvizrc.template
@@ -1,18 +1,19 @@
 #### ArviZ rcParams template ####
 ### DATA  ###
 # rcParams related with data loading related functions
+data.index_origin            : 0     # index origin, must be either 0 or 1
 data.load                    : lazy  # Sets the default data loading mode.
                                      # "lazy" stands for xarray lazy loading,
                                      # "eager" loads all datasets into memory
 
 ### PLOT  ###
 # rcParams related with plotting functions
-plot.backend                 : matplotlib  # Plotting backend.
-plot.max_subplots            : 40    # Maximum number of subplots.
-plot.point_estimate          : mean
+plot.backend                 : matplotlib  # One of bokeh, matplotlib
+plot.max_subplots            : 40          # Maximum number of subplots.
+plot.point_estimate          : mean        # One of mean, median, mode or None
 
 ### STATS ###
 # rcParams related with statistical and diagnostic functions
 stats.credible_interval      : 0.94
-stats.information_criterion  : waic
-stats.ic_scale               : deviance
+stats.information_criterion  : waic       # One of loo, waic
+stats.ic_scale               : deviance   # One of deviance, log, negative_log

--- a/arvizrc.template
+++ b/arvizrc.template
@@ -9,8 +9,10 @@ data.load                    : lazy  # Sets the default data loading mode.
 # rcParams related with plotting functions
 plot.backend                 : matplotlib  # Plotting backend.
 plot.max_subplots            : 40    # Maximum number of subplots.
+plot.point_estimate          : mean
 
 ### STATS ###
 # rcParams related with statistical and diagnostic functions
-stats.credible_interval      : 0.94  # Default credible interval
-stats.information_criterion  : waic  # Default information criterion
+stats.credible_interval      : 0.94
+stats.information_criterion  : waic
+stats.ic_scale               : deviance

--- a/arvizrc.template
+++ b/arvizrc.template
@@ -7,9 +7,10 @@ data.load                    : lazy  # Sets the default data loading mode.
 
 ### PLOT  ###
 # rcParams related with plotting functions
-plot.max_subplots            : 40    # Maximum number of subplots.
 plot.backend                 : matplotlib  # Plotting backend.
+plot.max_subplots            : 40    # Maximum number of subplots.
 
 ### STATS ###
 # rcParams related with statistical and diagnostic functions
+stats.credible_interval      : 0.94  # Default credible interval
 stats.information_criterion  : waic  # Default information criterion


### PR DESCRIPTION
Related to #792 and to #877.

Adds parameters `plot.backend`, `plot.point_estimate`, `stats.credible_interval` and `stats.ic_scale` to rcparams dict. However it does not modify the functions to use them. I think that now than most if not all plots will be tinkered with it is a good moment to get everything ready so that integrating rcparms is only calling them.

Handling of none is tricky. For instance, `None` is a valid value of `plot.point_estimate` meaning no point estimate. In this cases, I propose setting the default to `"auto"` so that auto means look up the value in rcparams. In general, using `None` as look up rcparams should be fine.