### PR TITLE
move backend show to args

### DIFF
--- a/arviz/plots/autocorrplot.py
+++ b/arviz/plots/autocorrplot.py
@@ -20,6 +20,7 @@ def plot_autocorr(
     ax=None,
     backend=None,
     backend_kwargs=None,
+    show=None,
 ):
     """Bar plot of the autocorrelation function for a sequence of data.
 
@@ -51,6 +52,8 @@ def plot_autocorr(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
+    show : bool, optional
+        Call backend show function.
 
     Returns
     -------
@@ -118,6 +121,7 @@ def plot_autocorr(
         xt_labelsize=xt_labelsize,
         titlesize=titlesize,
         backend_kwargs=backend_kwargs,
+        show=show,
     )
 
     if backend == "bokeh":

--- a/arviz/plots/backends/bokeh/__init__.py
+++ b/arviz/plots/backends/bokeh/__init__.py
@@ -3,7 +3,7 @@
 import packaging
 
 
-def backend_kwarg_defaults(*args, add_default=True, **kwargs):
+def backend_kwarg_defaults(*args, **kwargs):
     """Get default kwargs for backend.
 
     For args add a tuple with key and rcParam key pair.
@@ -12,10 +12,14 @@ def backend_kwarg_defaults(*args, add_default=True, **kwargs):
     # add needed default args from arviz.rcParams
     for key, arg in args:
         defaults.setdefault(key, rcParams[arg])
-    # add default args from rcParams
-    if add_default:
-        defaults.setdefault("show", rcParams["plot.bokeh.show"])
     return defaults
+
+
+def backend_show(show):
+    """Set default behaviour for show if not explicitly defined."""
+    if show is None:
+        show = rcParams["plot.bokeh.show"]
+    return show
 
 
 from .autocorrplot import plot_autocorr

--- a/arviz/plots/backends/bokeh/autocorrplot.py
+++ b/arviz/plots/backends/bokeh/autocorrplot.py
@@ -4,13 +4,13 @@ import numpy as np
 from bokeh.layouts import gridplot
 from bokeh.models.annotations import Title
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 from ...plot_utils import _create_axes_grid, make_label
 from ....stats import autocorr
 
 
 def plot_autocorr(
-    axes, plotters, max_lag, figsize, rows, cols, line_width, combined, backend_kwargs,
+    axes, plotters, max_lag, figsize, rows, cols, line_width, combined, backend_kwargs, show,
 ):
     """Bokeh autocorrelation plot."""
     if backend_kwargs is None:
@@ -20,7 +20,6 @@ def plot_autocorr(
         **backend_kwarg_defaults(),
         **backend_kwargs,
     }
-    show = backend_kwargs.pop("show")
 
     if axes is None:
         _, axes = _create_axes_grid(
@@ -61,6 +60,6 @@ def plot_autocorr(
         axes[0, 0].y_range._property_values["start"] = -1  # pylint: disable=protected-access
         axes[0, 0].y_range._property_values["end"] = 1  # pylint: disable=protected-access
 
-    if show:
-        bkp.show(gridplot([list(item) for item in axes], toolbar_location="above"))
+    if backend_show(show):
+        bkp.show(gridplot(axes.tolist(), toolbar_location="above"))
     return axes

--- a/arviz/plots/backends/bokeh/autocorrplot.py
+++ b/arviz/plots/backends/bokeh/autocorrplot.py
@@ -33,14 +33,18 @@ def plot_autocorr(
             backend="bokeh",
             backend_kwargs=backend_kwargs,
         )
+    else:
+        axes = np.atleast_2d(axes)
 
-    for (var_name, selection, x), ax_ in zip(plotters, axes.flatten()):
+    for (var_name, selection, x), ax in zip(
+        plotters, (item for item in axes.flatten() if item is not None)
+    ):
         x_prime = x
         if combined:
             x_prime = x.flatten()
         y = autocorr(x_prime)
 
-        ax_.segment(
+        ax.segment(
             x0=np.arange(len(y)),
             y0=0,
             x1=np.arange(len(y)),
@@ -48,11 +52,11 @@ def plot_autocorr(
             line_width=line_width,
             line_color="black",
         )
-        ax_.line([0, 0], [0, max_lag], line_color="steelblue")
+        ax.line([0, 0], [0, max_lag], line_color="steelblue")
 
         title = Title()
         title.text = make_label(var_name, selection)
-        ax_.title = title
+        ax.title = title
 
     if axes.size > 0:
         axes[0, 0].x_range._property_values["start"] = 0  # pylint: disable=protected-access

--- a/arviz/plots/backends/bokeh/compareplot.py
+++ b/arviz/plots/backends/bokeh/compareplot.py
@@ -2,7 +2,7 @@
 import bokeh.plotting as bkp
 from bokeh.models import Span
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 
 
 def plot_compare(
@@ -19,6 +19,7 @@ def plot_compare(
     information_criterion,
     step,
     backend_kwargs,
+    show,
 ):
     """Bokeh compareplot."""
     if backend_kwargs is None:
@@ -33,7 +34,6 @@ def plot_compare(
         **backend_kwargs,
     }
     dpi = backend_kwargs.pop("dpi")
-    show = backend_kwargs.pop("show")
 
     if ax is None:
         ax = bkp.figure(width=figsize[0] * dpi, height=figsize[1] * dpi, **backend_kwargs)
@@ -130,7 +130,7 @@ def plot_compare(
     ax.y_range._property_values["start"] = -1 + step  # pylint: disable=protected-access
     ax.y_range._property_values["end"] = 0 - step  # pylint: disable=protected-access
 
-    if show:
+    if backend_show(show):
         bkp.show(ax, toolbar_location="above")
 
     return ax

--- a/arviz/plots/backends/bokeh/densityplot.py
+++ b/arviz/plots/backends/bokeh/densityplot.py
@@ -41,17 +41,23 @@ def plot_density(
         **backend_kwargs,
     }
 
-    _, ax = _create_axes_grid(
-        length_plotters,
-        rows,
-        cols,
-        figsize=figsize,
-        squeeze=False,
-        backend="bokeh",
-        backend_kwargs=backend_kwargs,
-    )
+    if ax is None:
+        _, ax = _create_axes_grid(
+            length_plotters,
+            rows,
+            cols,
+            figsize=figsize,
+            squeeze=False,
+            backend="bokeh",
+            backend_kwargs=backend_kwargs,
+        )
+    else:
+        ax = np.atleast_2d(ax)
 
-    axis_map = {label: ax_ for label, ax_ in zip(all_labels, ax.flatten())}
+    axis_map = {
+        label: ax_
+        for label, ax_ in zip(all_labels, (item for item in ax.flatten() if item is not None))
+    }
     if data_labels is None:
         data_labels = {}
 

--- a/arviz/plots/backends/bokeh/densityplot.py
+++ b/arviz/plots/backends/bokeh/densityplot.py
@@ -4,7 +4,7 @@ import numpy as np
 from bokeh.layouts import gridplot
 from bokeh.models.annotations import Title
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 from ...kdeplot import _fast_kde
 from ...plot_utils import _create_axes_grid, make_label
 from ....stats import hpd
@@ -30,6 +30,7 @@ def plot_density(
     shade,
     data_labels,
     backend_kwargs,
+    show,
 ):
     """Bokeh density plot."""
     if backend_kwargs is None:
@@ -39,8 +40,6 @@ def plot_density(
         **backend_kwarg_defaults(),
         **backend_kwargs,
     }
-
-    show = backend_kwargs.pop("show")
 
     _, ax = _create_axes_grid(
         length_plotters,
@@ -83,8 +82,8 @@ def plot_density(
                 data_label=data_label,
             )
 
-    if show:
-        grid = gridplot([list(item) for item in ax], toolbar_location="above")
+    if backend_show(show):
+        grid = gridplot(ax.tolist(), toolbar_location="above")
         bkp.show(grid)
 
     return ax

--- a/arviz/plots/backends/bokeh/distplot.py
+++ b/arviz/plots/backends/bokeh/distplot.py
@@ -2,33 +2,34 @@
 import bokeh.plotting as bkp
 import numpy as np
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 from ...kdeplot import plot_kde
 from ...plot_utils import get_bins
 
 
 def plot_dist(
     values,
-    values2=None,
-    color="C0",
-    kind="auto",
-    cumulative=False,
-    label=None,
-    rotated=False,
-    rug=False,
-    bw=4.5,
-    quantiles=None,
-    contour=True,
-    fill_last=True,
-    plot_kwargs=None,
-    fill_kwargs=None,
-    rug_kwargs=None,
-    contour_kwargs=None,
-    contourf_kwargs=None,
-    pcolormesh_kwargs=None,
-    hist_kwargs=None,
-    ax=None,
-    backend_kwargs=None,
+    values2,
+    color,
+    kind,
+    cumulative,
+    label,
+    rotated,
+    rug,
+    bw,
+    quantiles,
+    contour,
+    fill_last,
+    plot_kwargs,
+    fill_kwargs,
+    rug_kwargs,
+    contour_kwargs,
+    contourf_kwargs,
+    pcolormesh_kwargs,
+    hist_kwargs,
+    ax,
+    backend_kwargs,
+    show,
     **kwargs  # pylint: disable=unused-argument
 ):
     """Bokeh distplot."""
@@ -44,7 +45,6 @@ def plot_dist(
         ),
         **backend_kwargs,
     }
-    show = backend_kwargs.pop("show")
     if ax is None:
         ax = bkp.figure(**backend_kwargs)
 
@@ -82,12 +82,13 @@ def plot_dist(
             pcolormesh_kwargs=pcolormesh_kwargs,
             ax=ax,
             backend="bokeh",
-            backend_kwargs={"show": False},
+            backend_kwargs={},
+            show=False,
         )
     else:
         raise TypeError('Invalid "kind":{}. Select from {{"auto","kde","hist"}}'.format(kind))
 
-    if show:
+    if backend_show(show):
         bkp.show(ax, toolbar_location="above")
     return ax
 

--- a/arviz/plots/backends/bokeh/elpdplot.py
+++ b/arviz/plots/backends/bokeh/elpdplot.py
@@ -6,7 +6,7 @@ import numpy as np
 from bokeh.layouts import gridplot
 from bokeh.models.annotations import Title
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 from ...plot_utils import _scale_fig_size
 from ....rcparams import rcParams
 
@@ -25,6 +25,7 @@ def plot_elpd(
     xdata,
     threshold,
     backend_kwargs,
+    show,
 ):
     """Bokeh elpd plot."""
     if backend_kwargs is None:
@@ -39,7 +40,6 @@ def plot_elpd(
         **backend_kwargs,
     }
     dpi = backend_kwargs.pop("dpi")
-    show = backend_kwargs.pop("show")
     if numvars == 2:
         (figsize, _, _, _, _, markersize) = _scale_fig_size(
             figsize, textsize, numvars - 1, numvars - 1
@@ -56,7 +56,7 @@ def plot_elpd(
             ax, xdata, ydata, *models, threshold, coord_labels, xlabels, True, True, plot_kwargs
         )
 
-        if show:
+        if backend_show(show):
             bkp.show(ax, toolbar_location="above")
 
     else:
@@ -128,8 +128,8 @@ def plot_elpd(
                     plot_kwargs,
                 )
 
-        if show:
-            bkp.show(gridplot([list(item) for item in ax], toolbar_location="above"))
+        if backend_show(show):
+            bkp.show(gridplot(ax.tolist(), toolbar_location="above"))
     return ax
 
 

--- a/arviz/plots/backends/bokeh/energyplot.py
+++ b/arviz/plots/backends/bokeh/energyplot.py
@@ -2,7 +2,7 @@
 import bokeh.plotting as bkp
 from bokeh.models import Label
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 from .distplot import _histplot_bokeh_op
 from ...kdeplot import plot_kde
 from ....stats import bfmi as e_bfmi
@@ -21,6 +21,7 @@ def plot_energy(
     bw,
     legend,
     backend_kwargs,
+    show,
 ):
     """Bokeh energy plot."""
     if backend_kwargs is None:
@@ -34,7 +35,6 @@ def plot_energy(
         ),
         **backend_kwargs,
     }
-    show = backend_kwargs.pop("show")
     dpi = backend_kwargs.pop("dpi")
     if ax is None:
         ax = bkp.figure(width=int(figsize[0] * dpi), height=int(figsize[1] * dpi), **backend_kwargs)
@@ -55,7 +55,8 @@ def plot_energy(
                 ax=ax,
                 legend=legend,
                 backend="bokeh",
-                backend_kwargs={"show": False},
+                backend_kwargs={},
+                show=False,
             )
     elif kind in {"hist", "histogram"}:
         hist_kwargs = plot_kwargs.copy()
@@ -94,7 +95,7 @@ def plot_energy(
         ax.legend.location = "top_left"
         ax.legend.click_policy = "hide"
 
-    if show:
+    if backend_show(show):
         bkp.show(ax, toolbar_location="above")
 
     return ax

--- a/arviz/plots/backends/bokeh/essplot.py
+++ b/arviz/plots/backends/bokeh/essplot.py
@@ -68,7 +68,12 @@ def plot_ess(
             backend="bokeh",
             backend_kwargs=backend_kwargs,
         )
-    for (var_name, selection, x), ax_ in zip(plotters, np.ravel(ax)):
+    else:
+        ax = np.atleast_2d(ax)
+
+    for (var_name, selection, x), ax_ in zip(
+        plotters, (item for item in ax.flatten() if item is not None)
+    ):
         ax_.circle(np.asarray(xdata), np.asarray(x), size=6)
         if kind == "evolution":
             ax_.line(np.asarray(xdata), np.asarray(x), legend_label="bulk")

--- a/arviz/plots/backends/bokeh/essplot.py
+++ b/arviz/plots/backends/bokeh/essplot.py
@@ -7,7 +7,7 @@ from bokeh.models import Dash, Span, ColumnDataSource
 from bokeh.models.annotations import Title
 from scipy.stats import rankdata
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 from ...plot_utils import (
     make_label,
     _create_axes_grid,
@@ -47,6 +47,7 @@ def plot_ess(
     rug_kwargs,
     hline_kwargs,
     backend_kwargs,
+    show,
 ):
     """Bokeh essplot."""
     if backend_kwargs is None:
@@ -56,7 +57,6 @@ def plot_ess(
         **backend_kwarg_defaults(),
         **backend_kwargs,
     }
-    show = backend_kwargs.pop("show")
     if ax is None:
         _, ax = _create_axes_grid(
             len(plotters),
@@ -155,8 +155,8 @@ def plot_ess(
         ax_.xaxis.axis_label = "Total number of draws" if kind == "evolution" else "Quantile"
         ax_.yaxis.axis_label = ylabel.format("Relative ESS" if relative else "ESS")
 
-    if show:
-        grid = gridplot([list(item) for item in ax], toolbar_location="above")
+    if backend_show(show):
+        grid = gridplot(ax.tolist(), toolbar_location="above")
         bkp.show(grid)
 
     return ax

--- a/arviz/plots/backends/bokeh/forestplot.py
+++ b/arviz/plots/backends/bokeh/forestplot.py
@@ -102,14 +102,16 @@ def plot_forest(
             axes.append(ax)
     else:
         axes = ax
-    axes = np.atleast_1d(axes)
+
+    axes = np.atleast_2d(axes)
+
     if kind == "forestplot":
         plot_handler.forestplot(
-            credible_interval, quartiles, linewidth, markersize, axes[0], rope,
+            credible_interval, quartiles, linewidth, markersize, axes[0, 0], rope,
         )
     elif kind == "ridgeplot":
         plot_handler.ridgeplot(
-            ridgeplot_overlap, linewidth, ridgeplot_alpha, ridgeplot_kind, axes[0]
+            ridgeplot_overlap, linewidth, ridgeplot_alpha, ridgeplot_kind, axes[0, 0]
         )
     else:
         raise TypeError(
@@ -140,21 +142,23 @@ def plot_forest(
 
     labels, ticks = plot_handler.labels_and_ticks()
 
-    axes[0].yaxis.ticker = FixedTicker(ticks=ticks)
-    axes[0].yaxis.major_label_overrides = dict(zip(map(str, ticks), map(str, labels)))
+    axes[0, 0].yaxis.ticker = FixedTicker(ticks=ticks)
+    axes[0, 0].yaxis.major_label_overrides = dict(zip(map(str, ticks), map(str, labels)))
 
     all_plotters = list(plot_handler.plotters.values())
     y_max = plot_handler.y_max() - all_plotters[-1].group_offset
     if kind == "ridgeplot":  # space at the top
         y_max += ridgeplot_overlap
 
-    axes[0].y_range._property_values["start"] = -all_plotters[  # pylint: disable=protected-access
+    axes[0, 0].y_range._property_values[
+        "start"
+    ] = -all_plotters[  # pylint: disable=protected-access
         0
     ].group_offset
-    axes[0].y_range._property_values["end"] = y_max  # pylint: disable=protected-access
+    axes[0, 0].y_range._property_values["end"] = y_max  # pylint: disable=protected-access
 
     if backend_show(show):
-        grid = gridplot([list(axes)], toolbar_location="above")
+        grid = gridplot(axes.tolist(), toolbar_location="above")
         bkp.show(grid)
 
     return axes

--- a/arviz/plots/backends/bokeh/forestplot.py
+++ b/arviz/plots/backends/bokeh/forestplot.py
@@ -11,7 +11,7 @@ from bokeh.models import Band, ColumnDataSource
 from bokeh.models.annotations import Title
 from bokeh.models.tickers import FixedTicker
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 from ...kdeplot import _fast_kde
 from ...plot_utils import _scale_fig_size, xarray_var_iter, make_label, get_bins
 from ....rcparams import rcParams
@@ -51,6 +51,7 @@ def plot_forest(
     ess,
     r_hat,
     backend_kwargs,
+    show,
 ):
     """Bokeh forest plot."""
     plot_handler = PlotHandler(
@@ -80,7 +81,6 @@ def plot_forest(
         **backend_kwargs,
     }
     dpi = backend_kwargs.pop("dpi")
-    show = backend_kwargs.pop("show")
 
     if ax is None:
         axes = []
@@ -153,7 +153,7 @@ def plot_forest(
     ].group_offset
     axes[0].y_range._property_values["end"] = y_max  # pylint: disable=protected-access
 
-    if show:
+    if backend_show(show):
         grid = gridplot([list(axes)], toolbar_location="above")
         bkp.show(grid)
 

--- a/arviz/plots/backends/bokeh/forestplot.py
+++ b/arviz/plots/backends/bokeh/forestplot.py
@@ -121,14 +121,14 @@ def plot_forest(
 
     idx = 1
     if ess:
-        plot_handler.plot_neff(axes[idx], markersize)
+        plot_handler.plot_neff(axes[0, idx], markersize)
         idx += 1
 
     if r_hat:
-        plot_handler.plot_rhat(axes[idx], markersize)
+        plot_handler.plot_rhat(axes[0, idx], markersize)
         idx += 1
 
-    for i, ax_ in enumerate(axes):
+    for i, ax_ in enumerate(axes.ravel()):
         if kind == "ridgeplot":
             ax_.xgrid.grid_line_color = None
             ax_.ygrid.grid_line_color = None

--- a/arviz/plots/backends/bokeh/hpdplot.py
+++ b/arviz/plots/backends/bokeh/hpdplot.py
@@ -5,10 +5,10 @@ import bokeh.plotting as bkp
 import numpy as np
 from matplotlib.pyplot import rcParams as mpl_rcParams
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 
 
-def plot_hpd(ax, x_data, y_data, plot_kwargs, fill_kwargs, backend_kwargs):
+def plot_hpd(ax, x_data, y_data, plot_kwargs, fill_kwargs, backend_kwargs, show):
     """Bokeh hpd plot."""
     if backend_kwargs is None:
         backend_kwargs = {}
@@ -22,7 +22,6 @@ def plot_hpd(ax, x_data, y_data, plot_kwargs, fill_kwargs, backend_kwargs):
         ),
         **backend_kwargs,
     }
-    show = backend_kwargs.pop("show")
     if ax is None:
         ax = bkp.figure(**backend_kwargs)
 
@@ -55,7 +54,7 @@ def plot_hpd(ax, x_data, y_data, plot_kwargs, fill_kwargs, backend_kwargs):
         **plot_kwargs
     )
 
-    if show:
+    if backend_show(show):
         bkp.show(ax, toolbar_location="above")
 
     return ax

--- a/arviz/plots/backends/bokeh/jointplot.py
+++ b/arviz/plots/backends/bokeh/jointplot.py
@@ -3,7 +3,7 @@ import bokeh.plotting as bkp
 import numpy as np
 from bokeh.layouts import gridplot
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 from ...distplot import plot_dist
 from ...kdeplot import plot_kde
 from ...plot_utils import make_label
@@ -21,6 +21,7 @@ def plot_joint(
     gridsize,
     marginal_kwargs,
     backend_kwargs,
+    show,
 ):
     """Bokeh joint plot."""
     if backend_kwargs is None:
@@ -35,7 +36,6 @@ def plot_joint(
         **backend_kwargs,
     }
     dpi = backend_kwargs.pop("dpi")
-    show = backend_kwargs.pop("show")
     if ax is None:
         axjoin = bkp.figure(
             width=int(figsize[0] * dpi * 0.8), height=int(figsize[1] * dpi * 0.8), **backend_kwargs
@@ -80,7 +80,8 @@ def plot_joint(
             fill_last=fill_last,
             ax=axjoin,
             backend="bokeh",
-            backend_kwargs={"show": False},
+            backend_kwargs={},
+            show=False,
             **joint_kwargs
         )
     else:
@@ -98,11 +99,12 @@ def plot_joint(
             rotated=rotate,
             ax=ax_,
             backend="bokeh",
-            backend_kwargs={"show": False},
+            backend_kwargs={},
+            show=False,
             **marginal_kwargs
         )
 
-    if show:
+    if backend_show(show):
         grid = gridplot([[ax_hist_x, None], [axjoin, ax_hist_y]], toolbar_location="above")
         bkp.show(grid)
 

--- a/arviz/plots/backends/bokeh/kdeplot.py
+++ b/arviz/plots/backends/bokeh/kdeplot.py
@@ -11,7 +11,7 @@ from matplotlib.cm import get_cmap
 from matplotlib.colors import rgb2hex
 from matplotlib.pyplot import rcParams as mpl_rcParams
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 
 
 def plot_kde(
@@ -25,22 +25,23 @@ def plot_kde(
     ymax,
     gridsize,
     values,
-    values2=None,
-    rug=False,
-    label=None,
-    quantiles=None,
-    rotated=False,
-    contour=True,
-    fill_last=True,
-    plot_kwargs=None,
-    fill_kwargs=None,
-    rug_kwargs=None,
-    contour_kwargs=None,
-    contourf_kwargs=None,
-    pcolormesh_kwargs=None,
-    ax=None,
-    legend=True,
-    backend_kwargs=None,
+    values2,
+    rug,
+    label,
+    quantiles,
+    rotated,
+    contour,
+    fill_last,
+    plot_kwargs,
+    fill_kwargs,
+    rug_kwargs,
+    contour_kwargs,
+    contourf_kwargs,
+    pcolormesh_kwargs,
+    ax,
+    legend,
+    backend_kwargs,
+    show,
 ):
     """Bokeh kde plot."""
     if backend_kwargs is None:
@@ -55,7 +56,6 @@ def plot_kde(
         ),
         **backend_kwargs,
     }
-    show = backend_kwargs.pop("show")
     if ax is None:
         ax = bkp.figure(**backend_kwargs)
 
@@ -228,7 +228,7 @@ def plot_kde(
             )
             ax.x_range.range_padding = ax.y_range.range_padding = 0
 
-    if show:
+    if backend_show(show):
         bkp.show(ax, toolbar_location="above")
     return ax
 

--- a/arviz/plots/backends/bokeh/khatplot.py
+++ b/arviz/plots/backends/bokeh/khatplot.py
@@ -5,7 +5,7 @@ import bokeh.plotting as bkp
 import numpy as np
 from bokeh.models import Span
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 from ....stats.stats_utils import histogram
 
 
@@ -22,6 +22,7 @@ def plot_khat(
     n_data_points,
     bin_format,
     backend_kwargs,
+    show,
 ):
     """Bokeh khat plot."""
     if backend_kwargs is None:
@@ -36,7 +37,6 @@ def plot_khat(
         **backend_kwargs,
     }
     dpi = backend_kwargs.pop("dpi")
-    show = backend_kwargs.pop("show")
     if ax is None:
         ax = bkp.figure(width=int(figsize[0] * dpi), height=int(figsize[1] * dpi), **backend_kwargs)
 
@@ -87,7 +87,7 @@ def plot_khat(
     elif ymax > 1 & annotate:
         ax.y_range._property_values["end"] = 1.1 * ymax  # pylint: disable=protected-access
 
-    if show:
+    if backend_show(show):
         bkp.show(ax, toolbar_location="above")
 
     return ax

--- a/arviz/plots/backends/bokeh/loopitplot.py
+++ b/arviz/plots/backends/bokeh/loopitplot.py
@@ -2,7 +2,7 @@
 import bokeh.plotting as bkp
 import numpy as np
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 from ...hpdplot import plot_hpd
 from ...kdeplot import _fast_kde
 
@@ -28,6 +28,7 @@ def plot_loo_pit(
     loo_pit_kde,
     plot_kwargs,
     backend_kwargs,
+    show,
 ):
     """Bokeh loo pit plot."""
     if backend_kwargs is None:
@@ -42,7 +43,6 @@ def plot_loo_pit(
         **backend_kwargs,
     }
     dpi = backend_kwargs.pop("dpi")
-    show = backend_kwargs.pop("show")
     if ax is None:
         ax = bkp.figure(width=int(figsize[0] * dpi), height=int(figsize[1] * dpi), **backend_kwargs)
 
@@ -121,7 +121,8 @@ def plot_loo_pit(
                 unif_densities,
                 backend="bokeh",
                 ax=ax,
-                backend_kwargs={"show": False},
+                backend_kwargs={},
+                show=False,
                 **hpd_kwargs
             )
         else:
@@ -142,7 +143,7 @@ def plot_loo_pit(
             line_width=plot_kwargs.get("linewidth", 3.0),
         )
 
-    if show:
+    if backend_show(show):
         bkp.show(ax, toolbar_location="above")
 
     return ax

--- a/arviz/plots/backends/bokeh/mcseplot.py
+++ b/arviz/plots/backends/bokeh/mcseplot.py
@@ -7,7 +7,7 @@ from bokeh.models import ColumnDataSource, Dash, Span
 from bokeh.models.annotations import Title
 from scipy.stats import rankdata
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 from ...plot_utils import (
     make_label,
     _create_axes_grid,
@@ -36,6 +36,7 @@ def plot_mcse(
     _markersize,
     _linewidth,
     backend_kwargs,
+    show,
 ):
     """Bokeh mcse plot."""
     if backend_kwargs is None:
@@ -45,7 +46,6 @@ def plot_mcse(
         **backend_kwarg_defaults(),
         **backend_kwargs,
     }
-    show = backend_kwargs.pop("show")
     if ax is None:
         _, ax = _create_axes_grid(
             length_plotters,
@@ -166,8 +166,8 @@ def plot_mcse(
             ax_.y_range._property_values["start"] = -0.05  # pylint: disable=protected-access
             ax_.y_range._property_values["end"] = 1  # pylint: disable=protected-access
 
-    if show:
-        grid = gridplot([list(item) for item in ax], toolbar_location="above")
+    if backend_show(show):
+        grid = gridplot(ax.tolist(), toolbar_location="above")
         bkp.show(grid)
 
     return ax

--- a/arviz/plots/backends/bokeh/mcseplot.py
+++ b/arviz/plots/backends/bokeh/mcseplot.py
@@ -55,8 +55,12 @@ def plot_mcse(
             backend="bokeh",
             backend_kwargs=backend_kwargs,
         )
+    else:
+        ax = np.atleast_2d(ax)
 
-    for (var_name, selection, x), ax_ in zip(plotters, np.ravel(ax)):
+    for (var_name, selection, x), ax_ in zip(
+        plotters, (item for item in ax.flatten() if item is not None)
+    ):
         if errorbar or rug:
             values = data[var_name].sel(**selection).values.flatten()
         if errorbar:

--- a/arviz/plots/backends/bokeh/pairplot.py
+++ b/arviz/plots/backends/bokeh/pairplot.py
@@ -8,7 +8,7 @@ import numpy as np
 from bokeh.layouts import gridplot
 from bokeh.models import ColumnDataSource
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 from ...kdeplot import plot_kde
 from ...plot_utils import _scale_fig_size
 from ....rcparams import rcParams
@@ -28,6 +28,7 @@ def plot_pair(
     diverging_mask,
     flat_var_names,
     backend_kwargs,
+    show,
 ):
     """Bokeh pair plot."""
     if backend_kwargs is None:
@@ -42,7 +43,6 @@ def plot_pair(
         **backend_kwargs,
     }
     dpi = backend_kwargs.pop("dpi")
-    show = backend_kwargs.pop("show")
     if numvars == 2:
         (figsize, _, _, _, _, _) = _scale_fig_size(figsize, textsize, numvars - 1, numvars - 1)
 
@@ -61,7 +61,8 @@ def plot_pair(
                 fill_last=fill_last,
                 ax=ax,
                 backend="bokeh",
-                backend_kwargs={"show": False},
+                backend_kwargs={},
+                show=False,
             )
         else:
             ax.hexbin(_posterior[0], _posterior[1], size=0.5)
@@ -80,7 +81,7 @@ def plot_pair(
         ax.xaxis.axis_label = flat_var_names[0]
         ax.yaxis.axis_label = flat_var_names[1]
 
-        if show:
+        if backend_show(show):
             bkp.show(ax)
 
     else:
@@ -167,7 +168,8 @@ def plot_pair(
                         fill_last=fill_last,
                         ax=ax[j, i],
                         backend="bokeh",
-                        backend_kwargs={"show": False},
+                        backend_kwargs={},
+                        show=False,
                         **plot_kwargs
                     )
 
@@ -192,8 +194,8 @@ def plot_pair(
                 ax[j, i].xaxis.axis_label = flat_var_names[i]
                 ax[j, i].yaxis.axis_label = flat_var_names[j + 1]
 
-        if show:
-            grid = gridplot([list(item) for item in ax], toolbar_location="above")
+        if backend_show(show):
+            grid = gridplot(ax.tolist(), toolbar_location="above")
             bkp.show(grid)
 
     return ax

--- a/arviz/plots/backends/bokeh/parallelplot.py
+++ b/arviz/plots/backends/bokeh/parallelplot.py
@@ -3,10 +3,10 @@ import bokeh.plotting as bkp
 import numpy as np
 from bokeh.models.tickers import FixedTicker
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 
 
-def plot_parallel(ax, diverging_mask, _posterior, var_names, figsize, backend_kwargs):
+def plot_parallel(ax, diverging_mask, _posterior, var_names, figsize, backend_kwargs, show):
     """Bokeh parallel plot."""
     if backend_kwargs is None:
         backend_kwargs = {}
@@ -20,7 +20,6 @@ def plot_parallel(ax, diverging_mask, _posterior, var_names, figsize, backend_kw
         **backend_kwargs,
     }
     dpi = backend_kwargs.pop("dpi")
-    show = backend_kwargs.pop("show")
     if ax is None:
         ax = bkp.figure(width=int(figsize[0] * dpi), height=int(figsize[1] * dpi), **backend_kwargs)
 
@@ -40,7 +39,7 @@ def plot_parallel(ax, diverging_mask, _posterior, var_names, figsize, backend_kw
     ax.xaxis.major_label_overrides = dict(zip(map(str, range(len(var_names))), map(str, var_names)))
     ax.xaxis.major_label_orientation = np.pi / 2
 
-    if show:
+    if backend_show(show):
         bkp.show(ax)
 
     return ax

--- a/arviz/plots/backends/bokeh/posteriorplot.py
+++ b/arviz/plots/backends/bokeh/posteriorplot.py
@@ -58,8 +58,12 @@ def plot_posterior(
             backend="bokeh",
             backend_kwargs=backend_kwargs,
         )
+    else:
+        ax = np.atleast_2d(ax)
     idx = 0
-    for (var_name, selection, x), ax_ in zip(plotters, np.ravel(ax)):
+    for (var_name, selection, x), ax_ in zip(
+        plotters, (item for item in ax.flatten() if item is not None)
+    ):
         _plot_posterior_op(
             idx,
             x.flatten(),

--- a/arviz/plots/backends/bokeh/posteriorplot.py
+++ b/arviz/plots/backends/bokeh/posteriorplot.py
@@ -8,7 +8,7 @@ from bokeh.layouts import gridplot
 from bokeh.models.annotations import Title
 from scipy.stats import mode
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 from ...kdeplot import plot_kde, _fast_kde
 from ...plot_utils import (
     make_label,
@@ -38,6 +38,7 @@ def plot_posterior(
     ax_labelsize,
     kwargs,
     backend_kwargs,
+    show,
 ):
     """Bokeh posterior plot."""
     if backend_kwargs is None:
@@ -47,7 +48,6 @@ def plot_posterior(
         **backend_kwarg_defaults(),
         **backend_kwargs,
     }
-    show = backend_kwargs.pop("show")
     if ax is None:
         _, ax = _create_axes_grid(
             length_plotters,
@@ -83,8 +83,8 @@ def plot_posterior(
         _title.text = make_label(var_name, selection)
         ax_.title = _title
 
-    if show:
-        grid = gridplot([list(item) for item in ax], toolbar_location="above")
+    if backend_show(show):
+        grid = gridplot(ax.tolist(), toolbar_location="above")
         bkp.show(grid)
 
     return ax
@@ -246,7 +246,8 @@ def _plot_posterior_op(
             ax=ax,
             rug=False,
             backend="bokeh",
-            backend_kwargs={"show": False},
+            backend_kwargs={},
+            show=False,
         )
         hist, edges = np.histogram(values, density=True)
     else:

--- a/arviz/plots/backends/bokeh/ppcplot.py
+++ b/arviz/plots/backends/bokeh/ppcplot.py
@@ -3,7 +3,7 @@ import bokeh.plotting as bkp
 import numpy as np
 from bokeh.layouts import gridplot
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 from ...kdeplot import plot_kde, _fast_kde
 from ...plot_utils import (
     _create_axes_grid,
@@ -31,6 +31,7 @@ def plot_ppc(
     markersize,
     backend_kwargs,
     num_pp_samples,
+    show,
 ):
     """Bokeh ppc plot."""
     if backend_kwargs is None:
@@ -40,7 +41,6 @@ def plot_ppc(
         **backend_kwarg_defaults(),
         **backend_kwargs,
     }
-    show = backend_kwargs.pop("show")
     if ax is None:
         _, axes = _create_axes_grid(
             length_plotters,
@@ -104,7 +104,8 @@ def plot_ppc(
                     fill_kwargs={"alpha": 0},
                     ax=ax_i,
                     backend="bokeh",
-                    backend_kwargs={"show": False},
+                    backend_kwargs={},
+                    show=False,
                 )
             else:
                 bins = get_bins(obs_vals)
@@ -194,7 +195,8 @@ def plot_ppc(
                         },
                         ax=ax_i,
                         backend="bokeh",
-                        backend_kwargs={"show": False},
+                        backend_kwargs={},
+                        show=False,
                     )
                 else:
                     vals = pp_vals.flatten()
@@ -239,8 +241,8 @@ def plot_ppc(
             xlabel = var_name
         ax_i.xaxis.axis_label = xlabel
 
-    if show:
-        grid = gridplot([list(item) for item in axes], toolbar_location="above")
+    if backend_show(show):
+        grid = gridplot(axes.tolist(), toolbar_location="above")
         bkp.show(grid)
 
     return axes

--- a/arviz/plots/backends/bokeh/ppcplot.py
+++ b/arviz/plots/backends/bokeh/ppcplot.py
@@ -51,9 +51,7 @@ def plot_ppc(
             backend_kwargs=backend_kwargs,
         )
     else:
-        axes = ax
-        if isinstance(axes, bkp.Figure):
-            axes = np.array([axes])
+        axes = np.atleast_2d(ax)
 
         if len([item for item in axes.ravel() if not None]) != length_plotters:
             raise ValueError(
@@ -62,7 +60,7 @@ def plot_ppc(
                 )
             )
 
-    for i, ax_i in enumerate(axes.ravel()):
+    for i, ax_i in enumerate((item for item in axes.flatten() if item is not None)):
         var_name, _, obs_vals = obs_plotters[i]
         pp_var_name, _, pp_vals = pp_plotters[i]
         dtype = posterior_predictive[pp_var_name].dtype.kind

--- a/arviz/plots/backends/bokeh/rankplot.py
+++ b/arviz/plots/backends/bokeh/rankplot.py
@@ -50,8 +50,12 @@ def plot_rank(
             backend="bokeh",
             backend_kwargs=backend_kwargs,
         )
+    else:
+        axes = np.atleast_2d(axes)
 
-    for ax, (var_name, selection, var_data) in zip(np.ravel(axes), plotters):
+    for ax, (var_name, selection, var_data) in zip(
+        (item for item in axes.flatten() if item is not None), plotters
+    ):
         ranks = scipy.stats.rankdata(var_data).reshape(var_data.shape)
         bin_ary = np.histogram_bin_edges(ranks, bins=bins, range=(0, ranks.size))
         all_counts = np.empty((len(ranks), len(bin_ary) - 1))

--- a/arviz/plots/backends/bokeh/rankplot.py
+++ b/arviz/plots/backends/bokeh/rankplot.py
@@ -7,7 +7,7 @@ from bokeh.models import Span
 from bokeh.models.annotations import Title
 from bokeh.models.tickers import FixedTicker
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 from ...plot_utils import (
     _create_axes_grid,
     make_label,
@@ -28,6 +28,7 @@ def plot_rank(
     ref_line,
     labels,
     backend_kwargs,
+    show,
 ):
     """Bokeh rank plot."""
     if backend_kwargs is None:
@@ -37,7 +38,6 @@ def plot_rank(
         **backend_kwarg_defaults(),
         **backend_kwargs,
     }
-    show = backend_kwargs.pop("show")
     if axes is None:
         _, axes = _create_axes_grid(
             length_plotters,
@@ -122,8 +122,8 @@ def plot_rank(
         _title.text = make_label(var_name, selection)
         ax.title = _title
 
-    if show:
-        grid = gridplot([list(item) for item in axes], toolbar_location="above")
+    if backend_show(show):
+        grid = gridplot(axes.tolist(), toolbar_location="above")
         bkp.show(grid)
 
     return axes

--- a/arviz/plots/backends/bokeh/traceplot.py
+++ b/arviz/plots/backends/bokeh/traceplot.py
@@ -9,7 +9,7 @@ from bokeh.layouts import gridplot
 from bokeh.models import ColumnDataSource, Dash, Span
 from bokeh.models.annotations import Title
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 from ...distplot import plot_dist
 from ...plot_utils import xarray_var_iter, make_label, _scale_fig_size
 from ....rcparams import rcParams
@@ -33,6 +33,7 @@ def plot_trace(
     divergence_data,
     colors,
     backend_kwargs: [Dict],
+    show,
 ):
     """Bokeh traceplot."""
     # If divergences are plotted they must be provided
@@ -52,7 +53,6 @@ def plot_trace(
         **backend_kwargs,
     }
     dpi = backend_kwargs.pop("dpi")
-    show = backend_kwargs.pop("show")
 
     backend_kwargs.setdefault("height", int(figsize[1] * dpi // len(plotters)))
     backend_kwargs.setdefault("width", int(figsize[0] * dpi // 2))
@@ -248,8 +248,8 @@ def plot_trace(
                     axes[idx, 0].add_glyph(tmp_cds, glyph_density)
                     axes[idx, 1].add_glyph(tmp_cds, glyph_trace)
 
-    if show is True:
-        grid = gridplot([list(item) for item in axes], toolbar_location="above")
+    if backend_show(show):
+        grid = gridplot(axes.tolist(), toolbar_location="above")
         bkp.show(grid)
 
     return axes
@@ -303,7 +303,8 @@ def _plot_chains_bokeh(
                 fill_kwargs=fill_kwargs,
                 rug_kwargs=rug_kwargs,
                 backend="bokeh",
-                backend_kwargs={"show": False},
+                backend_kwargs={},
+                show=False,
             )
 
     if combined:
@@ -320,5 +321,6 @@ def _plot_chains_bokeh(
             fill_kwargs=fill_kwargs,
             rug_kwargs=rug_kwargs,
             backend="bokeh",
-            backend_kwargs={"show": False},
+            backend_kwargs={},
+            show=False,
         )

--- a/arviz/plots/backends/bokeh/violinplot.py
+++ b/arviz/plots/backends/bokeh/violinplot.py
@@ -46,9 +46,12 @@ def plot_violin(
             backend="bokeh",
             backend_kwargs=backend_kwargs,
         )
-    ax = np.atleast_1d(ax)
+    else:
+        ax = np.atleast_2d(ax)
 
-    for (var_name, selection, x), ax_ in zip(plotters, ax.flatten()):
+    for (var_name, selection, x), ax_ in zip(
+        plotters, (item for item in ax.flatten() if item is not None)
+    ):
         val = x.flatten()
         if val[0].dtype.kind == "i":
             cat_hist(val, shade, ax_, **kwargs_shade)

--- a/arviz/plots/backends/bokeh/violinplot.py
+++ b/arviz/plots/backends/bokeh/violinplot.py
@@ -4,7 +4,7 @@ import numpy as np
 from bokeh.layouts import gridplot
 from bokeh.models.annotations import Title
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 from ...kdeplot import _fast_kde
 from ...plot_utils import get_bins, make_label, _create_axes_grid
 from ....stats import hpd
@@ -25,6 +25,7 @@ def plot_violin(
     linewidth,
     quartiles,
     backend_kwargs,
+    show,
 ):
     """Bokeh violin plot."""
     if backend_kwargs is None:
@@ -34,7 +35,6 @@ def plot_violin(
         **backend_kwarg_defaults(),
         **backend_kwargs,
     }
-    show = backend_kwargs.pop("show")
     if ax is None:
         _, ax = _create_axes_grid(
             len(plotters),
@@ -70,8 +70,8 @@ def plot_violin(
         ax_.xaxis.minor_tick_line_color = None
         ax_.xaxis.major_label_text_font_size = "0pt"
 
-    if show:
-        grid = gridplot([list(item) for item in ax], toolbar_location="above")
+    if backend_show(show):
+        grid = gridplot(ax.tolist(), toolbar_location="above")
         bkp.show(grid)
 
     return ax

--- a/arviz/plots/backends/matplotlib/__init__.py
+++ b/arviz/plots/backends/matplotlib/__init__.py
@@ -2,7 +2,7 @@
 """Matplotlib Plotting Backend."""
 
 
-def backend_kwarg_defaults(*args, add_default=True, **kwargs):
+def backend_kwarg_defaults(*args, **kwargs):
     """Get default kwargs for backend.
 
     For args add a tuple with key and rcParam key pair.
@@ -12,9 +12,15 @@ def backend_kwarg_defaults(*args, add_default=True, **kwargs):
     for key, arg in args:
         defaults.setdefault(key, rcParams[arg])
     # add default args from rcParams
-    if add_default:
-        defaults.setdefault("constrained_layout", rcParams["plot.matplotlib.constrained_layout"])
+    defaults.setdefault("constrained_layout", rcParams["plot.matplotlib.constrained_layout"])
     return defaults
+
+
+def backend_show(show):
+    """Set default behaviour for show if not explicitly defined."""
+    if show is None:
+        show = rcParams["plot.matplotlib.show"]
+    return show
 
 
 from .autocorrplot import plot_autocorr

--- a/arviz/plots/backends/matplotlib/autocorrplot.py
+++ b/arviz/plots/backends/matplotlib/autocorrplot.py
@@ -1,6 +1,8 @@
 """Matplotlib Autocorrplot."""
+import matplotlib.pyplot as plt
 import numpy as np
 
+from . import backend_show
 from ....stats import autocorr
 from ...plot_utils import _create_axes_grid, make_label
 
@@ -14,9 +16,10 @@ def plot_autocorr(
     cols,
     linewidth,
     titlesize,
-    combined=False,
-    xt_labelsize=None,
-    backend_kwargs=None,
+    combined,
+    xt_labelsize,
+    backend_kwargs,
+    show,
 ):
     """Matplotlib autocorrplot."""
     if axes is None:
@@ -47,5 +50,8 @@ def plot_autocorr(
     if axes.size > 0:
         axes[0, 0].set_xlim(0, max_lag)
         axes[0, 0].set_ylim(-1, 1)
+
+    if backend_show(show):
+        plt.show()
 
     return axes

--- a/arviz/plots/backends/matplotlib/compareplot.py
+++ b/arviz/plots/backends/matplotlib/compareplot.py
@@ -1,7 +1,7 @@
 """Matplotlib Compareplot."""
 import matplotlib.pyplot as plt
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 
 
 def plot_compare(
@@ -20,6 +20,7 @@ def plot_compare(
     xt_labelsize,
     step,
     backend_kwargs,
+    show,
 ):
     """Matplotlib compare plot."""
     if backend_kwargs is None:
@@ -98,5 +99,8 @@ def plot_compare(
     ax.set_yticklabels(yticks_labels)
     ax.set_ylim(-1 + step, 0 - step)
     ax.tick_params(labelsize=xt_labelsize)
+
+    if backend_show(show):
+        plt.show()
 
     return ax

--- a/arviz/plots/backends/matplotlib/densityplot.py
+++ b/arviz/plots/backends/matplotlib/densityplot.py
@@ -1,6 +1,8 @@
 """Matplotlib Densityplot."""
+import matplotlib.pyplot as plt
 import numpy as np
 
+from . import backend_show
 from ....stats import hpd
 from ...kdeplot import _fast_kde
 from ...plot_utils import _create_axes_grid, make_label
@@ -28,6 +30,7 @@ def plot_density(
     n_data,
     data_labels,
     backend_kwargs,
+    show,
 ):
     """Matplotlib densityplot."""
     _, ax = _create_axes_grid(
@@ -65,6 +68,9 @@ def plot_density(
         for m_idx, label in enumerate(data_labels):
             ax[0].plot([], label=label, c=colors[m_idx], markersize=markersize)
         ax[0].legend(fontsize=xt_labelsize)
+
+    if backend_show(show):
+        plt.show()
 
     return ax
 

--- a/arviz/plots/backends/matplotlib/distplot.py
+++ b/arviz/plots/backends/matplotlib/distplot.py
@@ -2,6 +2,7 @@
 import warnings
 import matplotlib.pyplot as plt
 
+from . import backend_show
 from ...kdeplot import plot_kde
 
 
@@ -28,6 +29,7 @@ def plot_dist(
     hist_kwargs,
     ax,
     backend_kwargs,
+    show,
 ):
     """Matplotlib distplot."""
     if backend_kwargs is not None:
@@ -37,6 +39,7 @@ def plot_dist(
                 "Supplied value won't be used"
             )
         )
+        backend_kwargs = None
     if ax is None:
         ax = plt.gca()
 
@@ -73,7 +76,12 @@ def plot_dist(
             pcolormesh_kwargs=pcolormesh_kwargs,
             ax=ax,
             backend="matplotlib",
+            backend_kwargs=backend_kwargs,
+            show=show,
         )
+
+    if backend_show(show):
+        plt.show()
 
     return ax
 

--- a/arviz/plots/backends/matplotlib/elpdplot.py
+++ b/arviz/plots/backends/matplotlib/elpdplot.py
@@ -1,11 +1,11 @@
 """Matplotlib ELPDPlot."""
 import warnings
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 from ...plot_utils import (
     _scale_fig_size,
     set_xticklabels,
@@ -30,6 +30,7 @@ def plot_elpd(
     handles,
     color,
     backend_kwargs,
+    show,
 ):
     """Matplotlib elpd plot."""
     if backend_kwargs is None:
@@ -153,5 +154,8 @@ def plot_elpd(
             ax[0, 1].legend(
                 handles=handles, ncol=ncols, title=color, bbox_to_anchor=(0, 1), loc="upper left"
             )
+
+    if backend_show(show):
+        plt.show()
 
     return ax

--- a/arviz/plots/backends/matplotlib/energyplot.py
+++ b/arviz/plots/backends/matplotlib/energyplot.py
@@ -1,7 +1,7 @@
 """Matplotlib energyplot."""
 import matplotlib.pyplot as plt
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 from ...kdeplot import plot_kde
 from ....stats import bfmi as e_bfmi
 
@@ -20,6 +20,7 @@ def plot_energy(
     bw,
     legend,
     backend_kwargs,
+    show,
 ):
     """Matplotlib energy plot."""
     if backend_kwargs is None:
@@ -72,5 +73,8 @@ def plot_energy(
 
     ax.set_xticks([])
     ax.set_yticks([])
+
+    if backend_show(show):
+        plt.show()
 
     return ax

--- a/arviz/plots/backends/matplotlib/essplot.py
+++ b/arviz/plots/backends/matplotlib/essplot.py
@@ -1,8 +1,9 @@
 """Matplotlib energyplot."""
+import matplotlib.pyplot as plt
 import numpy as np
 from scipy.stats import rankdata
 
-
+from . import backend_show
 from ...plot_utils import (
     make_label,
     _create_axes_grid,
@@ -42,6 +43,7 @@ def plot_ess(
     rug_kwargs,
     hline_kwargs,
     backend_kwargs,
+    show,
 ):
     """Matplotlib ess plot."""
     if ax is None:
@@ -125,5 +127,8 @@ def plot_ess(
             ax_.set_yticklabels(yticks)
         else:
             ax_.set_ylim(bottom=0)
+
+    if backend_show(show):
+        plt.show()
 
     return ax

--- a/arviz/plots/backends/matplotlib/forestplot.py
+++ b/arviz/plots/backends/matplotlib/forestplot.py
@@ -2,11 +2,11 @@
 from collections import defaultdict, OrderedDict
 from itertools import tee
 
-import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.colors import to_rgba
+import numpy as np
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 from ....stats import hpd
 from ....stats.diagnostics import _ess, _rhat
 from ....stats.stats_utils import histogram
@@ -45,6 +45,7 @@ def plot_forest(
     ess,
     r_hat,
     backend_kwargs,
+    show,
 ):
     """Matplotlib forest plot."""
     plot_handler = PlotHandler(
@@ -138,6 +139,9 @@ def plot_forest(
     if kind == "ridgeplot":  # space at the top
         y_max += ridgeplot_overlap
     axes[0].set_ylim(-all_plotters[0].group_offset, y_max)
+
+    if backend_show(show):
+        plt.show()
 
     return axes
 

--- a/arviz/plots/backends/matplotlib/hpdplot.py
+++ b/arviz/plots/backends/matplotlib/hpdplot.py
@@ -1,9 +1,11 @@
 """Matplotlib hpdplot."""
 import warnings
-from matplotlib.pyplot import gca
+import matplotlib.pyplot as plt
+
+from . import backend_show
 
 
-def plot_hpd(ax, x_data, y_data, plot_kwargs, fill_kwargs, backend_kwargs):
+def plot_hpd(ax, x_data, y_data, plot_kwargs, fill_kwargs, backend_kwargs, show):
     """Matplotlib hpd plot."""
     if backend_kwargs is not None:
         warnings.warn(
@@ -13,7 +15,11 @@ def plot_hpd(ax, x_data, y_data, plot_kwargs, fill_kwargs, backend_kwargs):
             )
         )
     if ax is None:
-        ax = gca()
+        ax = plt.gca()
     ax.plot(x_data, y_data, **plot_kwargs)
     ax.fill_between(x_data, y_data[:, 0], y_data[:, 1], **fill_kwargs)
+
+    if backend_show(show):
+        plt.show()
+
     return ax

--- a/arviz/plots/backends/matplotlib/jointplot.py
+++ b/arviz/plots/backends/matplotlib/jointplot.py
@@ -2,7 +2,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 from ...distplot import plot_dist
 from ...kdeplot import plot_kde
 from ...plot_utils import make_label
@@ -21,6 +21,7 @@ def plot_joint(
     gridsize,
     marginal_kwargs,
     backend_kwargs,
+    show,
 ):
     """Matplotlib joint plot."""
     if backend_kwargs is None:
@@ -77,5 +78,8 @@ def plot_joint(
 
     ax_hist_x.set_xlim(axjoin.get_xlim())
     ax_hist_y.set_ylim(axjoin.get_ylim())
+
+    if backend_show(show):
+        plt.show()
 
     return np.array([axjoin, ax_hist_x, ax_hist_y])

--- a/arviz/plots/backends/matplotlib/kdeplot.py
+++ b/arviz/plots/backends/matplotlib/kdeplot.py
@@ -3,6 +3,7 @@ import warnings
 from matplotlib import pyplot as plt
 import numpy as np
 
+from . import backend_show
 from ...plot_utils import _scale_fig_size
 
 
@@ -17,23 +18,24 @@ def plot_kde(
     ymax,
     gridsize,
     values,
-    values2=None,
-    rug=False,
-    label=None,
-    quantiles=None,
-    rotated=False,
-    contour=True,
-    fill_last=True,
-    textsize=None,
-    plot_kwargs=None,
-    fill_kwargs=None,
-    rug_kwargs=None,
-    contour_kwargs=None,
-    contourf_kwargs=None,
-    pcolormesh_kwargs=None,
-    ax=None,
-    legend=True,
-    backend_kwargs=None,
+    values2,
+    rug,
+    label,
+    quantiles,
+    rotated,
+    contour,
+    fill_last,
+    textsize,
+    plot_kwargs,
+    fill_kwargs,
+    rug_kwargs,
+    contour_kwargs,
+    contourf_kwargs,
+    pcolormesh_kwargs,
+    ax,
+    legend,
+    backend_kwargs,
+    show,
 ):
     """Matplotlib kde plot."""
     if backend_kwargs is not None:
@@ -145,5 +147,8 @@ def plot_kde(
                 qcs.collections[0].set_alpha(0)
         else:
             ax.pcolormesh(x_x, y_y, density, **pcolormesh_kwargs)
+
+    if backend_show(show):
+        plt.show()
 
     return ax

--- a/arviz/plots/backends/matplotlib/khatplot.py
+++ b/arviz/plots/backends/matplotlib/khatplot.py
@@ -51,7 +51,7 @@ def plot_khat(
         backend_kwargs = {}
 
     backend_kwargs = {
-        **backend_kwarg_defaults(("constrained_layout", not xlabels)),
+        **backend_kwarg_defaults(constrained_layout=(not xlabels))),
         **backend_kwargs,
     }
 

--- a/arviz/plots/backends/matplotlib/khatplot.py
+++ b/arviz/plots/backends/matplotlib/khatplot.py
@@ -5,7 +5,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 from ...plot_utils import set_xticklabels
 from ....stats.stats_utils import histogram
 
@@ -34,6 +34,7 @@ def plot_khat(
     n_data_points,
     bin_format,
     backend_kwargs,
+    show,
 ):
     """Matplotlib khat plot."""
     if hover_label and mpl.get_backend() not in mpl.rcsetup.interactive_bk:
@@ -50,10 +51,9 @@ def plot_khat(
         backend_kwargs = {}
 
     backend_kwargs = {
-        **backend_kwarg_defaults(),
+        **backend_kwarg_defaults(("constrained_layout", not xlabels)),
         **backend_kwargs,
     }
-    backend_kwargs["constrained_layout"] = not xlabels
 
     if ax is None:
         fig, ax = plt.subplots(figsize=figsize, **backend_kwargs)
@@ -112,6 +112,9 @@ def plot_khat(
 
     if hover_label and mpl.get_backend() in mpl.rcsetup.interactive_bk:
         _make_hover_annotation(fig, ax, sc_plot, coord_labels, rgba_c, hover_format)
+
+    if backend_show(show):
+        plt.show()
 
     return ax
 

--- a/arviz/plots/backends/matplotlib/khatplot.py
+++ b/arviz/plots/backends/matplotlib/khatplot.py
@@ -51,7 +51,7 @@ def plot_khat(
         backend_kwargs = {}
 
     backend_kwargs = {
-        **backend_kwarg_defaults(constrained_layout=(not xlabels))),
+        **backend_kwarg_defaults(constrained_layout=(not xlabels)),
         **backend_kwargs,
     }
 

--- a/arviz/plots/backends/matplotlib/loopitplot.py
+++ b/arviz/plots/backends/matplotlib/loopitplot.py
@@ -1,8 +1,8 @@
 """Matplotlib loopitplot."""
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 from ...kdeplot import _fast_kde
 from ...hpdplot import plot_hpd
 
@@ -31,6 +31,7 @@ def plot_loo_pit(
     credible_interval,
     plot_kwargs,
     backend_kwargs,
+    show,
 ):
     """Matplotlib loo pit plot."""
     if backend_kwargs is None:
@@ -67,5 +68,8 @@ def plot_loo_pit(
             label = "{:.3g}% credible interval".format(credible_interval) if ecdf else "Uniform"
             ax.plot([], label=label, **plot_unif_kwargs)
         ax.legend()
+
+    if backend_show(show):
+        plt.show()
 
     return ax

--- a/arviz/plots/backends/matplotlib/mcseplot.py
+++ b/arviz/plots/backends/matplotlib/mcseplot.py
@@ -1,8 +1,9 @@
 """Matplotlib mcseplot."""
-
+import matplotlib.pyplot as plt
 import numpy as np
 from scipy.stats import rankdata
 
+from . import backend_show
 from ....stats.stats_utils import quantile as _quantile
 from ...plot_utils import (
     make_label,
@@ -38,6 +39,7 @@ def plot_mcse(
     ax_labelsize,
     titlesize,
     backend_kwargs,
+    show,
 ):
     """Matplotlib mcseplot."""
     if ax is None:
@@ -124,5 +126,8 @@ def plot_mcse(
             ax_.set_yticklabels(["{:.3g}".format(ytick) for ytick in yticks])
         elif not errorbar:
             ax_.set_ylim(bottom=0)
+
+    if backend_show(show):
+        plt.show()
 
     return ax

--- a/arviz/plots/backends/matplotlib/pairplot.py
+++ b/arviz/plots/backends/matplotlib/pairplot.py
@@ -1,12 +1,12 @@
 """Matplotlib pairplot."""
 
 import warnings
-import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.ticker import NullFormatter
 from mpl_toolkits.axes_grid1 import make_axes_locatable
+import numpy as np
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 from ...kdeplot import plot_kde
 from ...plot_utils import _scale_fig_size
 from ....rcparams import rcParams
@@ -29,6 +29,7 @@ def plot_pair(
     divergences_kwargs,
     flat_var_names,
     backend_kwargs,
+    show,
 ):
     """Matplotlib pairplot."""
     if backend_kwargs is None:
@@ -146,5 +147,8 @@ def plot_pair(
                     )
 
                 ax[j, i].tick_params(labelsize=xt_labelsize)
+
+    if backend_show(show):
+        plt.show()
 
     return ax

--- a/arviz/plots/backends/matplotlib/parallelplot.py
+++ b/arviz/plots/backends/matplotlib/parallelplot.py
@@ -2,7 +2,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 
 
 def plot_parallel(
@@ -18,6 +18,7 @@ def plot_parallel(
     legend,
     figsize,
     backend_kwargs,
+    show,
 ):
     """Matplotlib parallel plot."""
     if backend_kwargs is None:
@@ -44,5 +45,8 @@ def plot_parallel(
         if np.any(diverging_mask):
             ax.plot([], color=colord, label="divergent")
         ax.legend(fontsize=xt_labelsize)
+
+    if backend_show(show):
+        plt.show()
 
     return ax

--- a/arviz/plots/backends/matplotlib/posteriorplot.py
+++ b/arviz/plots/backends/matplotlib/posteriorplot.py
@@ -1,9 +1,11 @@
 """Matplotlib Plot posterior densities."""
 from typing import Optional
 from numbers import Number
+import matplotlib.pyplot as plt
 import numpy as np
 from scipy.stats import mode
 
+from . import backend_show
 from ....stats import hpd
 from ...kdeplot import plot_kde, _fast_kde
 from ...plot_utils import (
@@ -35,6 +37,7 @@ def plot_posterior(
     kwargs,
     titlesize,
     backend_kwargs,
+    show,
 ):
     """Matplotlib posterior plot."""
     if ax is None:
@@ -69,6 +72,9 @@ def plot_posterior(
         )
         idx += 1
         ax_.set_title(make_label(var_name, selection), fontsize=titlesize, wrap=True)
+
+    if backend_show(show):
+        plt.show()
 
     return ax
 

--- a/arviz/plots/backends/matplotlib/ppcplot.py
+++ b/arviz/plots/backends/matplotlib/ppcplot.py
@@ -1,6 +1,9 @@
 """Matplotib Posterior predictive plot."""
-import numpy as np
 from matplotlib import animation
+import matplotlib.pyplot as plt
+import numpy as np
+
+from . import backend_show
 from ...kdeplot import plot_kde, _fast_kde
 from ...plot_utils import (
     make_label,
@@ -34,6 +37,7 @@ def plot_ppc(
     animation_kwargs,
     num_pp_samples,
     backend_kwargs,
+    show,
 ):
     """Matplotlib ppc plot."""
     if ax is None:
@@ -287,6 +291,9 @@ def plot_ppc(
                 ax_i.legend(fontsize=xt_labelsize * 0.75)
             else:
                 ax_i.legend([])
+
+    if backend_show(show):
+        plt.show()
 
     if animated:
         ani = animation.FuncAnimation(

--- a/arviz/plots/backends/matplotlib/rankplot.py
+++ b/arviz/plots/backends/matplotlib/rankplot.py
@@ -1,7 +1,9 @@
 """Matplotlib rankplot."""
 import numpy as np
+import matplotlib.pyplot as plt
 import scipy.stats
 
+from . import backend_show
 from ...plot_utils import (
     _create_axes_grid,
     make_label,
@@ -24,6 +26,7 @@ def plot_rank(
     ax_labelsize,
     titlesize,
     backend_kwargs,
+    show,
 ):
     """Matplotlib rankplot.."""
     if axes is None:
@@ -81,4 +84,8 @@ def plot_rank(
             ax.set_title(make_label(var_name, selection), fontsize=titlesize)
         else:
             ax.set_yticks([])
+
+    if backend_show(show):
+        plt.show()
+
     return axes

--- a/arviz/plots/backends/matplotlib/traceplot.py
+++ b/arviz/plots/backends/matplotlib/traceplot.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D
 import numpy as np
 
-from . import backend_kwarg_defaults
+from . import backend_kwarg_defaults, backend_show
 from ...distplot import plot_dist
 from ...plot_utils import _scale_fig_size, get_bins, make_label
 
@@ -27,6 +27,7 @@ def plot_trace(
     divergence_data,
     colors,
     backend_kwargs,
+    show,
 ):
     """Plot distribution (histogram or kernel density estimates) and sampled values.
 
@@ -112,16 +113,15 @@ def plot_trace(
 
     backend_kwargs = {**backend_kwarg_defaults(), **backend_kwargs}
 
-    backend_kwargs.setdefault("textsize", 10)
+    textsize = plot_kwargs.pop("textsize", 10)
 
     figsize, _, titlesize, xt_labelsize, linewidth, _ = _scale_fig_size(
-        figsize, backend_kwargs["textsize"], rows=len(plotters), cols=2
+        figsize, textsize, rows=len(plotters), cols=2
     )
 
     trace_kwargs.setdefault("linewidth", linewidth)
     plot_kwargs.setdefault("linewidth", linewidth)
 
-    backend_kwargs.pop("textsize")
     _, axes = plt.subplots(len(plotters), 2, squeeze=False, figsize=figsize, **backend_kwargs)
 
     for idx, (var_name, selection, value) in enumerate(plotters):
@@ -234,6 +234,10 @@ def plot_trace(
         if combined:
             handles.insert(0, Line2D([], [], color=colors[-1], label="combined"))
         axes[0, 1].legend(handles=handles, title="chain")
+
+    if backend_show(show):
+        plt.show()
+
     return axes
 
 
@@ -258,7 +262,7 @@ def _plot_chains_mpl(
         if not combined:
             plot_kwargs["color"] = colors[chain_idx]
             plot_dist(
-                row,
+                values=row,
                 textsize=xt_labelsize,
                 rug=rug,
                 ax=axes[idx, 0],
@@ -266,12 +270,15 @@ def _plot_chains_mpl(
                 plot_kwargs=plot_kwargs,
                 fill_kwargs=fill_kwargs,
                 rug_kwargs=rug_kwargs,
+                backend="matplotlib",
+                backend_kwargs={},
+                show=False,
             )
 
     if combined:
         plot_kwargs["color"] = colors[-1]
         plot_dist(
-            value.flatten(),
+            values=value.flatten(),
             textsize=xt_labelsize,
             rug=rug,
             ax=axes[idx, 0],
@@ -279,4 +286,7 @@ def _plot_chains_mpl(
             plot_kwargs=plot_kwargs,
             fill_kwargs=fill_kwargs,
             rug_kwargs=rug_kwargs,
+            backend="matplotlib",
+            backend_kwargs={},
+            show=False,
         )

--- a/arviz/plots/backends/matplotlib/violinplot.py
+++ b/arviz/plots/backends/matplotlib/violinplot.py
@@ -1,6 +1,8 @@
 """Matplotlib Violinplot."""
+import matplotlib.pyplot as plt
 import numpy as np
 
+from . import backend_show
 from ....stats import hpd
 from ....stats.stats_utils import histogram
 from ...kdeplot import _fast_kde
@@ -23,6 +25,7 @@ def plot_violin(
     xt_labelsize,
     quartiles,
     backend_kwargs,
+    show,
 ):
     """Matplotlib violin plot."""
     if ax is None:
@@ -57,6 +60,9 @@ def plot_violin(
         ax_.set_xticks([])
         ax_.tick_params(labelsize=xt_labelsize)
         ax_.grid(None, axis="x")
+
+    if backend_show(show):
+        plt.show()
 
     return ax
 

--- a/arviz/plots/compareplot.py
+++ b/arviz/plots/compareplot.py
@@ -16,6 +16,7 @@ def plot_compare(
     ax=None,
     backend=None,
     backend_kwargs=None,
+    show=None,
 ):
     """
     Summary plot for model comparison.
@@ -59,6 +60,8 @@ def plot_compare(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
+    show : bool, optional
+        Call backend show function.
 
     Returns
     -------
@@ -128,6 +131,7 @@ def plot_compare(
         xt_labelsize=xt_labelsize,
         step=step,
         backend_kwargs=backend_kwargs,
+        show=show,
     )
 
     if backend == "bokeh":

--- a/arviz/plots/densityplot.py
+++ b/arviz/plots/densityplot.py
@@ -34,6 +34,7 @@ def plot_density(
     ax=None,
     backend=None,
     backend_kwargs=None,
+    show=None,
 ):
     """Generate KDE plots for continuous variables and histograms for discrete ones.
 
@@ -64,7 +65,7 @@ def plot_density(
         Defaults to 'mean'.
     colors : Optional[Union[List[str],str]]
         List with valid matplotlib colors, one color per model. Alternative a string can be passed.
-        If the string is `cycle`, it will automatically choose a color per model from matplolib's
+        If the string is `cycle`, it will automatically choose a color per model from matplotlib's
         cycle. If a single color is passed, e.g. 'k', 'C2' or 'red' this color will be used for all
         models. Defaults to `cycle`.
     outline : bool
@@ -91,6 +92,8 @@ def plot_density(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
+    show : bool, optional
+        Call backend show function.
 
     Returns
     -------
@@ -239,6 +242,7 @@ def plot_density(
         n_data=n_data,
         data_labels=data_labels,
         backend_kwargs=backend_kwargs,
+        show=show,
     )
 
     if backend == "bokeh":

--- a/arviz/plots/distplot.py
+++ b/arviz/plots/distplot.py
@@ -27,6 +27,7 @@ def plot_dist(
     ax=None,
     backend=None,
     backend_kwargs=None,
+    show=None,
     **kwargs
 ):
     """Plot distribution as histogram or kernel density estimates.
@@ -91,6 +92,8 @@ def plot_dist(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
+    show : bool, optional
+        Call backend show function.
 
     Returns
     -------
@@ -184,6 +187,7 @@ def plot_dist(
         hist_kwargs=hist_kwargs,
         ax=ax,
         backend_kwargs=backend_kwargs,
+        show=show,
         **kwargs,
     )
 

--- a/arviz/plots/elpdplot.py
+++ b/arviz/plots/elpdplot.py
@@ -25,6 +25,7 @@ def plot_elpd(
     plot_kwargs=None,
     backend=None,
     backend_kwargs=None,
+    show=None,
 ):
     """
     Plot a scatter or hexbin matrix of the sampled parameters.
@@ -71,6 +72,8 @@ def plot_elpd(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
+    show : bool, optional
+        Call backend show function.
 
     Returns
     -------
@@ -201,6 +204,7 @@ def plot_elpd(
         handles=handles,
         color=color,
         backend_kwargs=backend_kwargs,
+        show=show,
     )
 
     if backend == "bokeh":

--- a/arviz/plots/energyplot.py
+++ b/arviz/plots/energyplot.py
@@ -22,6 +22,7 @@ def plot_energy(
     ax=None,
     backend=None,
     backend_kwargs=None,
+    show=None,
 ):
     """Plot energy transition distribution and marginal energy distribution in HMC algorithms.
 
@@ -63,6 +64,8 @@ def plot_energy(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
+    show : bool, optional
+        Call backend show function.
 
     Returns
     -------
@@ -130,6 +133,7 @@ def plot_energy(
         bw=bw,
         legend=legend,
         backend_kwargs=backend_kwargs,
+        show=show,
     )
 
     if backend == "bokeh":

--- a/arviz/plots/essplot.py
+++ b/arviz/plots/essplot.py
@@ -35,6 +35,7 @@ def plot_ess(
     rug_kwargs=None,
     backend=None,
     backend_kwargs=None,
+    show=None,
     **kwargs
 ):
     """Plot quantile, local or evolution of effective sample sizes (ESS).
@@ -86,6 +87,8 @@ def plot_ess(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
+    show : bool, optional
+        Call backend show function.
     **kwargs
         Passed as-is to plt.hist() or plt.plot() function depending on the value of `kind`.
 
@@ -316,6 +319,7 @@ def plot_ess(
         rug_kwargs=rug_kwargs,
         hline_kwargs=hline_kwargs,
         backend_kwargs=backend_kwargs,
+        show=show,
     )
 
     # TODO: Add backend kwargs

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -27,6 +27,7 @@ def plot_forest(
     ax=None,
     backend=None,
     backend_kwargs=None,
+    show=None,
 ):
     """Forest plot to compare credible intervals from a number of distributions.
 
@@ -93,6 +94,8 @@ def plot_forest(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
+    show : bool, optional
+        Call backend show function.
 
     Returns
     -------
@@ -174,6 +177,7 @@ def plot_forest(
         ess=ess,
         r_hat=r_hat,
         backend_kwargs=backend_kwargs,
+        show=show,
     )
 
     # TODO: Add backend kwargs

--- a/arviz/plots/hpdplot.py
+++ b/arviz/plots/hpdplot.py
@@ -20,6 +20,7 @@ def plot_hpd(
     ax=None,
     backend=None,
     backend_kwargs=None,
+    show=None,
 ):
     r"""
     Plot hpd intervals for regression data.
@@ -55,6 +56,8 @@ def plot_hpd(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
+    show : bool, optional
+        Call backend show function.
 
     Returns
     -------
@@ -107,6 +110,7 @@ def plot_hpd(
         plot_kwargs=plot_kwargs,
         fill_kwargs=fill_kwargs,
         backend_kwargs=backend_kwargs,
+        show=show,
     )
 
     # TODO: Add backend kwargs

--- a/arviz/plots/jointplot.py
+++ b/arviz/plots/jointplot.py
@@ -19,6 +19,7 @@ def plot_joint(
     ax=None,
     backend=None,
     backend_kwargs=None,
+    show=None,
 ):
     """
     Plot a scatter or hexbin of two variables with their respective marginals distributions.
@@ -58,6 +59,8 @@ def plot_joint(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
+    show : bool, optional
+        Call backend show function.
 
     Returns
     -------
@@ -164,6 +167,7 @@ def plot_joint(
         gridsize=gridsize,
         marginal_kwargs=marginal_kwargs,
         backend_kwargs=backend_kwargs,
+        show=show,
     )
 
     if backend == "bokeh":

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -34,6 +34,7 @@ def plot_kde(
     legend=True,
     backend=None,
     backend_kwargs=None,
+    show=None,
     **kwargs
 ):
     """1D or 2D KDE plot taking into account boundary conditions.
@@ -91,6 +92,8 @@ def plot_kde(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
+    show : bool, optional
+        Call backend show function.
 
     Returns
     -------
@@ -211,6 +214,7 @@ def plot_kde(
         ax=ax,
         legend=legend,
         backend_kwargs=backend_kwargs,
+        show=show,
         **kwargs,
     )
 

--- a/arviz/plots/khatplot.py
+++ b/arviz/plots/khatplot.py
@@ -33,6 +33,7 @@ def plot_khat(
     hlines_kwargs=None,
     backend=None,
     backend_kwargs=None,
+    show=None,
     **kwargs
 ):
     """
@@ -81,6 +82,8 @@ def plot_khat(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
+    show : bool, optional
+        Call backend show function.
     kwargs :
         Additional keywords passed to ax.scatter.
 
@@ -219,6 +222,7 @@ def plot_khat(
         n_data_points=n_data_points,
         bin_format=bin_format,
         backend_kwargs=backend_kwargs,
+        show=show,
     )
 
     if backend == "bokeh":

--- a/arviz/plots/loopitplot.py
+++ b/arviz/plots/loopitplot.py
@@ -30,6 +30,7 @@ def plot_loo_pit(
     fill_kwargs=None,
     backend=None,
     backend_kwargs=None,
+    show=None,
 ):
     """Plot Leave-One-Out (LOO) probability integral transformation (PIT) predictive checks.
 
@@ -88,6 +89,8 @@ def plot_loo_pit(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
+    show : bool, optional
+        Call backend show function.
 
     Returns
     -------
@@ -233,6 +236,7 @@ def plot_loo_pit(
         credible_interval=credible_interval,
         plot_kwargs=plot_kwargs,
         backend_kwargs=backend_kwargs,
+        show=show,
     )
 
     if backend == "bokeh":

--- a/arviz/plots/mcseplot.py
+++ b/arviz/plots/mcseplot.py
@@ -32,6 +32,7 @@ def plot_mcse(
     text_kwargs=None,
     backend=None,
     backend_kwargs=None,
+    show=None,
     **kwargs
 ):
     """Plot quantile or local Monte Carlo Standard Error.
@@ -76,6 +77,8 @@ def plot_mcse(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
+    show : bool, optional
+        Call backend show function.
     **kwargs
         Passed as-is to plt.hist() or plt.plot() function depending on the value of `kind`.
 
@@ -181,6 +184,7 @@ def plot_mcse(
         ax_labelsize=ax_labelsize,
         titlesize=titlesize,
         backend_kwargs=backend_kwargs,
+        show=show,
     )
 
     if backend == "bokeh":

--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -24,6 +24,7 @@ def plot_pair(
     plot_kwargs=None,
     backend=None,
     backend_kwargs=None,
+    show=None,
 ):
     """
     Plot a scatter or hexbin matrix of the sampled parameters.
@@ -69,6 +70,8 @@ def plot_pair(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
+    show : bool, optional
+        Call backend show function.
 
     Returns
     -------
@@ -190,6 +193,7 @@ def plot_pair(
         divergences_kwargs=divergences_kwargs,
         flat_var_names=flat_var_names,
         backend_kwargs=backend_kwargs,
+        show=show,
     )
 
     if backend == "bokeh":

--- a/arviz/plots/parallelplot.py
+++ b/arviz/plots/parallelplot.py
@@ -22,6 +22,7 @@ def plot_parallel(
     norm_method=None,
     backend=None,
     backend_kwargs=None,
+    show=None,
 ):
     """
     Plot parallel coordinates plot showing posterior points with and without divergences.
@@ -62,6 +63,8 @@ def plot_parallel(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
+    show : bool, optional
+        Call backend show function.
 
     Returns
     -------
@@ -137,6 +140,7 @@ def plot_parallel(
         legend=legend,
         figsize=figsize,
         backend_kwargs=backend_kwargs,
+        show=show,
     )
 
     if backend == "bokeh":

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -212,11 +212,8 @@ def _create_axes_grid(length_plotters, rows, cols, backend=None, backend_kwargs=
     fig : matplotlib figure
     ax : matplotlib axes
     """
-    if kwargs is None:
-        kwargs = {}
     if backend_kwargs is None:
         backend_kwargs = {}
-    kwargs.setdefault("constrained_layout", True)
 
     if backend == "bokeh":
         from bokeh.plotting import figure
@@ -229,7 +226,6 @@ def _create_axes_grid(length_plotters, rows, cols, backend=None, backend_kwargs=
                 ("width", "plot.bokeh.figure.width"),
                 ("height", "plot.bokeh.figure.height"),
                 ("dpi", "plot.bokeh.figure.dpi"),
-                add_default=False,
             ),
             **backend_kwargs,
         }

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -32,6 +32,7 @@ def plot_posterior(
     ax=None,
     backend=None,
     backend_kwargs=None,
+    show=None,
     **kwargs
 ):
     """Plot Posterior densities in the style of John K. Kruschke's book.
@@ -86,6 +87,8 @@ def plot_posterior(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
+    show : bool, optional
+        Call backend show function.
     **kwargs
         Passed as-is to plt.hist() or plt.plot() function depending on the value of `kind`.
 
@@ -210,6 +213,7 @@ def plot_posterior(
         kwargs=kwargs,
         titlesize=titlesize,
         backend_kwargs=backend_kwargs,
+        show=show,
     )
 
     if backend == "bokeh":

--- a/arviz/plots/ppcplot.py
+++ b/arviz/plots/ppcplot.py
@@ -37,6 +37,7 @@ def plot_ppc(
     ax=None,
     backend=None,
     backend_kwargs=None,
+    show=None,
 ):
     """
     Plot for posterior predictive checks.
@@ -107,6 +108,8 @@ def plot_ppc(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
+    show : bool, optional
+        Call backend show function.
 
     Returns
     -------
@@ -290,6 +293,7 @@ def plot_ppc(
         animation_kwargs=animation_kwargs,
         num_pp_samples=num_pp_samples,
         backend_kwargs=backend_kwargs,
+        show=show,
     )
 
     if backend == "bokeh":

--- a/arviz/plots/rankplot.py
+++ b/arviz/plots/rankplot.py
@@ -27,6 +27,7 @@ def plot_rank(
     axes=None,
     backend=None,
     backend_kwargs=None,
+    show=None,
 ):
     """Plot rank order statistics of chains.
 
@@ -59,7 +60,7 @@ def plot_rank(
         ranks are represented as vertical lines above or below `ref_line`.
     colors : string or list of strings
         List with valid matplotlib colors, one color per model. Alternative a string can be passed.
-        If the string is `cycle`, it will automatically choose a color per model from matplolib's
+        If the string is `cycle`, it will automatically choose a color per model from matplotlib's
         cycle. If a single color is passed, e.g. 'k', 'C2' or 'red' this color will be used for all
         models. Defaults to `cycle`.
     ref_line : boolean
@@ -75,6 +76,8 @@ def plot_rank(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
+    show : bool, optional
+        Call backend show function.
 
     Returns
     -------
@@ -159,6 +162,7 @@ def plot_rank(
         ax_labelsize=ax_labelsize,
         titlesize=titlesize,
         backend_kwargs=backend_kwargs,
+        show=show,
     )
 
     if backend == "bokeh":

--- a/arviz/plots/traceplot.py
+++ b/arviz/plots/traceplot.py
@@ -28,6 +28,7 @@ def plot_trace(
     trace_kwargs=None,
     backend=None,
     backend_kwargs=None,
+    show=None,
 ):
     """Plot distribution (histogram or kernel density estimates) and sampled values.
 
@@ -75,6 +76,8 @@ def plot_trace(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
+    show : bool, optional
+        Call backend show function.
 
     Returns
     -------
@@ -208,6 +211,7 @@ def plot_trace(
         plotters=plotters,
         colors=colors,
         backend_kwargs=backend_kwargs,
+        show=show,
     )
 
     plot = get_plotting_function("plot_trace", "traceplot", backend)

--- a/arviz/plots/violinplot.py
+++ b/arviz/plots/violinplot.py
@@ -24,6 +24,7 @@ def plot_violin(
     kwargs_shade=None,
     backend=None,
     backend_kwargs=None,
+    show=None,
 ):
     """Plot posterior of traces as violin plot.
 
@@ -66,6 +67,8 @@ def plot_violin(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
+    show : bool, optional
+        Call backend show function.
 
     Returns
     -------
@@ -104,6 +107,7 @@ def plot_violin(
         xt_labelsize=xt_labelsize,
         quartiles=quartiles,
         backend_kwargs=backend_kwargs,
+        show=show,
     )
 
     if backend == "bokeh":

--- a/arviz/rcparams.py
+++ b/arviz/rcparams.py
@@ -108,7 +108,7 @@ defaultParams = {  # pylint: disable=invalid-name
     "plot.bokeh.figure.height": (500, _validate_positive_int),
     "plot.bokeh.show": (True, _validate_boolean),
     "plot.matplotlib.constrained_layout": (True, _validate_boolean),
-    "plot.matplotlib.show": (True, _validate_boolean),
+    "plot.matplotlib.show": (False, _validate_boolean),
     "plot.max_subplots": (40, _validate_positive_int_or_none),
     "plot.point_estimate": (
         "mean",

--- a/arviz/rcparams.py
+++ b/arviz/rcparams.py
@@ -108,6 +108,7 @@ defaultParams = {  # pylint: disable=invalid-name
     "plot.bokeh.figure.height": (500, _validate_positive_int),
     "plot.bokeh.show": (True, _validate_boolean),
     "plot.matplotlib.constrained_layout": (True, _validate_boolean),
+    "plot.matplotlib.show": (True, _validate_boolean),
     "plot.max_subplots": (40, _validate_positive_int_or_none),
     "plot.point_estimate": (
         "mean",

--- a/arviz/tests/test_plots_bokeh.py
+++ b/arviz/tests/test_plots_bokeh.py
@@ -868,8 +868,9 @@ def test_plot_ppc_bad(models, kind):
 @pytest.mark.parametrize("kind", ["kde", "cumulative", "scatter"])
 def test_plot_ppc_ax(models, kind):
     """Test ax argument of plot_ppc."""
-    axes = plot_ppc(models.model_1, kind=kind, ax=bkp.figure(), backend="bokeh", show=False)
-    assert axes[0] is ax
+    ax = bkp.figure()
+    axes = plot_ppc(models.model_1, kind=kind, ax=ax, backend="bokeh", show=False)
+    assert axes[0,0] is ax
 
 
 @pytest.mark.parametrize(

--- a/arviz/tests/test_plots_bokeh.py
+++ b/arviz/tests/test_plots_bokeh.py
@@ -41,7 +41,7 @@ from ..plots import (
 from ..stats import compare, loo, waic
 
 rcParams["data.load"] = "eager"
-
+rcParams["plot.bokeh.show"] = False
 
 @pytest.fixture(scope="module")
 def data(eight_schools_params):
@@ -74,11 +74,6 @@ def get_ax():
     return ax
 
 
-@pytest.fixture(scope="session")
-def backend_kwargs():
-    return {"show": False}
-
-
 @pytest.mark.parametrize(
     "kwargs",
     [
@@ -91,25 +86,25 @@ def backend_kwargs():
         {"shade": 1},
     ],
 )
-def test_plot_density_float(models, kwargs, backend_kwargs):
+def test_plot_density_float(models, kwargs):
     obj = [getattr(models, model_fit) for model_fit in ["model_1", "model_2"]]
-    axes = plot_density(obj, backend="bokeh", backend_kwargs=backend_kwargs.copy(), **kwargs)
+    axes = plot_density(obj, backend="bokeh", **kwargs)
     assert axes.shape[0] >= 6
     assert axes.shape[0] >= 3
 
 
-def test_plot_density_discrete(discrete_model, backend_kwargs):
+def test_plot_density_discrete(discrete_model):
     axes = plot_density(
-        discrete_model, shade=0.9, backend="bokeh", backend_kwargs=backend_kwargs.copy()
+        discrete_model, shade=0.9, backend="bokeh"
     )
     assert axes.shape[0] == 1
 
 
-def test_plot_density_bad_kwargs(models, backend_kwargs):
+def test_plot_density_bad_kwargs(models):
     obj = [getattr(models, model_fit) for model_fit in ["model_1", "model_2"]]
     with pytest.raises(ValueError):
         plot_density(
-            obj, point_estimate="bad_value", backend="bokeh", backend_kwargs=backend_kwargs.copy()
+            obj, point_estimate="bad_value", backend="bokeh"
         )
 
     with pytest.raises(ValueError):
@@ -117,12 +112,12 @@ def test_plot_density_bad_kwargs(models, backend_kwargs):
             obj,
             data_labels=["bad_value_{}".format(i) for i in range(len(obj) + 10)],
             backend="bokeh",
-            backend_kwargs=backend_kwargs.copy(),
+
         )
 
     with pytest.raises(ValueError):
         plot_density(
-            obj, credible_interval=2, backend="bokeh", backend_kwargs=backend_kwargs.copy()
+            obj, credible_interval=2, backend="bokeh"
         )
 
 
@@ -141,22 +136,22 @@ def test_plot_density_bad_kwargs(models, backend_kwargs):
         {"lines": [("mu", {}, 8)]},
     ],
 )
-def test_plot_trace(models, kwargs, backend_kwargs):
+def test_plot_trace(models, kwargs):
     axes = plot_trace(
-        models.model_1, backend="bokeh", backend_kwargs=backend_kwargs.copy(), **kwargs
+        models.model_1, backend="bokeh", **kwargs
     )
     assert axes.shape
 
 
-def test_plot_trace_discrete(discrete_model, backend_kwargs):
-    axes = plot_trace(discrete_model, backend="bokeh", backend_kwargs=backend_kwargs.copy())
+def test_plot_trace_discrete(discrete_model):
+    axes = plot_trace(discrete_model, backend="bokeh")
     assert axes.shape
 
 
-def test_plot_trace_max_subplots_warning(models, backend_kwargs):
+def test_plot_trace_max_subplots_warning(models):
     with pytest.warns(SyntaxWarning):
         with rc_context(rc={"plot.max_subplots": 1}):
-            axes = plot_trace(models.model_1, backend="bokeh", backend_kwargs=backend_kwargs.copy())
+            axes = plot_trace(models.model_1, backend="bokeh")
     assert axes.shape
 
 
@@ -174,12 +169,12 @@ def test_plot_trace_max_subplots_warning(models, backend_kwargs):
         {"contour": False, "pcolormesh_kwargs": {"cmap": "plasma"}},
     ],
 )
-def test_plot_kde(continuous_model, kwargs, backend_kwargs):
+def test_plot_kde(continuous_model, kwargs):
     axes = plot_kde(
         continuous_model["x"],
         continuous_model["y"],
         backend="bokeh",
-        backend_kwargs=backend_kwargs.copy(),
+
         **kwargs
     )
     assert axes
@@ -194,23 +189,23 @@ def test_plot_kde(continuous_model, kwargs, backend_kwargs):
         {"rug": True, "rug_kwargs": {"line_alpha": 0.2}, "rotated": True},
     ],
 )
-def test_plot_kde_cumulative(continuous_model, kwargs, backend_kwargs):
+def test_plot_kde_cumulative(continuous_model, kwargs):
     axes = plot_kde(
-        continuous_model["x"], backend="bokeh", backend_kwargs=backend_kwargs.copy(), **kwargs
+        continuous_model["x"], backend="bokeh", **kwargs
     )
     assert axes
 
 
 @pytest.mark.parametrize("kwargs", [{"kind": "hist"}, {"kind": "kde"}])
-def test_plot_dist(continuous_model, kwargs, backend_kwargs):
+def test_plot_dist(continuous_model, kwargs):
     axes = plot_dist(
-        continuous_model["x"], backend="bokeh", backend_kwargs=backend_kwargs.copy(), **kwargs
+        continuous_model["x"], backend="bokeh", **kwargs
     )
     assert axes
 
 
-def test_plot_kde_1d(continuous_model, backend_kwargs):
-    axes = plot_kde(continuous_model["y"], backend="bokeh", backend_kwargs=backend_kwargs.copy())
+def test_plot_kde_1d(continuous_model):
+    axes = plot_kde(continuous_model["y"], backend="bokeh")
     assert axes
 
 
@@ -223,11 +218,11 @@ def test_plot_kde_1d(continuous_model, backend_kwargs):
         {"contour": False, "pcolormesh_kwargs": {"cmap": "plasma"}},
     ],
 )
-def test_plot_kde_2d(continuous_model, kwargs, backend_kwargs):
+def test_plot_kde_2d(continuous_model, kwargs):
     axes = plot_kde(
         continuous_model["x"],
         continuous_model["y"],
-        backend_kwargs=backend_kwargs.copy(),
+
         backend="bokeh",
         **kwargs
     )
@@ -237,27 +232,27 @@ def test_plot_kde_2d(continuous_model, kwargs, backend_kwargs):
 @pytest.mark.parametrize(
     "kwargs", [{"plot_kwargs": {"line_dash": "solid"}}, {"cumulative": True}, {"rug": True}]
 )
-def test_plot_kde_quantiles(continuous_model, kwargs, backend_kwargs):
+def test_plot_kde_quantiles(continuous_model, kwargs):
     axes = plot_kde(
         continuous_model["x"],
         quantiles=[0.05, 0.5, 0.95],
-        backend_kwargs=backend_kwargs.copy(),
+
         backend="bokeh",
         **kwargs
     )
     assert axes
 
 
-def test_plot_autocorr_short_chain(backend_kwargs):
+def test_plot_autocorr_short_chain():
     """Check that logic for small chain defaulting doesn't cause exception"""
     chain = np.arange(10)
-    axes = plot_autocorr(chain, backend="bokeh", backend_kwargs=backend_kwargs.copy())
+    axes = plot_autocorr(chain, backend="bokeh")
     assert axes
 
 
-def test_plot_autocorr_uncombined(models, backend_kwargs):
+def test_plot_autocorr_uncombined(models):
     axes = plot_autocorr(
-        models.model_1, combined=False, backend="bokeh", backend_kwargs=backend_kwargs.copy()
+        models.model_1, combined=False, backend="bokeh"
     )
     assert axes.shape[0] == 10
     max_subplots = (
@@ -266,22 +261,22 @@ def test_plot_autocorr_uncombined(models, backend_kwargs):
     assert len([ax for ax in axes.ravel() if ax is not None]) == min(72, max_subplots)
 
 
-def test_plot_autocorr_combined(models, backend_kwargs):
+def test_plot_autocorr_combined(models):
     axes = plot_autocorr(
-        models.model_1, combined=True, backend="bokeh", backend_kwargs=backend_kwargs.copy()
+        models.model_1, combined=True, backend="bokeh"
     )
     assert axes.shape[0] == 6
     assert axes.shape[1] == 3
 
 
 @pytest.mark.parametrize("var_names", (None, "mu", ["mu", "tau"]))
-def test_plot_autocorr_var_names(models, var_names, backend_kwargs):
+def test_plot_autocorr_var_names(models, var_names):
     axes = plot_autocorr(
         models.model_1,
         var_names=var_names,
         combined=True,
         backend="bokeh",
-        backend_kwargs=backend_kwargs.copy(),
+
     )
     assert axes.shape
 
@@ -289,34 +284,34 @@ def test_plot_autocorr_var_names(models, var_names, backend_kwargs):
 @pytest.mark.parametrize(
     "kwargs", [{"insample_dev": False}, {"plot_standard_error": False}, {"plot_ic_diff": False}]
 )
-def test_plot_compare(models, kwargs, backend_kwargs):
+def test_plot_compare(models, kwargs):
 
     model_compare = compare({"Model 1": models.model_1, "Model 2": models.model_2})
 
     axes = plot_compare(
-        model_compare, backend="bokeh", backend_kwargs=backend_kwargs.copy(), **kwargs
+        model_compare, backend="bokeh", **kwargs
     )
     assert axes
 
 
-def test_plot_compare_manual(models, backend_kwargs):
+def test_plot_compare_manual(models):
     """Test compare plot without scale column"""
     model_compare = compare({"Model 1": models.model_1, "Model 2": models.model_2})
 
     # remove "scale" column
     del model_compare["waic_scale"]
-    axes = plot_compare(model_compare, backend="bokeh", backend_kwargs=backend_kwargs.copy())
+    axes = plot_compare(model_compare, backend="bokeh")
     assert axes
 
 
-def test_plot_compare_no_ic(models, backend_kwargs):
+def test_plot_compare_no_ic(models):
     """Check exception is raised if model_compare doesn't contain a valid information criterion"""
     model_compare = compare({"Model 1": models.model_1, "Model 2": models.model_2})
 
     # Drop column needed for plotting
     model_compare = model_compare.drop("waic", axis=1)
     with pytest.raises(ValueError) as err:
-        plot_compare(model_compare, backend="bokeh", backend_kwargs=backend_kwargs.copy())
+        plot_compare(model_compare, backend="bokeh")
 
     assert "comp_df must contain one of the following" in str(err.value)
     assert "['waic', 'loo']" in str(err.value)
@@ -327,7 +322,7 @@ def test_plot_compare_no_ic(models, backend_kwargs):
 )
 @pytest.mark.parametrize("add_model", [False, True])
 @pytest.mark.parametrize("use_elpddata", [False, True])
-def test_plot_elpd(models, add_model, use_elpddata, kwargs, backend_kwargs):
+def test_plot_elpd(models, add_model, use_elpddata, kwargs):
     model_dict = {"Model 1": models.model_1, "Model 2": models.model_2}
     if add_model:
         model_dict["Model 3"] = create_model(seed=12)
@@ -340,7 +335,7 @@ def test_plot_elpd(models, add_model, use_elpddata, kwargs, backend_kwargs):
         else:
             model_dict = {k: loo(v, scale=scale, pointwise=True) for k, v in model_dict.items()}
 
-    axes = plot_elpd(model_dict, backend="bokeh", backend_kwargs=backend_kwargs.copy(), **kwargs)
+    axes = plot_elpd(model_dict, backend="bokeh", **kwargs)
     assert np.any(axes)
     if add_model:
         assert axes.shape[0] == axes.shape[1]
@@ -352,7 +347,7 @@ def test_plot_elpd(models, add_model, use_elpddata, kwargs, backend_kwargs):
 )
 @pytest.mark.parametrize("add_model", [False, True])
 @pytest.mark.parametrize("use_elpddata", [False, True])
-def test_plot_elpd_multidim(multidim_models, add_model, use_elpddata, kwargs, backend_kwargs):
+def test_plot_elpd_multidim(multidim_models, add_model, use_elpddata, kwargs):
     model_dict = {"Model 1": multidim_models.model_1, "Model 2": multidim_models.model_2}
     if add_model:
         model_dict["Model 3"] = create_multidimensional_model(seed=12)
@@ -365,7 +360,7 @@ def test_plot_elpd_multidim(multidim_models, add_model, use_elpddata, kwargs, ba
         else:
             model_dict = {k: loo(v, scale=scale, pointwise=True) for k, v in model_dict.items()}
 
-    axes = plot_elpd(model_dict, backend="bokeh", backend_kwargs=backend_kwargs.copy(), **kwargs)
+    axes = plot_elpd(model_dict, backend="bokeh", **kwargs)
     assert np.any(axes)
     if add_model:
         assert axes.shape[0] == axes.shape[1]
@@ -373,16 +368,16 @@ def test_plot_elpd_multidim(multidim_models, add_model, use_elpddata, kwargs, ba
 
 
 @pytest.mark.parametrize("kind", ["kde", "hist"])
-def test_plot_energy(models, kind, backend_kwargs):
+def test_plot_energy(models, kind):
     assert plot_energy(
-        models.model_1, kind=kind, backend="bokeh", backend_kwargs=backend_kwargs.copy()
+        models.model_1, kind=kind, backend="bokeh"
     )
 
 
-def test_plot_energy_bad(models, backend_kwargs):
+def test_plot_energy_bad(models):
     with pytest.raises(ValueError):
         plot_energy(
-            models.model_1, kind="bad_kind", backend="bokeh", backend_kwargs=backend_kwargs.copy()
+            models.model_1, kind="bad_kind", backend="bokeh"
         )
 
 
@@ -396,10 +391,10 @@ def test_plot_energy_bad(models, backend_kwargs):
     ],
 )
 @pytest.mark.parametrize("kind", ["local", "quantile", "evolution"])
-def test_plot_ess(models, kind, kwargs, backend_kwargs):
+def test_plot_ess(models, kind, kwargs):
     """Test plot_ess arguments common to all kind of plots."""
     idata = models.model_1
-    ax = plot_ess(idata, kind=kind, backend="bokeh", backend_kwargs=backend_kwargs.copy(), **kwargs)
+    ax = plot_ess(idata, kind=kind, backend="bokeh", **kwargs)
     assert np.all(ax)
 
 
@@ -414,14 +409,14 @@ def test_plot_ess(models, kind, kwargs, backend_kwargs):
     ],
 )
 @pytest.mark.parametrize("kind", ["local", "quantile"])
-def test_plot_ess_local_quantile(models, kind, kwargs, backend_kwargs):
+def test_plot_ess_local_quantile(models, kind, kwargs):
     """Test specific arguments in kinds local and quantile of plot_ess."""
     idata = models.model_1
-    ax = plot_ess(idata, kind=kind, backend="bokeh", backend_kwargs=backend_kwargs.copy(), **kwargs)
+    ax = plot_ess(idata, kind=kind, backend="bokeh", **kwargs)
     assert np.all(ax)
 
 
-def test_plot_ess_evolution(models, backend_kwargs):
+def test_plot_ess_evolution(models):
     """Test specific arguments in evolution kind of plot_ess."""
     idata = models.model_1
     ax = plot_ess(
@@ -430,41 +425,41 @@ def test_plot_ess_evolution(models, backend_kwargs):
         extra_kwargs={"linestyle": "--"},
         color="b",
         backend="bokeh",
-        backend_kwargs=backend_kwargs.copy(),
+
     )
     assert np.all(ax)
 
 
-def test_plot_ess_bad_kind(models, backend_kwargs):
+def test_plot_ess_bad_kind(models):
     """Test error when plot_ess recieves an invalid kind."""
     idata = models.model_1
     with pytest.raises(ValueError, match="Invalid kind"):
-        plot_ess(idata, kind="bad kind", backend="bokeh", backend_kwargs=backend_kwargs.copy())
+        plot_ess(idata, kind="bad kind", backend="bokeh")
 
 
 @pytest.mark.parametrize("dim", ["chain", "draw"])
-def test_plot_ess_bad_coords(models, dim, backend_kwargs):
+def test_plot_ess_bad_coords(models, dim):
     """Test error when chain or dim are used as coords to select a data subset."""
     idata = models.model_1
     with pytest.raises(ValueError, match="invalid coordinates"):
         plot_ess(
-            idata, coords={dim: slice(3)}, backend="bokeh", backend_kwargs=backend_kwargs.copy()
+            idata, coords={dim: slice(3)}, backend="bokeh"
         )
 
 
-def test_plot_ess_no_sample_stats(models, backend_kwargs):
+def test_plot_ess_no_sample_stats(models):
     """Test error when rug=True but sample_stats group is not present."""
     idata = models.model_1
     with pytest.raises(ValueError, match="must contain sample_stats"):
-        plot_ess(idata.posterior, rug=True, backend="bokeh", backend_kwargs=backend_kwargs.copy())
+        plot_ess(idata.posterior, rug=True, backend="bokeh")
 
 
-def test_plot_ess_no_divergences(models, backend_kwargs):
+def test_plot_ess_no_divergences(models):
     """Test error when rug=True, but the variable defined by rug_kind is missing."""
     idata = deepcopy(models.model_1)
     idata.sample_stats = idata.sample_stats.rename({"diverging": "diverging_missing"})
     with pytest.raises(ValueError, match="not contain diverging"):
-        plot_ess(idata, rug=True, backend="bokeh", backend_kwargs=backend_kwargs.copy())
+        plot_ess(idata, rug=True, backend="bokeh")
 
 
 @pytest.mark.parametrize("model_fits", [["model_1"], ["model_1", "model_2"]])
@@ -487,41 +482,41 @@ def test_plot_ess_no_divergences(models, backend_kwargs):
         ),
     ],
 )
-def test_plot_forest(models, model_fits, args_expected, backend_kwargs):
+def test_plot_forest(models, model_fits, args_expected):
     obj = [getattr(models, model_fit) for model_fit in model_fits]
     args, expected = args_expected
-    axes = plot_forest(obj, backend="bokeh", backend_kwargs=backend_kwargs.copy(), **args)
+    axes = plot_forest(obj, backend="bokeh", **args)
     assert axes.shape == (expected,)
 
 
-def test_plot_forest_rope_exception(backend_kwargs):
+def test_plot_forest_rope_exception():
     with pytest.raises(ValueError) as err:
         plot_forest(
             {"x": [1]},
             rope="not_correct_format",
             backend="bokeh",
-            backend_kwargs=backend_kwargs.copy(),
+
         )
     assert "Argument `rope` must be None, a dictionary like" in str(err.value)
 
 
-def test_plot_forest_single_value(backend_kwargs):
-    axes = plot_forest({"x": [1]}, backend="bokeh", backend_kwargs=backend_kwargs.copy())
+def test_plot_forest_single_value():
+    axes = plot_forest({"x": [1]}, backend="bokeh")
     assert axes.shape
 
 
 @pytest.mark.parametrize("model_fits", [["model_1"], ["model_1", "model_2"]])
-def test_plot_forest_bad(models, model_fits, backend_kwargs):
+def test_plot_forest_bad(models, model_fits):
     obj = [getattr(models, model_fit) for model_fit in model_fits]
     with pytest.raises(TypeError):
-        plot_forest(obj, kind="bad_kind", backend="bokeh", backend_kwargs=backend_kwargs.copy())
+        plot_forest(obj, kind="bad_kind", backend="bokeh")
 
     with pytest.raises(ValueError):
         plot_forest(
             obj,
             model_names=["model_name_{}".format(i) for i in range(len(obj) + 10)],
             backend="bokeh",
-            backend_kwargs=backend_kwargs.copy(),
+
         )
 
 
@@ -535,59 +530,59 @@ def test_plot_forest_bad(models, model_fits, backend_kwargs):
         {"smooth": False},
     ],
 )
-def test_plot_hpd(models, data, kwargs, backend_kwargs):
+def test_plot_hpd(models, data, kwargs):
     axis = plot_hpd(
         data["y"],
         models.model_1.posterior["theta"],
         backend="bokeh",
-        backend_kwargs=backend_kwargs.copy(),
+
         **kwargs
     )
     assert axis
 
 
 @pytest.mark.parametrize("kind", ["scatter", "hexbin", "kde"])
-def test_plot_joint(models, kind, backend_kwargs):
+def test_plot_joint(models, kind):
     axes = plot_joint(
         models.model_1,
         var_names=("mu", "tau"),
         kind=kind,
         backend="bokeh",
-        backend_kwargs=backend_kwargs.copy(),
+
     )
     assert axes[1, 0]
 
 
-def test_plot_joint_ax_tuple(models, backend_kwargs):
+def test_plot_joint_ax_tuple(models):
     ax = plot_joint(
         models.model_1,
         var_names=("mu", "tau"),
         backend="bokeh",
-        backend_kwargs=backend_kwargs.copy(),
+
     )
     axes = plot_joint(
         models.model_2,
         var_names=("mu", "tau"),
         ax=ax,
         backend="bokeh",
-        backend_kwargs=backend_kwargs.copy(),
+
     )
     assert axes[1, 0]
 
 
-def test_plot_joint_discrete(discrete_model, backend_kwargs):
-    axes = plot_joint(discrete_model, backend="bokeh", backend_kwargs=backend_kwargs.copy())
+def test_plot_joint_discrete(discrete_model):
+    axes = plot_joint(discrete_model, backend="bokeh")
     assert axes[1, 0]
 
 
-def test_plot_joint_bad(models, backend_kwargs):
+def test_plot_joint_bad(models):
     with pytest.raises(ValueError):
         plot_joint(
             models.model_1,
             var_names=("mu", "tau"),
             kind="bad_kind",
             backend="bokeh",
-            backend_kwargs=backend_kwargs.copy(),
+
         )
 
     with pytest.raises(Exception):
@@ -595,7 +590,7 @@ def test_plot_joint_bad(models, backend_kwargs):
             models.model_1,
             var_names=("mu", "tau", "eta"),
             backend="bokeh",
-            backend_kwargs=backend_kwargs.copy(),
+
         )
 
     with pytest.raises(ValueError):
@@ -605,7 +600,7 @@ def test_plot_joint_bad(models, backend_kwargs):
             var_names=("mu", "tau"),
             ax=axes,
             backend="bokeh",
-            backend_kwargs=backend_kwargs.copy(),
+
         )
 
 
@@ -622,7 +617,7 @@ def test_plot_joint_bad(models, backend_kwargs):
     ],
 )
 @pytest.mark.parametrize("input_type", ["elpd_data", "data_array", "array"])
-def test_plot_khat(models, input_type, kwargs, backend_kwargs):
+def test_plot_khat(models, input_type, kwargs):
     khats_data = loo(models.model_1, pointwise=True)
 
     if input_type == "data_array":
@@ -632,7 +627,7 @@ def test_plot_khat(models, input_type, kwargs, backend_kwargs):
         if "color" in kwargs and isinstance(kwargs["color"], str) and kwargs["color"] == "obs_dim":
             kwargs["color"] = None
 
-    axes = plot_khat(khats_data, backend="bokeh", backend_kwargs=backend_kwargs.copy(), **kwargs)
+    axes = plot_khat(khats_data, backend="bokeh", **kwargs)
     assert axes
 
 
@@ -649,7 +644,7 @@ def test_plot_khat(models, input_type, kwargs, backend_kwargs):
     ],
 )
 @pytest.mark.parametrize("input_type", ["elpd_data", "data_array", "array"])
-def test_plot_khat_multidim(multidim_models, input_type, kwargs, backend_kwargs):
+def test_plot_khat_multidim(multidim_models, input_type, kwargs):
     khats_data = loo(multidim_models.model_1, pointwise=True)
 
     if input_type == "data_array":
@@ -663,20 +658,20 @@ def test_plot_khat_multidim(multidim_models, input_type, kwargs, backend_kwargs)
         ):
             kwargs["color"] = None
 
-    axes = plot_khat(khats_data, backend="bokeh", backend_kwargs=backend_kwargs.copy(), **kwargs)
+    axes = plot_khat(khats_data, backend="bokeh", **kwargs)
     assert axes
 
 
-def test_plot_khat_annotate(backend_kwargs):
+def test_plot_khat_annotate():
     khats = np.array([0, 0, 0.6, 0.6, 0.8, 0.9, 0.9, 2, 3, 4, 1.5])
-    axes = plot_khat(khats, annotate=True, backend="bokeh", backend_kwargs=backend_kwargs.copy())
+    axes = plot_khat(khats, annotate=True, backend="bokeh")
     assert axes
 
 
-def test_plot_khat_bad_input(models, backend_kwargs):
+def test_plot_khat_bad_input(models):
     with pytest.raises(ValueError):
         plot_khat(
-            models.model_1.sample_stats, backend="bokeh", backend_kwargs=backend_kwargs.copy()
+            models.model_1.sample_stats, backend="bokeh"
         )
 
 
@@ -693,14 +688,14 @@ def test_plot_khat_bad_input(models, backend_kwargs):
         {"ecdf": True, "credible_interval": 0.97, "fill_kwargs": {"color": "red"}},
     ],
 )
-def test_plot_loo_pit(models, kwargs, backend_kwargs):
+def test_plot_loo_pit(models, kwargs):
     axes = plot_loo_pit(
-        idata=models.model_1, y="y", backend="bokeh", backend_kwargs=backend_kwargs.copy(), **kwargs
+        idata=models.model_1, y="y", backend="bokeh", **kwargs
     )
     assert axes
 
 
-def test_plot_loo_pit_incompatible_args(models, backend_kwargs):
+def test_plot_loo_pit_incompatible_args(models):
     """Test error when both ecdf and use_hpd are True."""
     with pytest.raises(ValueError, match="incompatible"):
         plot_loo_pit(
@@ -709,7 +704,7 @@ def test_plot_loo_pit_incompatible_args(models, backend_kwargs):
             ecdf=True,
             use_hpd=True,
             backend="bokeh",
-            backend_kwargs=backend_kwargs.copy(),
+
         )
 
 
@@ -723,7 +718,7 @@ def test_plot_loo_pit_incompatible_args(models, backend_kwargs):
         {"y": "ndarray", "y_hat": "ndarray"},
     ],
 )
-def test_plot_loo_pit_label(models, args, backend_kwargs):
+def test_plot_loo_pit_label(models, args):
     if args["y"] == "str":
         y = "y"
     elif args["y"] == "DataArray":
@@ -745,7 +740,7 @@ def test_plot_loo_pit_label(models, args, backend_kwargs):
         y=y,
         y_hat=y_hat,
         backend="bokeh",
-        backend_kwargs=backend_kwargs.copy(),
+
     )
     assert ax
 
@@ -762,35 +757,35 @@ def test_plot_loo_pit_label(models, args, backend_kwargs):
         {"extra_methods": True, "extra_kwargs": {"ls": ":"}, "text_kwargs": {"x": 0, "ha": "left"}},
     ],
 )
-def test_plot_mcse(models, kwargs, backend_kwargs):
+def test_plot_mcse(models, kwargs):
     idata = models.model_1
-    ax = plot_mcse(idata, backend="bokeh", backend_kwargs=backend_kwargs.copy(), **kwargs)
+    ax = plot_mcse(idata, backend="bokeh", **kwargs)
     assert np.all(ax)
 
 
 @pytest.mark.parametrize("dim", ["chain", "draw"])
-def test_plot_mcse_bad_coords(models, dim, backend_kwargs):
+def test_plot_mcse_bad_coords(models, dim):
     """Test error when chain or dim are used as coords to select a data subset."""
     idata = models.model_1
     with pytest.raises(ValueError, match="invalid coordinates"):
         plot_mcse(
-            idata, coords={dim: slice(3)}, backend="bokeh", backend_kwargs=backend_kwargs.copy()
+            idata, coords={dim: slice(3)}, backend="bokeh"
         )
 
 
-def test_plot_mcse_no_sample_stats(models, backend_kwargs):
+def test_plot_mcse_no_sample_stats(models):
     """Test error when rug=True but sample_stats group is not present."""
     idata = models.model_1
     with pytest.raises(ValueError, match="must contain sample_stats"):
-        plot_mcse(idata.posterior, rug=True, backend="bokeh", backend_kwargs=backend_kwargs.copy())
+        plot_mcse(idata.posterior, rug=True, backend="bokeh")
 
 
-def test_plot_mcse_no_divergences(models, backend_kwargs):
+def test_plot_mcse_no_divergences(models):
     """Test error when rug=True, but the variable defined by rug_kind is missing."""
     idata = deepcopy(models.model_1)
     idata.sample_stats = idata.sample_stats.rename({"diverging": "diverging_missing"})
     with pytest.raises(ValueError, match="not contain diverging"):
-        plot_mcse(idata, rug=True, backend="bokeh", backend_kwargs=backend_kwargs.copy())
+        plot_mcse(idata, rug=True, backend="bokeh")
 
 
 @pytest.mark.slow
@@ -810,32 +805,32 @@ def test_plot_mcse_no_divergences(models, backend_kwargs):
         },
     ],
 )
-def test_plot_pair(models, kwargs, backend_kwargs):
-    ax = plot_pair(models.model_1, backend="bokeh", backend_kwargs=backend_kwargs.copy(), **kwargs)
+def test_plot_pair(models, kwargs):
+    ax = plot_pair(models.model_1, backend="bokeh", **kwargs)
     assert np.any(ax)
 
 
 @pytest.mark.parametrize("kwargs", [{"kind": "scatter"}, {"kind": "kde"}, {"kind": "hexbin"}])
-def test_plot_pair_2var(discrete_model, get_ax, kwargs, backend_kwargs):
+def test_plot_pair_2var(discrete_model, get_ax, kwargs):
     ax = plot_pair(
-        discrete_model, ax=get_ax, backend="bokeh", backend_kwargs=backend_kwargs.copy(), **kwargs
+        discrete_model, ax=get_ax, backend="bokeh", **kwargs
     )
     assert ax
 
 
-def test_plot_pair_bad(models, backend_kwargs):
+def test_plot_pair_bad(models):
     with pytest.raises(ValueError):
         plot_pair(
-            models.model_1, kind="bad_kind", backend="bokeh", backend_kwargs=backend_kwargs.copy()
+            models.model_1, kind="bad_kind", backend="bokeh"
         )
     with pytest.raises(Exception):
         plot_pair(
-            models.model_1, var_names=["mu"], backend="bokeh", backend_kwargs=backend_kwargs.copy()
+            models.model_1, var_names=["mu"], backend="bokeh"
         )
 
 
 @pytest.mark.parametrize("has_sample_stats", [True, False])
-def test_plot_pair_divergences_warning(has_sample_stats, backend_kwargs):
+def test_plot_pair_divergences_warning(has_sample_stats):
     data = load_arviz_data("centered_eight")
     if has_sample_stats:
         # sample_stats present, diverging field missing
@@ -845,29 +840,29 @@ def test_plot_pair_divergences_warning(has_sample_stats, backend_kwargs):
         data = data.posterior  # pylint: disable=no-member
     with pytest.warns(SyntaxWarning):
         ax = plot_pair(
-            data, divergences=True, backend="bokeh", backend_kwargs=backend_kwargs.copy()
+            data, divergences=True, backend="bokeh"
         )
     assert np.any(ax)
 
 
-def test_plot_parallel_raises_valueerror(df_trace, backend_kwargs):  # pylint: disable=invalid-name
+def test_plot_parallel_raises_valueerror(df_trace):  # pylint: disable=invalid-name
     with pytest.raises(ValueError):
-        plot_parallel(df_trace, backend="bokeh", backend_kwargs=backend_kwargs.copy())
+        plot_parallel(df_trace, backend="bokeh")
 
 
 @pytest.mark.parametrize("norm_method", [None, "normal", "minmax", "rank"])
-def test_plot_parallel(models, norm_method, backend_kwargs):
+def test_plot_parallel(models, norm_method):
     assert plot_parallel(
         models.model_1,
         var_names=["mu", "tau"],
         norm_method=norm_method,
         backend="bokeh",
-        backend_kwargs=backend_kwargs.copy(),
+
     )
 
 
 @pytest.mark.parametrize("var_names", [None, "mu", ["mu", "tau"]])
-def test_plot_parallel_exception(models, var_names, backend_kwargs):
+def test_plot_parallel_exception(models, var_names):
     """Ensure that correct exception is raised when one variable is passed."""
     with pytest.raises(ValueError):
         assert plot_parallel(
@@ -875,59 +870,59 @@ def test_plot_parallel_exception(models, var_names, backend_kwargs):
             var_names=var_names,
             norm_method="foo",
             backend="bokeh",
-            backend_kwargs=backend_kwargs.copy(),
+
         )
 
 
 @pytest.mark.parametrize("var_names", (None, "mu", ["mu", "tau"]))
-def test_plot_violin(models, var_names, backend_kwargs):
+def test_plot_violin(models, var_names):
     axes = plot_violin(
-        models.model_1, var_names=var_names, backend="bokeh", backend_kwargs=backend_kwargs.copy()
+        models.model_1, var_names=var_names, backend="bokeh"
     )
     assert axes.shape
 
 
-def test_plot_violin_ax(models, backend_kwargs):
+def test_plot_violin_ax(models):
     ax = bkp.figure()
     axes = plot_violin(
-        models.model_1, var_names="mu", ax=ax, backend="bokeh", backend_kwargs=backend_kwargs.copy()
+        models.model_1, var_names="mu", ax=ax, backend="bokeh"
     )
     assert axes.shape
 
 
-def test_plot_violin_layout(models, backend_kwargs):
+def test_plot_violin_layout(models):
     axes = plot_violin(
         models.model_1,
         var_names=["mu", "tau"],
         sharey=False,
         backend="bokeh",
-        backend_kwargs=backend_kwargs.copy(),
+
     )
     assert axes.shape
 
 
-def test_plot_violin_discrete(discrete_model, backend_kwargs):
-    axes = plot_violin(discrete_model, backend="bokeh", backend_kwargs=backend_kwargs.copy())
+def test_plot_violin_discrete(discrete_model):
+    axes = plot_violin(discrete_model, backend="bokeh")
     assert axes.shape
 
 
 @pytest.mark.parametrize("kind", ["kde", "cumulative", "scatter"])
 @pytest.mark.parametrize("alpha", [None, 0.2, 1])
-def test_plot_ppc(models, kind, alpha, backend_kwargs):
+def test_plot_ppc(models, kind, alpha):
     axes = plot_ppc(
         models.model_1,
         kind=kind,
         alpha=alpha,
         random_seed=3,
         backend="bokeh",
-        backend_kwargs=backend_kwargs.copy(),
+
     )
     assert axes
 
 
 @pytest.mark.parametrize("kind", ["kde", "cumulative", "scatter"])
 @pytest.mark.parametrize("jitter", [None, 0, 0.1, 1, 3])
-def test_plot_ppc_multichain(kind, jitter, backend_kwargs):
+def test_plot_ppc_multichain(kind, jitter):
     data = from_dict(
         posterior_predictive={
             "x": np.random.randn(4, 100, 30),
@@ -942,29 +937,29 @@ def test_plot_ppc_multichain(kind, jitter, backend_kwargs):
         jitter=jitter,
         random_seed=3,
         backend="bokeh",
-        backend_kwargs=backend_kwargs.copy(),
+
     )
     assert np.all(axes)
 
 
 @pytest.mark.parametrize("kind", ["kde", "cumulative", "scatter"])
-def test_plot_ppc_discrete(kind, backend_kwargs):
+def test_plot_ppc_discrete(kind):
     data = from_dict(
         observed_data={"obs": np.random.randint(1, 100, 15)},
         posterior_predictive={"obs": np.random.randint(1, 300, (1, 20, 15))},
     )
 
-    axes = plot_ppc(data, kind=kind, backend="bokeh", backend_kwargs=backend_kwargs.copy())
+    axes = plot_ppc(data, kind=kind, backend="bokeh")
     assert axes
 
 
-def test_plot_ppc_grid(models, backend_kwargs):
+def test_plot_ppc_grid(models):
     axes = plot_ppc(
         models.model_1,
         kind="scatter",
         flatten=[],
         backend="bokeh",
-        backend_kwargs=backend_kwargs.copy(),
+
     )
     assert len(axes.ravel()) == 8
     axes = plot_ppc(
@@ -973,7 +968,7 @@ def test_plot_ppc_grid(models, backend_kwargs):
         flatten=[],
         coords={"obs_dim": [1, 2, 3]},
         backend="bokeh",
-        backend_kwargs=backend_kwargs.copy(),
+
     )
     assert len(axes.ravel()) == 3
     axes = plot_ppc(
@@ -982,35 +977,35 @@ def test_plot_ppc_grid(models, backend_kwargs):
         flatten=["obs_dim"],
         coords={"obs_dim": [1, 2, 3]},
         backend="bokeh",
-        backend_kwargs=backend_kwargs.copy(),
+
     )
     assert len(axes.ravel()) == 1
 
 
 @pytest.mark.parametrize("kind", ["kde", "cumulative", "scatter"])
-def test_plot_ppc_bad(models, kind, backend_kwargs):
+def test_plot_ppc_bad(models, kind):
     data = from_dict(posterior={"mu": np.random.randn()})
     with pytest.raises(TypeError):
-        plot_ppc(data, kind=kind, backend="bokeh", backend_kwargs=backend_kwargs.copy())
+        plot_ppc(data, kind=kind, backend="bokeh")
     with pytest.raises(TypeError):
         plot_ppc(
-            models.model_1, kind="bad_val", backend="bokeh", backend_kwargs=backend_kwargs.copy()
+            models.model_1, kind="bad_val", backend="bokeh"
         )
     with pytest.raises(TypeError):
         plot_ppc(
             models.model_1,
             num_pp_samples="bad_val",
             backend="bokeh",
-            backend_kwargs=backend_kwargs.copy(),
+
         )
 
 
 @pytest.mark.parametrize("kind", ["kde", "cumulative", "scatter"])
-def test_plot_ppc_ax(models, kind, get_ax, backend_kwargs):
+def test_plot_ppc_ax(models, kind, get_ax):
     """Test ax argument of plot_ppc."""
     ax = get_ax
     axes = plot_ppc(
-        models.model_1, kind=kind, ax=ax, backend="bokeh", backend_kwargs=backend_kwargs.copy()
+        models.model_1, kind=kind, ax=ax, backend="bokeh"
     )
     assert axes[0] is ax
 
@@ -1040,50 +1035,50 @@ def test_plot_ppc_ax(models, kind, get_ax, backend_kwargs):
         },
     ],
 )
-def test_plot_posterior(models, kwargs, backend_kwargs):
+def test_plot_posterior(models, kwargs):
     axes = plot_posterior(
-        models.model_1, backend="bokeh", backend_kwargs=backend_kwargs.copy(), **kwargs
+        models.model_1, backend="bokeh", **kwargs
     )
     assert axes.shape
 
 
 @pytest.mark.parametrize("kwargs", [{}, {"point_estimate": "mode"}, {"bins": None, "kind": "hist"}])
-def test_plot_posterior_discrete(discrete_model, kwargs, backend_kwargs):
+def test_plot_posterior_discrete(discrete_model, kwargs):
     axes = plot_posterior(
-        discrete_model, backend="bokeh", backend_kwargs=backend_kwargs.copy(), **kwargs
+        discrete_model, backend="bokeh", **kwargs
     )
     assert axes.shape
 
 
-def test_plot_posterior_bad(models, backend_kwargs):
+def test_plot_posterior_bad(models):
     with pytest.raises(ValueError):
         plot_posterior(
-            models.model_1, backend="bokeh", backend_kwargs=backend_kwargs.copy(), rope="bad_value"
+            models.model_1, backend="bokeh", rope="bad_value"
         )
     with pytest.raises(ValueError):
         plot_posterior(
             models.model_1,
             ref_val="bad_value",
             backend="bokeh",
-            backend_kwargs=backend_kwargs.copy(),
+
         )
     with pytest.raises(ValueError):
         plot_posterior(
             models.model_1,
             point_estimate="bad_value",
             backend="bokeh",
-            backend_kwargs=backend_kwargs.copy(),
+
         )
 
 
 @pytest.mark.parametrize("point_estimate", ("mode", "mean", "median"))
-def test_plot_posterior_point_estimates(models, point_estimate, backend_kwargs):
+def test_plot_posterior_point_estimates(models, point_estimate):
     axes = plot_posterior(
         models.model_1,
         var_names=("mu", "tau"),
         point_estimate=point_estimate,
         backend="bokeh",
-        backend_kwargs=backend_kwargs.copy(),
+
     )
     assert axes.shape == (1, 2)
 
@@ -1099,8 +1094,8 @@ def test_plot_posterior_point_estimates(models, point_estimate, backend_kwargs):
         {"var_names": "mu", "kind": "vlines"},
     ],
 )
-def test_plot_rank(models, kwargs, backend_kwargs):
+def test_plot_rank(models, kwargs):
     axes = plot_rank(
-        models.model_1, backend="bokeh", backend_kwargs=backend_kwargs.copy(), **kwargs
+        models.model_1, backend="bokeh", **kwargs
     )
     assert axes.shape

--- a/arviz/tests/test_plots_bokeh.py
+++ b/arviz/tests/test_plots_bokeh.py
@@ -43,6 +43,7 @@ from ..stats import compare, loo, waic
 rcParams["data.load"] = "eager"
 rcParams["plot.bokeh.show"] = False
 
+
 @pytest.fixture(scope="module")
 def data(eight_schools_params):
     data = eight_schools_params
@@ -94,31 +95,24 @@ def test_plot_density_float(models, kwargs):
 
 
 def test_plot_density_discrete(discrete_model):
-    axes = plot_density(
-        discrete_model, shade=0.9, backend="bokeh"
-    )
+    axes = plot_density(discrete_model, shade=0.9, backend="bokeh")
     assert axes.shape[0] == 1
 
 
 def test_plot_density_bad_kwargs(models):
     obj = [getattr(models, model_fit) for model_fit in ["model_1", "model_2"]]
     with pytest.raises(ValueError):
-        plot_density(
-            obj, point_estimate="bad_value", backend="bokeh"
-        )
+        plot_density(obj, point_estimate="bad_value", backend="bokeh")
 
     with pytest.raises(ValueError):
         plot_density(
             obj,
             data_labels=["bad_value_{}".format(i) for i in range(len(obj) + 10)],
             backend="bokeh",
-
         )
 
     with pytest.raises(ValueError):
-        plot_density(
-            obj, credible_interval=2, backend="bokeh"
-        )
+        plot_density(obj, credible_interval=2, backend="bokeh")
 
 
 @pytest.mark.parametrize(
@@ -137,9 +131,7 @@ def test_plot_density_bad_kwargs(models):
     ],
 )
 def test_plot_trace(models, kwargs):
-    axes = plot_trace(
-        models.model_1, backend="bokeh", **kwargs
-    )
+    axes = plot_trace(models.model_1, backend="bokeh", **kwargs)
     assert axes.shape
 
 
@@ -170,13 +162,7 @@ def test_plot_trace_max_subplots_warning(models):
     ],
 )
 def test_plot_kde(continuous_model, kwargs):
-    axes = plot_kde(
-        continuous_model["x"],
-        continuous_model["y"],
-        backend="bokeh",
-
-        **kwargs
-    )
+    axes = plot_kde(continuous_model["x"], continuous_model["y"], backend="bokeh", **kwargs)
     assert axes
 
 
@@ -190,17 +176,13 @@ def test_plot_kde(continuous_model, kwargs):
     ],
 )
 def test_plot_kde_cumulative(continuous_model, kwargs):
-    axes = plot_kde(
-        continuous_model["x"], backend="bokeh", **kwargs
-    )
+    axes = plot_kde(continuous_model["x"], backend="bokeh", **kwargs)
     assert axes
 
 
 @pytest.mark.parametrize("kwargs", [{"kind": "hist"}, {"kind": "kde"}])
 def test_plot_dist(continuous_model, kwargs):
-    axes = plot_dist(
-        continuous_model["x"], backend="bokeh", **kwargs
-    )
+    axes = plot_dist(continuous_model["x"], backend="bokeh", **kwargs)
     assert axes
 
 
@@ -219,13 +201,7 @@ def test_plot_kde_1d(continuous_model):
     ],
 )
 def test_plot_kde_2d(continuous_model, kwargs):
-    axes = plot_kde(
-        continuous_model["x"],
-        continuous_model["y"],
-
-        backend="bokeh",
-        **kwargs
-    )
+    axes = plot_kde(continuous_model["x"], continuous_model["y"], backend="bokeh", **kwargs)
     assert axes
 
 
@@ -233,13 +209,7 @@ def test_plot_kde_2d(continuous_model, kwargs):
     "kwargs", [{"plot_kwargs": {"line_dash": "solid"}}, {"cumulative": True}, {"rug": True}]
 )
 def test_plot_kde_quantiles(continuous_model, kwargs):
-    axes = plot_kde(
-        continuous_model["x"],
-        quantiles=[0.05, 0.5, 0.95],
-
-        backend="bokeh",
-        **kwargs
-    )
+    axes = plot_kde(continuous_model["x"], quantiles=[0.05, 0.5, 0.95], backend="bokeh", **kwargs)
     assert axes
 
 
@@ -251,9 +221,7 @@ def test_plot_autocorr_short_chain():
 
 
 def test_plot_autocorr_uncombined(models):
-    axes = plot_autocorr(
-        models.model_1, combined=False, backend="bokeh"
-    )
+    axes = plot_autocorr(models.model_1, combined=False, backend="bokeh")
     assert axes.shape[0] == 10
     max_subplots = (
         np.inf if rcParams["plot.max_subplots"] is None else rcParams["plot.max_subplots"]
@@ -262,22 +230,14 @@ def test_plot_autocorr_uncombined(models):
 
 
 def test_plot_autocorr_combined(models):
-    axes = plot_autocorr(
-        models.model_1, combined=True, backend="bokeh"
-    )
+    axes = plot_autocorr(models.model_1, combined=True, backend="bokeh")
     assert axes.shape[0] == 6
     assert axes.shape[1] == 3
 
 
 @pytest.mark.parametrize("var_names", (None, "mu", ["mu", "tau"]))
 def test_plot_autocorr_var_names(models, var_names):
-    axes = plot_autocorr(
-        models.model_1,
-        var_names=var_names,
-        combined=True,
-        backend="bokeh",
-
-    )
+    axes = plot_autocorr(models.model_1, var_names=var_names, combined=True, backend="bokeh",)
     assert axes.shape
 
 
@@ -288,9 +248,7 @@ def test_plot_compare(models, kwargs):
 
     model_compare = compare({"Model 1": models.model_1, "Model 2": models.model_2})
 
-    axes = plot_compare(
-        model_compare, backend="bokeh", **kwargs
-    )
+    axes = plot_compare(model_compare, backend="bokeh", **kwargs)
     assert axes
 
 
@@ -369,16 +327,12 @@ def test_plot_elpd_multidim(multidim_models, add_model, use_elpddata, kwargs):
 
 @pytest.mark.parametrize("kind", ["kde", "hist"])
 def test_plot_energy(models, kind):
-    assert plot_energy(
-        models.model_1, kind=kind, backend="bokeh"
-    )
+    assert plot_energy(models.model_1, kind=kind, backend="bokeh")
 
 
 def test_plot_energy_bad(models):
     with pytest.raises(ValueError):
-        plot_energy(
-            models.model_1, kind="bad_kind", backend="bokeh"
-        )
+        plot_energy(models.model_1, kind="bad_kind", backend="bokeh")
 
 
 @pytest.mark.parametrize(
@@ -420,12 +374,7 @@ def test_plot_ess_evolution(models):
     """Test specific arguments in evolution kind of plot_ess."""
     idata = models.model_1
     ax = plot_ess(
-        idata,
-        kind="evolution",
-        extra_kwargs={"linestyle": "--"},
-        color="b",
-        backend="bokeh",
-
+        idata, kind="evolution", extra_kwargs={"linestyle": "--"}, color="b", backend="bokeh",
     )
     assert np.all(ax)
 
@@ -442,9 +391,7 @@ def test_plot_ess_bad_coords(models, dim):
     """Test error when chain or dim are used as coords to select a data subset."""
     idata = models.model_1
     with pytest.raises(ValueError, match="invalid coordinates"):
-        plot_ess(
-            idata, coords={dim: slice(3)}, backend="bokeh"
-        )
+        plot_ess(idata, coords={dim: slice(3)}, backend="bokeh")
 
 
 def test_plot_ess_no_sample_stats(models):
@@ -492,10 +439,7 @@ def test_plot_forest(models, model_fits, args_expected):
 def test_plot_forest_rope_exception():
     with pytest.raises(ValueError) as err:
         plot_forest(
-            {"x": [1]},
-            rope="not_correct_format",
-            backend="bokeh",
-
+            {"x": [1]}, rope="not_correct_format", backend="bokeh",
         )
     assert "Argument `rope` must be None, a dictionary like" in str(err.value)
 
@@ -516,7 +460,6 @@ def test_plot_forest_bad(models, model_fits):
             obj,
             model_names=["model_name_{}".format(i) for i in range(len(obj) + 10)],
             backend="bokeh",
-
         )
 
 
@@ -531,42 +474,19 @@ def test_plot_forest_bad(models, model_fits):
     ],
 )
 def test_plot_hpd(models, data, kwargs):
-    axis = plot_hpd(
-        data["y"],
-        models.model_1.posterior["theta"],
-        backend="bokeh",
-
-        **kwargs
-    )
+    axis = plot_hpd(data["y"], models.model_1.posterior["theta"], backend="bokeh", **kwargs)
     assert axis
 
 
 @pytest.mark.parametrize("kind", ["scatter", "hexbin", "kde"])
 def test_plot_joint(models, kind):
-    axes = plot_joint(
-        models.model_1,
-        var_names=("mu", "tau"),
-        kind=kind,
-        backend="bokeh",
-
-    )
+    axes = plot_joint(models.model_1, var_names=("mu", "tau"), kind=kind, backend="bokeh",)
     assert axes[1, 0]
 
 
 def test_plot_joint_ax_tuple(models):
-    ax = plot_joint(
-        models.model_1,
-        var_names=("mu", "tau"),
-        backend="bokeh",
-
-    )
-    axes = plot_joint(
-        models.model_2,
-        var_names=("mu", "tau"),
-        ax=ax,
-        backend="bokeh",
-
-    )
+    ax = plot_joint(models.model_1, var_names=("mu", "tau"), backend="bokeh",)
+    axes = plot_joint(models.model_2, var_names=("mu", "tau"), ax=ax, backend="bokeh",)
     assert axes[1, 0]
 
 
@@ -578,29 +498,18 @@ def test_plot_joint_discrete(discrete_model):
 def test_plot_joint_bad(models):
     with pytest.raises(ValueError):
         plot_joint(
-            models.model_1,
-            var_names=("mu", "tau"),
-            kind="bad_kind",
-            backend="bokeh",
-
+            models.model_1, var_names=("mu", "tau"), kind="bad_kind", backend="bokeh",
         )
 
     with pytest.raises(Exception):
         plot_joint(
-            models.model_1,
-            var_names=("mu", "tau", "eta"),
-            backend="bokeh",
-
+            models.model_1, var_names=("mu", "tau", "eta"), backend="bokeh",
         )
 
     with pytest.raises(ValueError):
         _, axes = list(range(5))
         plot_joint(
-            models.model_1,
-            var_names=("mu", "tau"),
-            ax=axes,
-            backend="bokeh",
-
+            models.model_1, var_names=("mu", "tau"), ax=axes, backend="bokeh",
         )
 
 
@@ -670,9 +579,7 @@ def test_plot_khat_annotate():
 
 def test_plot_khat_bad_input(models):
     with pytest.raises(ValueError):
-        plot_khat(
-            models.model_1.sample_stats, backend="bokeh"
-        )
+        plot_khat(models.model_1.sample_stats, backend="bokeh")
 
 
 @pytest.mark.parametrize(
@@ -689,9 +596,7 @@ def test_plot_khat_bad_input(models):
     ],
 )
 def test_plot_loo_pit(models, kwargs):
-    axes = plot_loo_pit(
-        idata=models.model_1, y="y", backend="bokeh", **kwargs
-    )
+    axes = plot_loo_pit(idata=models.model_1, y="y", backend="bokeh", **kwargs)
     assert axes
 
 
@@ -699,12 +604,7 @@ def test_plot_loo_pit_incompatible_args(models):
     """Test error when both ecdf and use_hpd are True."""
     with pytest.raises(ValueError, match="incompatible"):
         plot_loo_pit(
-            idata=models.model_1,
-            y="y",
-            ecdf=True,
-            use_hpd=True,
-            backend="bokeh",
-
+            idata=models.model_1, y="y", ecdf=True, use_hpd=True, backend="bokeh",
         )
 
 
@@ -735,13 +635,7 @@ def test_plot_loo_pit_label(models, args):
     else:
         y_hat = None
 
-    ax = plot_loo_pit(
-        idata=models.model_1,
-        y=y,
-        y_hat=y_hat,
-        backend="bokeh",
-
-    )
+    ax = plot_loo_pit(idata=models.model_1, y=y, y_hat=y_hat, backend="bokeh",)
     assert ax
 
 
@@ -768,9 +662,7 @@ def test_plot_mcse_bad_coords(models, dim):
     """Test error when chain or dim are used as coords to select a data subset."""
     idata = models.model_1
     with pytest.raises(ValueError, match="invalid coordinates"):
-        plot_mcse(
-            idata, coords={dim: slice(3)}, backend="bokeh"
-        )
+        plot_mcse(idata, coords={dim: slice(3)}, backend="bokeh")
 
 
 def test_plot_mcse_no_sample_stats(models):
@@ -812,21 +704,15 @@ def test_plot_pair(models, kwargs):
 
 @pytest.mark.parametrize("kwargs", [{"kind": "scatter"}, {"kind": "kde"}, {"kind": "hexbin"}])
 def test_plot_pair_2var(discrete_model, get_ax, kwargs):
-    ax = plot_pair(
-        discrete_model, ax=get_ax, backend="bokeh", **kwargs
-    )
+    ax = plot_pair(discrete_model, ax=get_ax, backend="bokeh", **kwargs)
     assert ax
 
 
 def test_plot_pair_bad(models):
     with pytest.raises(ValueError):
-        plot_pair(
-            models.model_1, kind="bad_kind", backend="bokeh"
-        )
+        plot_pair(models.model_1, kind="bad_kind", backend="bokeh")
     with pytest.raises(Exception):
-        plot_pair(
-            models.model_1, var_names=["mu"], backend="bokeh"
-        )
+        plot_pair(models.model_1, var_names=["mu"], backend="bokeh")
 
 
 @pytest.mark.parametrize("has_sample_stats", [True, False])
@@ -839,9 +725,7 @@ def test_plot_pair_divergences_warning(has_sample_stats):
         # sample_stats missing
         data = data.posterior  # pylint: disable=no-member
     with pytest.warns(SyntaxWarning):
-        ax = plot_pair(
-            data, divergences=True, backend="bokeh"
-        )
+        ax = plot_pair(data, divergences=True, backend="bokeh")
     assert np.any(ax)
 
 
@@ -853,11 +737,7 @@ def test_plot_parallel_raises_valueerror(df_trace):  # pylint: disable=invalid-n
 @pytest.mark.parametrize("norm_method", [None, "normal", "minmax", "rank"])
 def test_plot_parallel(models, norm_method):
     assert plot_parallel(
-        models.model_1,
-        var_names=["mu", "tau"],
-        norm_method=norm_method,
-        backend="bokeh",
-
+        models.model_1, var_names=["mu", "tau"], norm_method=norm_method, backend="bokeh",
     )
 
 
@@ -866,38 +746,24 @@ def test_plot_parallel_exception(models, var_names):
     """Ensure that correct exception is raised when one variable is passed."""
     with pytest.raises(ValueError):
         assert plot_parallel(
-            models.model_1,
-            var_names=var_names,
-            norm_method="foo",
-            backend="bokeh",
-
+            models.model_1, var_names=var_names, norm_method="foo", backend="bokeh",
         )
 
 
 @pytest.mark.parametrize("var_names", (None, "mu", ["mu", "tau"]))
 def test_plot_violin(models, var_names):
-    axes = plot_violin(
-        models.model_1, var_names=var_names, backend="bokeh"
-    )
+    axes = plot_violin(models.model_1, var_names=var_names, backend="bokeh")
     assert axes.shape
 
 
 def test_plot_violin_ax(models):
     ax = bkp.figure()
-    axes = plot_violin(
-        models.model_1, var_names="mu", ax=ax, backend="bokeh"
-    )
+    axes = plot_violin(models.model_1, var_names="mu", ax=ax, backend="bokeh")
     assert axes.shape
 
 
 def test_plot_violin_layout(models):
-    axes = plot_violin(
-        models.model_1,
-        var_names=["mu", "tau"],
-        sharey=False,
-        backend="bokeh",
-
-    )
+    axes = plot_violin(models.model_1, var_names=["mu", "tau"], sharey=False, backend="bokeh",)
     assert axes.shape
 
 
@@ -909,14 +775,7 @@ def test_plot_violin_discrete(discrete_model):
 @pytest.mark.parametrize("kind", ["kde", "cumulative", "scatter"])
 @pytest.mark.parametrize("alpha", [None, 0.2, 1])
 def test_plot_ppc(models, kind, alpha):
-    axes = plot_ppc(
-        models.model_1,
-        kind=kind,
-        alpha=alpha,
-        random_seed=3,
-        backend="bokeh",
-
-    )
+    axes = plot_ppc(models.model_1, kind=kind, alpha=alpha, random_seed=3, backend="bokeh",)
     assert axes
 
 
@@ -931,13 +790,7 @@ def test_plot_ppc_multichain(kind, jitter):
         observed_data={"x": np.random.randn(30), "y": np.random.randn(3, 10)},
     )
     axes = plot_ppc(
-        data,
-        kind=kind,
-        data_pairs={"y": "y_hat"},
-        jitter=jitter,
-        random_seed=3,
-        backend="bokeh",
-
+        data, kind=kind, data_pairs={"y": "y_hat"}, jitter=jitter, random_seed=3, backend="bokeh",
     )
     assert np.all(axes)
 
@@ -954,21 +807,10 @@ def test_plot_ppc_discrete(kind):
 
 
 def test_plot_ppc_grid(models):
-    axes = plot_ppc(
-        models.model_1,
-        kind="scatter",
-        flatten=[],
-        backend="bokeh",
-
-    )
+    axes = plot_ppc(models.model_1, kind="scatter", flatten=[], backend="bokeh",)
     assert len(axes.ravel()) == 8
     axes = plot_ppc(
-        models.model_1,
-        kind="scatter",
-        flatten=[],
-        coords={"obs_dim": [1, 2, 3]},
-        backend="bokeh",
-
+        models.model_1, kind="scatter", flatten=[], coords={"obs_dim": [1, 2, 3]}, backend="bokeh",
     )
     assert len(axes.ravel()) == 3
     axes = plot_ppc(
@@ -977,7 +819,6 @@ def test_plot_ppc_grid(models):
         flatten=["obs_dim"],
         coords={"obs_dim": [1, 2, 3]},
         backend="bokeh",
-
     )
     assert len(axes.ravel()) == 1
 
@@ -988,15 +829,10 @@ def test_plot_ppc_bad(models, kind):
     with pytest.raises(TypeError):
         plot_ppc(data, kind=kind, backend="bokeh")
     with pytest.raises(TypeError):
-        plot_ppc(
-            models.model_1, kind="bad_val", backend="bokeh"
-        )
+        plot_ppc(models.model_1, kind="bad_val", backend="bokeh")
     with pytest.raises(TypeError):
         plot_ppc(
-            models.model_1,
-            num_pp_samples="bad_val",
-            backend="bokeh",
-
+            models.model_1, num_pp_samples="bad_val", backend="bokeh",
         )
 
 
@@ -1004,9 +840,7 @@ def test_plot_ppc_bad(models, kind):
 def test_plot_ppc_ax(models, kind, get_ax):
     """Test ax argument of plot_ppc."""
     ax = get_ax
-    axes = plot_ppc(
-        models.model_1, kind=kind, ax=ax, backend="bokeh"
-    )
+    axes = plot_ppc(models.model_1, kind=kind, ax=ax, backend="bokeh")
     assert axes[0] is ax
 
 
@@ -1036,49 +870,33 @@ def test_plot_ppc_ax(models, kind, get_ax):
     ],
 )
 def test_plot_posterior(models, kwargs):
-    axes = plot_posterior(
-        models.model_1, backend="bokeh", **kwargs
-    )
+    axes = plot_posterior(models.model_1, backend="bokeh", **kwargs)
     assert axes.shape
 
 
 @pytest.mark.parametrize("kwargs", [{}, {"point_estimate": "mode"}, {"bins": None, "kind": "hist"}])
 def test_plot_posterior_discrete(discrete_model, kwargs):
-    axes = plot_posterior(
-        discrete_model, backend="bokeh", **kwargs
-    )
+    axes = plot_posterior(discrete_model, backend="bokeh", **kwargs)
     assert axes.shape
 
 
 def test_plot_posterior_bad(models):
     with pytest.raises(ValueError):
+        plot_posterior(models.model_1, backend="bokeh", rope="bad_value")
+    with pytest.raises(ValueError):
         plot_posterior(
-            models.model_1, backend="bokeh", rope="bad_value"
+            models.model_1, ref_val="bad_value", backend="bokeh",
         )
     with pytest.raises(ValueError):
         plot_posterior(
-            models.model_1,
-            ref_val="bad_value",
-            backend="bokeh",
-
-        )
-    with pytest.raises(ValueError):
-        plot_posterior(
-            models.model_1,
-            point_estimate="bad_value",
-            backend="bokeh",
-
+            models.model_1, point_estimate="bad_value", backend="bokeh",
         )
 
 
 @pytest.mark.parametrize("point_estimate", ("mode", "mean", "median"))
 def test_plot_posterior_point_estimates(models, point_estimate):
     axes = plot_posterior(
-        models.model_1,
-        var_names=("mu", "tau"),
-        point_estimate=point_estimate,
-        backend="bokeh",
-
+        models.model_1, var_names=("mu", "tau"), point_estimate=point_estimate, backend="bokeh",
     )
     assert axes.shape == (1, 2)
 
@@ -1095,7 +913,5 @@ def test_plot_posterior_point_estimates(models, point_estimate):
     ],
 )
 def test_plot_rank(models, kwargs):
-    axes = plot_rank(
-        models.model_1, backend="bokeh", **kwargs
-    )
+    axes = plot_rank(models.model_1, backend="bokeh", **kwargs)
     assert axes.shape

--- a/arviz/tests/test_plots_bokeh.py
+++ b/arviz/tests/test_plots_bokeh.py
@@ -438,7 +438,7 @@ def test_plot_forest(models, model_fits, args_expected):
     obj = [getattr(models, model_fit) for model_fit in model_fits]
     args, expected = args_expected
     axes = plot_forest(obj, backend="bokeh", show=False, **args)
-    assert axes.shape == (expected,)
+    assert axes.shape == (1, expected)
 
 
 def test_plot_forest_rope_exception():
@@ -870,7 +870,7 @@ def test_plot_ppc_ax(models, kind):
     """Test ax argument of plot_ppc."""
     ax = bkp.figure()
     axes = plot_ppc(models.model_1, kind=kind, ax=ax, backend="bokeh", show=False)
-    assert axes[0,0] is ax
+    assert axes[0, 0] is ax
 
 
 @pytest.mark.parametrize(

--- a/arviz/tests/test_plots_bokeh.py
+++ b/arviz/tests/test_plots_bokeh.py
@@ -66,12 +66,6 @@ def continuous_model():
     return {"x": np.random.beta(2, 5, size=100), "y": np.random.beta(2, 5, size=100)}
 
 
-@pytest.fixture(scope="function")
-def get_ax():
-    ax = bkp.figure()
-    return np.atleast_2d(ax)
-
-
 @pytest.mark.parametrize(
     "kwargs",
     [
@@ -719,8 +713,8 @@ def test_plot_pair(models, kwargs):
 
 
 @pytest.mark.parametrize("kwargs", [{"kind": "scatter"}, {"kind": "kde"}, {"kind": "hexbin"}])
-def test_plot_pair_2var(discrete_model, get_ax, kwargs):
-    ax = plot_pair(discrete_model, ax=get_ax, backend="bokeh", show=False, **kwargs)
+def test_plot_pair_2var(discrete_model, kwargs):
+    ax = plot_pair(discrete_model, ax=bkp.figure(), backend="bokeh", show=False, **kwargs)
     assert ax
 
 
@@ -777,7 +771,7 @@ def test_plot_violin(models, var_names):
 
 
 def test_plot_violin_ax(models):
-    ax = np.atleast_2d(bkp.figure())
+    ax = bkp.figure()
     axes = plot_violin(models.model_1, var_names="mu", ax=ax, backend="bokeh", show=False)
     assert axes.shape
 
@@ -872,10 +866,9 @@ def test_plot_ppc_bad(models, kind):
 
 
 @pytest.mark.parametrize("kind", ["kde", "cumulative", "scatter"])
-def test_plot_ppc_ax(models, kind, get_ax):
+def test_plot_ppc_ax(models, kind):
     """Test ax argument of plot_ppc."""
-    ax = get_ax
-    axes = plot_ppc(models.model_1, kind=kind, ax=ax, backend="bokeh", show=False)
+    axes = plot_ppc(models.model_1, kind=kind, ax=bkp.figure(), backend="bokeh", show=False)
     assert axes[0] is ax
 
 

--- a/arviz/tests/test_plots_matplotlib.py
+++ b/arviz/tests/test_plots_matplotlib.py
@@ -45,7 +45,6 @@ from ..plots import (
 from ..plots.kdeplot import _cov
 
 rcParams["data.load"] = "eager"
-rcParams["plot.matplotlib.show"] = False
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/arviz/tests/test_plots_matplotlib.py
+++ b/arviz/tests/test_plots_matplotlib.py
@@ -45,6 +45,7 @@ from ..plots import (
 from ..plots.kdeplot import _cov
 
 rcParams["data.load"] = "eager"
+rcParams["plot.matplotlib.show"] = False
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/arviz/tests/test_rcparams.py
+++ b/arviz/tests/test_rcparams.py
@@ -18,6 +18,8 @@ from ..rcparams import (
 
 from .helpers import models  # pylint: disable=unused-import
 
+# reset rcParam manually
+rcParams["plot.bokeh.show"] = True
 
 ### Test rcparams classes ###
 def test_rc_context_dict():

--- a/arviz/tests/test_rcparams.py
+++ b/arviz/tests/test_rcparams.py
@@ -18,9 +18,6 @@ from ..rcparams import (
 
 from .helpers import models  # pylint: disable=unused-import
 
-# reset rcParam manually
-rcParams["plot.bokeh.show"] = True
-
 ### Test rcparams classes ###
 def test_rc_context_dict():
     rcParams["data.load"] = "lazy"

--- a/arvizrc.template
+++ b/arvizrc.template
@@ -20,6 +20,7 @@ plot.bokeh.figure.width      : 500         # num of pixels
 plot.bokeh.show              : true        # call bokeh.plotting.show for figure or grid of figures. One of "true", "false"
 
 plot.matplotlib.constrained_layout : true  # One of "true" or "false"
+plot.matplotlib.show         : true        # call plt.show. One of "true", "false"
 
 plot.max_subplots            : 40          # Maximum number of subplots.
 plot.point_estimate          : mean        # One of mean, median, mode or None

--- a/arvizrc.template
+++ b/arvizrc.template
@@ -20,7 +20,7 @@ plot.bokeh.figure.width      : 500         # num of pixels
 plot.bokeh.show              : true        # call bokeh.plotting.show for figure or grid of figures. One of "true", "false"
 
 plot.matplotlib.constrained_layout : true  # One of "true" or "false"
-plot.matplotlib.show         : false        # call plt.show. One of "true", "false"
+plot.matplotlib.show         : false       # call plt.show. One of "true", "false"
 
 plot.max_subplots            : 40          # Maximum number of subplots.
 plot.point_estimate          : mean        # One of mean, median, mode or None

--- a/arvizrc.template
+++ b/arvizrc.template
@@ -20,7 +20,7 @@ plot.bokeh.figure.width      : 500         # num of pixels
 plot.bokeh.show              : true        # call bokeh.plotting.show for figure or grid of figures. One of "true", "false"
 
 plot.matplotlib.constrained_layout : true  # One of "true" or "false"
-plot.matplotlib.show         : true        # call plt.show. One of "true", "false"
+plot.matplotlib.show         : false        # call plt.show. One of "true", "false"
 
 plot.max_subplots            : 40          # Maximum number of subplots.
 plot.point_estimate          : mean        # One of mean, median, mode or None

--- a/examples/bokeh/bokeh_plot_dist.py
+++ b/examples/bokeh/bokeh_plot_dist.py
@@ -17,16 +17,9 @@ ax_poisson = bkp.figure(**figure_kwargs)
 ax_normal = bkp.figure(**figure_kwargs)
 
 az.plot_dist(
-    a,
-    color="black",
-    label="Poisson",
-    ax=ax_poisson,
-    backend="bokeh",
-    backend_kwargs={"show": False},
+    a, color="black", label="Poisson", ax=ax_poisson, backend="bokeh", show=False,
 )
-az.plot_dist(
-    b, color="red", label="Gaussian", ax=ax_normal, backend="bokeh", backend_kwargs={"show": False}
-)
+az.plot_dist(b, color="red", label="Gaussian", ax=ax_normal, backend="bokeh", show=False)
 
 ax = row(ax_poisson, ax_normal)
 

--- a/examples/bokeh/bokeh_plot_hpd.py
+++ b/examples/bokeh/bokeh_plot_hpd.py
@@ -13,7 +13,7 @@ y_data = 2 + x_data * 0.5
 y_data_rep = np.random.normal(y_data, 0.5, (200, 100))
 x_data_sorted = np.sort(x_data)
 
-ax = az.plot_hpd(x_data, y_data_rep, color="red", backend="bokeh", backend_kwargs={"show": False})
+ax = az.plot_hpd(x_data, y_data_rep, color="red", backend="bokeh", show=False)
 ax.line(x_data_sorted, 2 + x_data_sorted * 0.5, line_color="black", line_width=3)
 
 if az.rcParams["plot.bokeh.show"]:


### PR DESCRIPTION
This changes the logic, show backend `show` is not in `backend_kwargs`. This also implement this for matplotlib.