### PR TITLE
Move matplotlib animation import until needed

### DIFF
--- a/arviz/plots/ppcplot.py
+++ b/arviz/plots/ppcplot.py
@@ -3,7 +3,6 @@ from numbers import Integral
 import platform
 import logging
 import numpy as np
-from matplotlib import animation
 from .kdeplot import plot_kde, _fast_kde
 from .plot_utils import (
     xarray_var_iter,
@@ -511,6 +510,7 @@ def plot_ppc(
                 ax_i.legend([])
 
     if animated:
+        from matplotlib import animation
         ani = animation.FuncAnimation(
             fig, animate, np.arange(0, num_pp_samples), init_func=init, **animation_kwargs
         )


### PR DESCRIPTION
This is an odd pull request, so I understand if you want to reject.

I'm running some code on a cluster under some strict thread limits (each Python instance only gets 1 thread), so calls to `subprocess.Popen()` are failing (for reasons I admit I don't totally understand, but anyways...). The code imports `pymc3`, which imports `arviz`, which runs the `from matplotlib import animation` (triggered on import). `matplotlib/animation.py` [checks for various movie writers](https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/animation.py), like imagemagick and ffmpeg, by opening subprocesses (e.g., it runs `convert --version` and parses the output to check for imagemagick). So, the behavior I'm seeing is: my code imports `pymc3` and then dies because `matplotlib` is unable to open a process to check for imagemagick support. I think the below would solve that, but I understand that this is a pretty niche issue!