### PR TITLE
Support log_likelihood and obs data for pyro io

### DIFF
--- a/arviz/data/io_pyro.py
+++ b/arviz/data/io_pyro.py
@@ -49,12 +49,13 @@ class PyroConverter:
         import pyro
 
         self.pyro = pyro
-        if posterior is not None and pyro.__version__.startswith("1"):
+        if posterior is not None:
             self.nchains, self.ndraws = posterior.num_chains, posterior.num_samples
-            self.model = self.posterior.kernel.model
-            # model arguments and keyword arguments
-            self._args = self.posterior._args  # pylint: disable=protected-access
-            self._kwargs = self.posterior._kwargs  # pylint: disable=protected-access
+            if pyro.__version__.startswith("1"):
+                self.model = self.posterior.kernel.model
+                # model arguments and keyword arguments
+                self._args = self.posterior._args  # pylint: disable=protected-access
+                self._kwargs = self.posterior._kwargs  # pylint: disable=protected-access
         else:
             self.nchains = self.ndraws = 0
 

--- a/arviz/data/io_pyro.py
+++ b/arviz/data/io_pyro.py
@@ -1,6 +1,7 @@
 """Pyro-specific conversion code."""
 import logging
 import numpy as np
+import packaging
 import xarray as xr
 
 from .inference_data import InferenceData
@@ -51,7 +52,7 @@ class PyroConverter:
         self.pyro = pyro
         if posterior is not None:
             self.nchains, self.ndraws = posterior.num_chains, posterior.num_samples
-            if pyro.__version__.startswith("1"):
+            if packaging.version.parse(pyro.__version__) >= packaging.version.parse("1.0.0"):
                 self.model = self.posterior.kernel.model
                 # model arguments and keyword arguments
                 self._args = self.posterior._args  # pylint: disable=protected-access

--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -284,12 +284,13 @@ def pyro_noncentered_schools(data, draws, chains):
     y = torch.from_numpy(data["y"]).float()
     sigma = torch.from_numpy(data["sigma"]).float()
 
-    nuts_kernel = NUTS(_pyro_noncentered_model)
+    nuts_kernel = NUTS(_pyro_noncentered_model, jit_compile=True, ignore_jit_warnings=True)
     posterior = MCMC(nuts_kernel, num_samples=draws, warmup_steps=draws, num_chains=chains)
     posterior.run(data["J"], sigma, y)
 
     # This block lets the posterior be pickled
     posterior.sampler = None
+    posterior.kernel.potential_fn = None
     return posterior
 
 

--- a/arviz/tests/test_data_pyro.py
+++ b/arviz/tests/test_data_pyro.py
@@ -2,6 +2,7 @@
 import numpy as np
 import pytest
 import torch
+import pyro
 from pyro.infer import Predictive
 
 from ..data.io_pyro import from_pyro
@@ -43,12 +44,14 @@ class TestDataPyro:
         inference_data = self.get_inference_data(data, eight_schools_params)
         test_dict = {
             "posterior": ["mu", "tau", "eta"],
-            "sample_stats": ["diverging", "log_likelihood"],
+            "sample_stats": ["diverging"],
             "posterior_predictive": ["obs"],
             "prior": ["mu", "tau", "eta"],
             "prior_predictive": ["obs"],
-            "observed_data": ["obs"],
         }
+        if pyro.__version__.startswith("1"):
+            test_dict["sample_stats"].append("log_likelihood")
+            test_dict["observed_data"] = ["obs"]
         fails = check_multiple_attrs(test_dict, inference_data)
         assert not fails
 
@@ -75,7 +78,9 @@ class TestDataPyro:
         idata = from_pyro(data.obj)
         test_dict = {
             "posterior": ["mu", "tau", "eta"],
-            "sample_stats": ["diverging", "log_likelihood"],
+            "sample_stats": ["diverging"],
         }
+        if pyro.__version__.startswith("1"):
+            test_dict["sample_stats"].append("log_likelihood")
         fails = check_multiple_attrs(test_dict, idata)
         assert not fails

--- a/arviz/tests/test_data_pyro.py
+++ b/arviz/tests/test_data_pyro.py
@@ -73,6 +73,9 @@ class TestDataPyro:
 
     def test_inference_data_only_posterior(self, data):
         idata = from_pyro(data.obj)
-        test_dict = {"posterior": ["mu", "tau", "eta"], "sample_stats": ["diverging"]}
+        test_dict = {
+            "posterior": ["mu", "tau", "eta"],
+            "sample_stats": ["diverging", "log_likelihood"],
+        }
         fails = check_multiple_attrs(test_dict, idata)
         assert not fails

--- a/arviz/tests/test_data_pyro.py
+++ b/arviz/tests/test_data_pyro.py
@@ -43,10 +43,11 @@ class TestDataPyro:
         inference_data = self.get_inference_data(data, eight_schools_params)
         test_dict = {
             "posterior": ["mu", "tau", "eta"],
-            "sample_stats": ["diverging"],
+            "sample_stats": ["diverging", "log_likelihood"],
             "posterior_predictive": ["obs"],
             "prior": ["mu", "tau", "eta"],
             "prior_predictive": ["obs"],
+            "observed_data": ["obs"],
         }
         fails = check_multiple_attrs(test_dict, inference_data)
         assert not fails
@@ -72,9 +73,6 @@ class TestDataPyro:
 
     def test_inference_data_only_posterior(self, data):
         idata = from_pyro(data.obj)
-        test_dict = {
-            "posterior": ["mu", "tau", "eta"],
-            "sample_stats": ["diverging"],
-        }
+        test_dict = {"posterior": ["mu", "tau", "eta"], "sample_stats": ["diverging"]}
         fails = check_multiple_attrs(test_dict, idata)
         assert not fails

--- a/arviz/tests/test_data_pyro.py
+++ b/arviz/tests/test_data_pyro.py
@@ -1,5 +1,6 @@
 # pylint: disable=no-member, invalid-name, redefined-outer-name
 import numpy as np
+import packaging
 import pytest
 import torch
 import pyro
@@ -49,7 +50,7 @@ class TestDataPyro:
             "prior": ["mu", "tau", "eta"],
             "prior_predictive": ["obs"],
         }
-        if pyro.__version__.startswith("1"):
+        if packaging.version.parse(pyro.__version__) >= packaging.version.parse("1.0.0"):
             test_dict["sample_stats"].append("log_likelihood")
             test_dict["observed_data"] = ["obs"]
         fails = check_multiple_attrs(test_dict, inference_data)
@@ -80,7 +81,7 @@ class TestDataPyro:
             "posterior": ["mu", "tau", "eta"],
             "sample_stats": ["diverging"],
         }
-        if pyro.__version__.startswith("1"):
+        if packaging.version.parse(pyro.__version__) >= packaging.version.parse("1.0.0"):
             test_dict["sample_stats"].append("log_likelihood")
         fails = check_multiple_attrs(test_dict, idata)
         assert not fails

--- a/arviz/tests/test_data_pyro.py
+++ b/arviz/tests/test_data_pyro.py
@@ -53,7 +53,7 @@ class TestDataPyro:
         fails = check_multiple_attrs(test_dict, inference_data)
         assert not fails
 
-    @pytest.skipif(
+    @pytest.mark.skipif(
         packaging.version.parse(pyro.__version__) < packaging.version.parse("1.0.0"),
         reason="requires pyro 1.0.0 or higher",
     )
@@ -88,9 +88,9 @@ class TestDataPyro:
         fails = check_multiple_attrs(test_dict, idata)
         assert not fails
 
-    @pytest.skipif(
+    @pytest.mark.skipif(
         packaging.version.parse(pyro.__version__) < packaging.version.parse("1.0.0"),
-        reason="requires pyro 2.0.0 or higher",
+        reason="requires pyro 1.0.0 or higher",
     )
     def test_inference_data_only_posterior_has_log_likelihood(self, data):
         idata = from_pyro(data.obj)

--- a/arviz/tests/test_data_pyro.py
+++ b/arviz/tests/test_data_pyro.py
@@ -50,10 +50,17 @@ class TestDataPyro:
             "prior": ["mu", "tau", "eta"],
             "prior_predictive": ["obs"],
         }
-        if packaging.version.parse(pyro.__version__) >= packaging.version.parse("1.0.0"):
-            test_dict["sample_stats"].append("log_likelihood")
-            test_dict["observed_data"] = ["obs"]
         fails = check_multiple_attrs(test_dict, inference_data)
+        assert not fails
+
+    @pytest.skipif(
+        packaging.version.parse(pyro.__version__) < packaging.version.parse("1.0.0"),
+        reason="requires pyro 1.0.0 or higher",
+    )
+    def test_inference_data_has_log_likelihood_and_observed_data(self, data):
+        idata = from_pyro(data.obj)
+        test_dict = {"sample_stats": ["log_likelihood"], "observed_data": ["obs"]}
+        fails = check_multiple_attrs(test_dict, idata)
         assert not fails
 
     def test_inference_data_no_posterior(self, data, eight_schools_params):
@@ -77,11 +84,16 @@ class TestDataPyro:
 
     def test_inference_data_only_posterior(self, data):
         idata = from_pyro(data.obj)
-        test_dict = {
-            "posterior": ["mu", "tau", "eta"],
-            "sample_stats": ["diverging"],
-        }
-        if packaging.version.parse(pyro.__version__) >= packaging.version.parse("1.0.0"):
-            test_dict["sample_stats"].append("log_likelihood")
+        test_dict = {"posterior": ["mu", "tau", "eta"], "sample_stats": ["diverging"]}
+        fails = check_multiple_attrs(test_dict, idata)
+        assert not fails
+
+    @pytest.skipif(
+        packaging.version.parse(pyro.__version__) < packaging.version.parse("1.0.0"),
+        reason="requires pyro 2.0.0 or higher",
+    )
+    def test_inference_data_only_posterior_has_log_likelihood(self, data):
+        idata = from_pyro(data.obj)
+        test_dict = {"sample_stats": ["log_likelihood"]}
         fails = check_multiple_attrs(test_dict, idata)
         assert not fails

--- a/doc/notebooks/InferenceDataCookbook.ipynb
+++ b/doc/notebooks/InferenceDataCookbook.ipynb
@@ -432,7 +432,9 @@
        "\t> posterior\n",
        "\t> sample_stats\n",
        "\t> posterior_predictive\n",
-       "\t> prior"
+       "\t> prior\n",
+       "\t> prior_predictive\n",
+       "\t> observed_data"
       ]
      },
      "execution_count": 19,


### PR DESCRIPTION
This PR addresses the remaining issue of #853. Users can get information criterions with from_pyro now.