### PR TITLE
Fixed bug in extracting prior samples for cmdstanpy.

### DIFF
--- a/arviz/data/io_cmdstanpy.py
+++ b/arviz/data/io_cmdstanpy.py
@@ -156,7 +156,7 @@ class CmdStanPyConverter:
             ]
 
         valid_cols = [col for col in columns if col not in set(prior_predictive)]
-        data = _unpack_frame(self.posterior.sample, columns, valid_cols)
+        data = _unpack_frame(self.prior.sample, columns, valid_cols)
         return dict_to_dataset(data, library=self.cmdstanpy, coords=self.coords, dims=self.dims)
 
     @requires("prior")


### PR DESCRIPTION
When extracting *prior* samples from cmdstanpy output, the call to `_unpack_frame()`, *posterior* samples were being unpacked. I fixed this so that prior samples are unpacked.