### PR TITLE
Proposal for PyMC3 predictions support

### DIFF
--- a/arviz/data/__init__.py
+++ b/arviz/data/__init__.py
@@ -7,7 +7,7 @@ from .converters import convert_to_dataset, convert_to_inference_data
 from .io_cmdstan import from_cmdstan
 from .io_cmdstanpy import from_cmdstanpy
 from .io_dict import from_dict
-from .io_pymc3 import from_pymc3
+from .io_pymc3 import from_pymc3, add_predictions_pymc3
 from .io_pystan import from_pystan
 from .io_emcee import from_emcee
 from .io_pyro import from_pyro
@@ -24,6 +24,7 @@ __all__ = [
     "dict_to_dataset",
     "convert_to_dataset",
     "convert_to_inference_data",
+    "add_predictions_pymc3",
     "from_pymc3",
     "from_pystan",
     "from_emcee",

--- a/arviz/data/base.py
+++ b/arviz/data/base.py
@@ -230,3 +230,54 @@ def make_attrs(attrs=None, library=None):
     if attrs is not None:
         default_attrs.update(attrs)
     return default_attrs
+
+
+def get_predictions_dims(idata, dims=None):
+    """Get the dimensions for the predictions and constant data predictions."""
+    if dims is not None:
+        return dims
+    dims = {}
+    if hasattr(idata, "posterior_predictive"):
+        dataset = idata.posterior_predictive
+        for var_name in dataset.data_vars:
+            dims[var_name] = list(dataset[var_name].dims)[2:]
+    if hasattr(idata, "observed_data"):
+        dataset = idata.observed_data
+        for var_name in dataset.data_vars:
+            dims[var_name] = list(dataset[var_name].dims)
+    if hasattr(idata, "constant_data"):
+        dataset = idata.constant_data
+        for var_name in dataset.data_vars:
+            dims[var_name] = list(dataset[var_name].dims)
+    return dims
+
+
+def get_posterior_var_names(idata):
+    """Get the variable names of the posterior variables.
+
+    It firts tries to get them from the posterior group, otherwise the names are taken
+    from the prior group.
+    """
+    if hasattr(idata, "posterior"):
+        return list(idata.posterior.data_vars)
+    if hasattr(idata, "prior"):
+        return list(idata.prior.data_vars)
+    return []
+
+
+def get_posterior_nchains_ndraws(idata):
+    """Get number of chains and number of draws.
+
+    Try to get number of chains and draws from posterior, sample_stats or
+    posterior_predictive.
+    """
+    if hasattr(idata, "posterior"):
+        dataset = idata.posterior
+        return len(dataset.chain), len(dataset.draw)
+    if hasattr(idata, "sample_stats"):
+        dataset = idata.sample_stats
+        return len(dataset.chain), len(dataset.draw)
+    if hasattr(idata, "posterior_predictive"):
+        dataset = idata.posterior_predictive
+        return len(dataset.chain), len(dataset.draw)
+    return -1, -1

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -314,12 +314,15 @@ def concat(*args, dim=None, copy=True, inplace=False, reset_dim=True):
 
         basic_order = [
             "posterior",
-            "posterior_predictive",
             "sample_stats",
+            "posterior_predictive",
+            "observed_data",
+            "constant_data",
+            "predictions",
+            "constant_data_predictions",
             "prior",
             "prior_predictive",
             "sample_stats_prior",
-            "observed_data",
         ]
         other_groups = [group for group in args_groups if group not in basic_order]
 

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -1,6 +1,6 @@
 """PyMC3-specific conversion code."""
 import logging
-from typing import Dict, List, Any, Optional, TYPE_CHECKING
+from typing import Dict, Any, Optional
 
 import numpy as np
 import xarray as xr
@@ -18,12 +18,10 @@ from .base import (
     get_posterior_nchains_ndraws,
 )
 
-if TYPE_CHECKING:
-    import pymc3 as pm
-
 _log = logging.getLogger(__name__)
 
 
+# pylint: disable=too-many-instance-attributes
 class PyMC3Converter:
     """Encapsulate PyMC3 specific logic."""
 
@@ -42,7 +40,7 @@ class PyMC3Converter:
         coords: Optional[CoordSpec] = None,
         dims: Optional[DimSpec] = None,
         model=None,
-        predictions=False,
+        predictions=False
     ):
         import pymc3
 
@@ -328,8 +326,6 @@ def add_predictions_pymc3(
     inplace: bool, optional
         Add predictions data inplace or return a new InferenceData object
     """
-    import pymc3 as pm
-
     dims = get_predictions_dims(idata, dims)
     converter = PyMC3Converter(
         posterior_predictive=predictions, model=model, dims=dims, coords=coords, predictions=True


### PR DESCRIPTION
Proposal on how to add data to `predictions` and `constant_data_predictions` with PyMC3.

One example usage (borrowing the model and code from @corriebar in https://github.com/pymc-devs/pymc3/issues/3640) could be the following:

```python
import numpy as np
import pymc3 as pm
import pandas as pd
import arviz as az
import matplotlib.pyplot as plt

size = 200
true_intercept = 1
true_slope = 2

x = np.linspace(0, 1, size)
# y = a + b*x
true_regression_line = true_intercept + true_slope * x
# add noise
y = true_regression_line + np.random.normal(scale=.5, size=size)

data = pd.DataFrame(data={"x":x, "y":y})
del x
del y

with pm.Model() as model:
    x = pm.Data("x", data["x"])
    # Define priors
    sigma = pm.HalfCauchy('sigma', beta=10, testval=1.)
    intercept = pm.Normal('Intercept', 0, sigma=20)
    x_coeff = pm.Normal('x_coeff', 0, sigma=20)

    # Define likelihood
    likelihood = pm.Normal('y', mu=intercept + x_coeff * x,
                        sigma=sigma, observed=data["y"])

    # Inference!
    trace = pm.sample(1000, cores=2) # draw 3000 posterior samples using NUTS sampling

idata = az.from_pymc3(trace, dims={"y": ["custom_dim"]})

print(idata)
#Inference data with groups:
#        > posterior
#        > sample_stats
#        > observed_data
#        > constant_data

more_data = np.linspace(1, 1.2, num=3)

with model:
    pm.set_data({"x": more_data})
    post_pred = pm.sample_posterior_predictive(trace, samples=1000)
   
    idata_all = az.add_predictions_pymc3(idata, predictions=post_pred) 

print(idata_all)
#Inference data with groups:
#        > posterior
#        > sample_stats
#        > observed_data
#        > constant_data
#        > predictions
#        > constant_data_predictions
print(idata_all.predictions)
#<xarray.Dataset>
#Dimensions:     (chain: 1, custom_dim: 3, draw: 1000)
#Coordinates:
#  * chain       (chain) int64 0
#  * draw        (draw) int64 0 1 2 3 4 5 6 7 ... 992 993 994 995 996 997 998 999
#  * custom_dim  (custom_dim) int64 0 1 2
#Data variables:
#    y           (chain, draw, custom_dim) float64 2.59 4.246 ... 2.909 4.701
#Attributes:
#    created_at:                 2019-11-24T22:24:18.516325
#    inference_library:          pymc3
#    inference_library_version:  3.7
```

The default is set to returning a new inferenceData object for now. Also, to get `constant_data_predictions` `add_predictions_pymc3` must be called within a `Model` context or a model passed to it. As it can be seen in the example, when possible, it uses the dimensions from related groups.