### PR TITLE
constrain numpy version temporarily

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib>=3.0
-numpy>=1.12
+numpy>=1.12,<1.18
 scipy>=0.19
 packaging
 pandas>=0.23


### PR DESCRIPTION
Python 3.7 + jax + numpy 1.18 have some problems, let's constrain numpy version until this bug has been fixed by jax -package.