### PR TITLE
separate prior from prior predictive variables

### DIFF
--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -174,7 +174,7 @@ class PyMC3Converter:
         return dict_to_dataset(data, library=self.pymc3, coords=self.coords, dims=self.dims)
 
     def priors_to_xarray(self):
-        """Convert prior samples to xarray."""
+        """Convert prior samples (and if possible prior predictive too) to xarray."""
         if self.prior is None:
             return {"prior": None, "prior_predictive": None}
         if self.trace is not None:

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -181,7 +181,7 @@ class PyMC3Converter:
             prior_vars = self.pymc3.util.get_default_varnames(  # pylint: disable=no-member
                 self.trace.varnames, include_transformed=False
             )
-            prior_predictive_vars = [key for key in self.prior.keys() if key in prior_vars]
+            prior_predictive_vars = [key for key in self.prior.keys() if key not in prior_vars]
         else:
             prior_vars = list(self.prior.keys())
             prior_predictive_vars = None

--- a/arviz/data/io_pyro.py
+++ b/arviz/data/io_pyro.py
@@ -83,7 +83,7 @@ class PyroConverter:
         return dict_to_dataset(data, library=self.pyro, coords=self.coords, dims=self.dims)
 
     def priors_to_xarray(self):
-        """Convert prior samples to xarray."""
+        """Convert prior samples (and if possible prior predictive too) to xarray."""
         if self.prior is None:
             return {"prior": None, "prior_predictive": None}
         if self.posterior is not None:

--- a/arviz/tests/test_data_numpyro.py
+++ b/arviz/tests/test_data_numpyro.py
@@ -45,7 +45,8 @@ class TestDataNumPyro:
             "posterior": ["mu", "tau", "eta"],
             "sample_stats": ["diverging", "tree_size", "depth", "log_likelihood"],
             "posterior_predictive": ["obs"],
-            "prior": ["mu", "tau", "eta", "obs"],
+            "prior": ["mu", "tau", "eta"],
+            "prior_predictive": ["obs"],
             "observed_data": ["obs"],
         }
         fails = check_multiple_attrs(test_dict, inference_data)

--- a/arviz/tests/test_data_pymc.py
+++ b/arviz/tests/test_data_pymc.py
@@ -45,7 +45,7 @@ class TestDataPyMC3:
             "sample_stats": ["diverging", "log_likelihood"],
             "posterior_predictive": ["obs"],
             "prior": ["mu", "tau", "eta", "theta"],
-            "posterior_predictive": ["obs"],
+            "prior_predictive": ["obs"],
             "observed_data": ["obs"],
         }
         fails = check_multiple_attrs(test_dict, inference_data)

--- a/arviz/tests/test_data_pymc.py
+++ b/arviz/tests/test_data_pymc.py
@@ -45,6 +45,7 @@ class TestDataPyMC3:
             "sample_stats": ["diverging", "log_likelihood"],
             "posterior_predictive": ["obs"],
             "prior": ["mu", "tau", "eta", "theta"],
+            "posterior_predictive": ["obs"],
             "observed_data": ["obs"],
         }
         fails = check_multiple_attrs(test_dict, inference_data)

--- a/arviz/tests/test_data_pyro.py
+++ b/arviz/tests/test_data_pyro.py
@@ -45,7 +45,37 @@ class TestDataPyro:
             "posterior": ["mu", "tau", "eta"],
             "sample_stats": ["diverging"],
             "posterior_predictive": ["obs"],
-            "prior": ["mu", "tau", "eta", "obs"],
+            "prior": ["mu", "tau", "eta"],
+            "prior_predictive": ["obs"],
         }
         fails = check_multiple_attrs(test_dict, inference_data)
+        assert not fails
+
+    def test_inference_data_no_posterior(self, data, eight_schools_params):
+        posterior_samples = data.obj.get_samples()
+        model = data.obj.kernel.model
+        posterior_predictive = Predictive(model, posterior_samples).get_samples(
+            eight_schools_params["J"], torch.from_numpy(eight_schools_params["sigma"]).float()
+        )
+        prior = Predictive(model, num_samples=500).get_samples(
+            eight_schools_params["J"], torch.from_numpy(eight_schools_params["sigma"]).float()
+        )
+        idata = from_pyro(prior=prior, posterior_predictive=posterior_predictive,
+            coords={"school": np.arange(eight_schools_params["J"])},
+            dims={"theta": ["school"], "eta": ["school"]},
+                          )
+        test_dict = {
+            "posterior_predictive": ["obs"],
+            "prior": ["mu", "tau", "eta", "obs"]
+        }
+        fails = check_multiple_attrs(test_dict, idata)
+        assert not fails
+
+    def test_inference_data_only_posterior(self, data):
+        idata = from_pyro(data.obj)
+        test_dict = {
+            "posterior": ["mu", "tau", "eta"],
+            "sample_stats": ["diverging"],
+        }
+        fails = check_multiple_attrs(test_dict, idata)
         assert not fails

--- a/arviz/tests/test_data_pyro.py
+++ b/arviz/tests/test_data_pyro.py
@@ -60,14 +60,13 @@ class TestDataPyro:
         prior = Predictive(model, num_samples=500).get_samples(
             eight_schools_params["J"], torch.from_numpy(eight_schools_params["sigma"]).float()
         )
-        idata = from_pyro(prior=prior, posterior_predictive=posterior_predictive,
+        idata = from_pyro(
+            prior=prior,
+            posterior_predictive=posterior_predictive,
             coords={"school": np.arange(eight_schools_params["J"])},
             dims={"theta": ["school"], "eta": ["school"]},
-                          )
-        test_dict = {
-            "posterior_predictive": ["obs"],
-            "prior": ["mu", "tau", "eta", "obs"]
-        }
+        )
+        test_dict = {"posterior_predictive": ["obs"], "prior": ["mu", "tau", "eta", "obs"]}
         fails = check_multiple_attrs(test_dict, idata)
         assert not fails
 


### PR DESCRIPTION
Currently, pymc3 and pyro store both prior and prior predictive in the `prior` group. This aims to fix the issue when possible.

Only ~numpyro~ and ~updating docs (cookbook and schema example) is missing.~

EDIT: 

numpyro is done and the schema is still in a too early phase, I don't think we need to update the examples every PR