### PR TITLE
infrerence_data to ColumnDataSource (bokeh)

### DIFF
--- a/arviz/plots/backends/__init__.py
+++ b/arviz/plots/backends/__init__.py
@@ -6,10 +6,11 @@ from ...data import convert_to_inference_data
 from ...rcparams import rcParams
 
 
-def to_cds(data, var_names=None, groups=None, ignore_groups=None, index_origin=None):
+def to_cds(data, var_names=None, groups=None, ignore_groups=None, index_origin=None, return_dict):
     """Transform data to ColumnDataSource (CDS) compatible with Bokeh.
 
-    Uses `_ARVIZ_CDS_SELECTION_` to separate var_name from dimensions.
+    Uses `_ARVIZ_GROUP_` and `_ARVIZ_CDS_SELECTION_`to separate var_name 
+    from group and dimensions in CDS columns.
 
     Parameters
     ----------
@@ -31,8 +32,6 @@ def to_cds(data, var_names=None, groups=None, ignore_groups=None, index_origin=N
     -------
     bokeh.models.ColumnDataSource object
     """
-    from bokeh.models import ColumnDataSource
-
     data = convert_to_inference_data(data)
 
     if groups is None:
@@ -74,6 +73,10 @@ def to_cds(data, var_names=None, groups=None, ignore_groups=None, index_origin=N
                             var_name, group, "_".join((str(item + index_origin) for item in loc))
                         )
                         cds_dict[var_name_dim] = var[loc].values
+
+    if return_dict:
+        return cds_dict
+    
     cds_data = ColumnDataSource(cds_dict)
     return cds_data
 

--- a/arviz/plots/backends/__init__.py
+++ b/arviz/plots/backends/__init__.py
@@ -1,5 +1,72 @@
 # pylint: disable=no-member,invalid-name,redefined-outer-name
 """ArviZ plotting backends."""
+import numpy as np
+
+from ...data import convert_to_inference_data
+from ...rcparams import rcParams
+
+
+def to_cds(data, var_names=None, groups=None, index_origin=None):
+    """Transform data to ColumnDataSource compatible with Bokeh.
+
+    Uses `_ARVIZ_CDS_SELECTION_` to separate var_name from dimensions.
+
+    Parameters
+    ----------
+    data : obj
+        Any object that can be converted to an az.InferenceData object
+        Refer to documentation of az.convert_to_inference_data for details
+    var_names : list of variable names, optional
+        Variables to be processed, if None all variables are processed.
+    groups : str or list of str, optional
+        Select groups for CDS. Default groups are {"posterior_groups", "prior_groups"}
+            posterior_groups: posterior, posterior_predictive, sample_stats
+            prior_groups: prior, posterior_predictive, sample_stats_prior
+    index_origin : int, optional
+        Start parameter indeces from `index_origin`. Either 0 or 1.
+
+    Returns
+    -------
+    bokeh.models.ColumnDataSource object
+    """
+    from bokeh.models import ColumnDataSource
+
+    data = convert_to_inference_data(data)
+
+    if groups is None:
+        groups = ["posterior", "posterior_predictive", "sample_stats"]
+    elif isinstance(groups, str):
+        if groups.lower() == "posterior_groups":
+            groups = ["posterior", "posterior_predictive", "sample_stats"]
+        elif groups.lower() == "prior_groups":
+            groups = ["prior", "prior_predictive", "sample_stats_prior"]
+        else:
+            raise TypeError("Valid predefined groups are {posterior_groups, prior_groups}")
+
+    if index_origin is None:
+        index_origin = rcParams["data.index_origin"]
+
+    cds_dict = {}
+    for group in groups:
+        if hasattr(data, group):
+            group_data = getattr(data, group).stack(samples=("chain", "draw"))
+            for var_name, var in group_data.data_vars.items():
+                if var_names is not None and var_name not in var_names:
+                    continue
+                if "chain" not in cds_dict:
+                    cds_dict["chain"] = var.coords.get("chain").values
+                if "draw" not in cds_dict:
+                    cds_dict["draw"] = var.coords.get("draw").values
+                if len(var.shape) == 1:
+                    cds_dict[var_name] = var.values
+                else:
+                    for loc in np.ndindex(var.shape[:-1]):
+                        var_name_dim = "{}_ARVIZ_CDS_SELECTION_{}".format(
+                            var_name, "_".join((str(item + index_origin) for item in loc))
+                        )
+                        cds_dict[var_name_dim] = var[loc].values
+    cds_data = ColumnDataSource(cds_dict)
+    return cds_data
 
 
 def output_notebook(*args, **kwargs):
@@ -16,6 +83,13 @@ def output_file(*args, **kwargs):
     return bkp.output_file(*args, **kwargs)
 
 
+def ColumnDataSource(*args, **kwargs):
+    """Wrap bokeh.models.ColumnDataSource."""
+    from bokeh.models import ColumnDataSource
+
+    return ColumnDataSource(*args, **kwargs)
+
+
 def _copy_docstring(lib, function):
     """Extract docstring from function."""
     import importlib
@@ -28,13 +102,6 @@ def _copy_docstring(lib, function):
         doc = "Failed to import function {} from {}".format(function, lib)
 
     return doc
-
-
-def ColumnDataSource(*args, **kwargs):
-    """Wrap bokeh.models.ColumnDataSource."""
-    from bokeh.models import ColumnDataSource
-
-    return ColumnDataSource(*args, **kwargs)
 
 
 output_notebook.__doc__ += "\n\n" + _copy_docstring("bokeh.plotting", "output_notebook")

--- a/arviz/plots/backends/__init__.py
+++ b/arviz/plots/backends/__init__.py
@@ -1,5 +1,6 @@
 # pylint: disable=no-member,invalid-name,redefined-outer-name
 """ArviZ plotting backends."""
+from pandas import DataFrame
 
 
 def to_cds(
@@ -7,7 +8,7 @@ def to_cds(
     var_names=None,
     groups=None,
     dimensions=None,
-    add_group_info=True,
+    group_info=True,
     var_name_format=None,
     index_origin=None,
 ):
@@ -31,7 +32,7 @@ def to_cds(
         Ignore specific groups from CDS.
     dimension : list, optional
         Select dimensions along to slice the data. By default uses ("chain", "draw").
-    add_group_info : bool
+    group_info : bool
         Add group info for `var_name_format`
     var_name_format : str or tuple of tuple of string, optional
         Select column name format for non-scalar input. Predefined {"brackets", "underscore", "cds"}
@@ -59,21 +60,21 @@ def to_cds(
     -------
     bokeh.models.ColumnDataSource object
     """
-    from ...utils import inference_data_to_dict
+    from ...utils import flat_inference_data_to_dict
 
     if var_name_format is None:
         var_name_format = "cds"
 
-    cds_dict = inference_data_to_dict(
+    cds_dict = flat_inference_data_to_dict(
         data=data,
         var_names=var_names,
         groups=groups,
         dimensions=dimensions,
-        add_group_info=add_group_info,
+        group_info=group_info,
         index_origin=index_origin,
         var_name_format=var_name_format,
     )
-    cds_data = ColumnDataSource(cds_dict)
+    cds_data = ColumnDataSource(DataFrame.from_dict(cds_dict, orient="columns"))
     return cds_data
 
 

--- a/arviz/plots/backends/__init__.py
+++ b/arviz/plots/backends/__init__.py
@@ -35,7 +35,8 @@ def to_cds(
     group_info : bool
         Add group info for `var_name_format`
     var_name_format : str or tuple of tuple of string, optional
-        Select column name format for non-scalar input. Predefined {"brackets", "underscore", "cds"}
+        Select column name format for non-scalar input.
+        Predefined options are {"brackets", "underscore", "cds"}
             "brackets":
                 - add_group_info == False: theta[0,0]
                 - add_group_info == True: theta_posterior[0,0]
@@ -48,7 +49,9 @@ def to_cds(
             tuple:
                 Structure:
                     tuple: (dim_info, group_info)
-                        dim_info: (str: `.join` separator, str: dim_separator_start, str: dim_separator_end)
+                        dim_info: (str: `.join` separator,
+                                   str: dim_separator_start,
+                                   str: dim_separator_end)
                         group_info: (str: group separator start, str: group separator end)
                 Example: ((",", "[", "]"), "_", "")
                     - add_group_info == False: theta[0,0]

--- a/arviz/plots/backends/__init__.py
+++ b/arviz/plots/backends/__init__.py
@@ -27,7 +27,7 @@ def to_cds(
     groups : str or list of str, optional
         Select groups for CDS. Default groups are {"posterior_groups", "prior_groups"}
             - posterior_groups: posterior, posterior_predictive, sample_stats
-            - prior_groups: prior, posterior_predictive, sample_stats_prior
+            - prior_groups: prior, prior_predictive, sample_stats_prior
     ignore_groups : str or list of str, optional
         Ignore specific groups from CDS.
     dimension : str, or list of str, optional

--- a/arviz/plots/backends/__init__.py
+++ b/arviz/plots/backends/__init__.py
@@ -67,11 +67,11 @@ def to_cds(data, var_names=None, groups=None, ignore_groups=None, index_origin=N
                 if "draw" not in cds_dict:
                     cds_dict["draw"] = var.coords.get("draw").values
                 if len(var.shape) == 1:
-                    cds_dict[var_name] = var.values
+                    cds_dict["{}_ARVIZ_GROUP_{}".format(var_name, group)] = var.values
                 else:
                     for loc in np.ndindex(var.shape[:-1]):
-                        var_name_dim = "{}_ARVIZ_CDS_SELECTION_{}".format(
-                            var_name, "_".join((str(item + index_origin) for item in loc))
+                        var_name_dim = "{}_ARVIZ_GROUP_{}_ARVIZ_CDS_SELECTION_{}".format(
+                            var_name, group, "_".join((str(item + index_origin) for item in loc))
                         )
                         cds_dict[var_name_dim] = var[loc].values
     cds_data = ColumnDataSource(cds_dict)

--- a/arviz/plots/backends/__init__.py
+++ b/arviz/plots/backends/__init__.py
@@ -6,8 +6,8 @@ from ...data import convert_to_inference_data
 from ...rcparams import rcParams
 
 
-def to_cds(data, var_names=None, groups=None, index_origin=None):
-    """Transform data to ColumnDataSource compatible with Bokeh.
+def to_cds(data, var_names=None, groups=None, ignore_groups=None, index_origin=None):
+    """Transform data to ColumnDataSource (CDS) compatible with Bokeh.
 
     Uses `_ARVIZ_CDS_SELECTION_` to separate var_name from dimensions.
 
@@ -22,6 +22,8 @@ def to_cds(data, var_names=None, groups=None, index_origin=None):
         Select groups for CDS. Default groups are {"posterior_groups", "prior_groups"}
             posterior_groups: posterior, posterior_predictive, sample_stats
             prior_groups: prior, posterior_predictive, sample_stats_prior
+    ignore_groups : str or list of str, optional
+        Ignore specific groups from CDS.
     index_origin : int, optional
         Start parameter indeces from `index_origin`. Either 0 or 1.
 
@@ -43,11 +45,18 @@ def to_cds(data, var_names=None, groups=None, index_origin=None):
         else:
             raise TypeError("Valid predefined groups are {posterior_groups, prior_groups}")
 
+    if ignore_groups is None:
+        ignore_groups = []
+    elif isinstance(ignore_groups, str):
+        ignore_groups = [ignore_groups]
+
     if index_origin is None:
         index_origin = rcParams["data.index_origin"]
 
     cds_dict = {}
     for group in groups:
+        if group in ignore_groups:
+            continue
         if hasattr(data, group):
             group_data = getattr(data, group).stack(samples=("chain", "draw"))
             for var_name, var in group_data.data_vars.items():

--- a/arviz/plots/backends/__init__.py
+++ b/arviz/plots/backends/__init__.py
@@ -57,7 +57,7 @@ def to_cds(
                     - add_group_info == False: theta[0,0]
                     - add_group_info == True: theta_posterior[0,0]
     index_origin : int, optional
-        Start parameter indeces from `index_origin`. Either 0 or 1.
+        Start parameter indices from `index_origin`. Either 0 or 1.
 
     Returns
     -------

--- a/arviz/plots/backends/__init__.py
+++ b/arviz/plots/backends/__init__.py
@@ -22,15 +22,15 @@ def to_cds(
     data : obj
         Any object that can be converted to an az.InferenceData object
         Refer to documentation of az.convert_to_inference_data for details
-    var_names : list of variable names, optional
+    var_names : str or list of str, optional
         Variables to be processed, if None all variables are processed.
     groups : str or list of str, optional
         Select groups for CDS. Default groups are {"posterior_groups", "prior_groups"}
-            posterior_groups: posterior, posterior_predictive, sample_stats
-            prior_groups: prior, posterior_predictive, sample_stats_prior
+            - posterior_groups: posterior, posterior_predictive, sample_stats
+            - prior_groups: prior, posterior_predictive, sample_stats_prior
     ignore_groups : str or list of str, optional
         Ignore specific groups from CDS.
-    dimension : list, optional
+    dimension : str, or list of str, optional
         Select dimensions along to slice the data. By default uses ("chain", "draw").
     group_info : bool
         Add group info for `var_name_format`
@@ -53,7 +53,7 @@ def to_cds(
                                    str: dim_separator_start,
                                    str: dim_separator_end)
                         group_info: (str: group separator start, str: group separator end)
-                Example: ((",", "[", "]"), "_", "")
+                Example: ((",", "[", "]"), ("_", ""))
                     - add_group_info == False: theta[0,0]
                     - add_group_info == True: theta_posterior[0,0]
     index_origin : int, optional

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -287,7 +287,7 @@ def selection_to_string(selection):
     return ", ".join(["{}".format(v) for _, v in selection.items()])
 
 
-def make_label(var_name, selection, position="below", index_origin=None):
+def make_label(var_name, selection, position="below"):
     """Consistent labelling for plots.
 
     Parameters

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -287,7 +287,7 @@ def selection_to_string(selection):
     return ", ".join(["{}".format(v) for _, v in selection.items()])
 
 
-def make_label(var_name, selection, position="below"):
+def make_label(var_name, selection, position="below", index_origin=None):
     """Consistent labelling for plots.
 
     Parameters
@@ -297,8 +297,9 @@ def make_label(var_name, selection, position="below"):
 
     selection : dict[Any] -> Any
         Coordinates of the variable
-    position : whether to position the coordinates' label "below" (default) or "beside" the name
-               of the variable
+    position : str
+        Whether to position the coordinates' label "below" (default) or "beside"
+        the name of the variable
 
     Returns
     -------

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -811,7 +811,7 @@ def summary(
     extend=True,
     credible_interval=0.94,
     order="C",
-    index_origin=0,
+    index_origin=None,
     coords: Optional[CoordSpec] = None,
     dims: Optional[DimSpec] = None,
 ) -> Union[pd.DataFrame, xr.Dataset]:
@@ -851,7 +851,8 @@ def summary(
     order : {"C", "F"}
         If fmt is "wide", use either C or F unpacking order. Defaults to C.
     index_origin : int
-        If fmt is "wide, select n-based indexing for multivariate parameters. Defaults to 0.
+        If fmt is "wide, select n-based indexing for multivariate parameters.
+        Defaults to rcParam data.index.origin, which is 0.
     coords: Dict[str, List[Any]], optional
         Coordinates specification to be used if the ``fmt`` is ``'xarray'``.
     dims: Dict[str, List[str]], optional
@@ -905,6 +906,8 @@ def summary(
         extra_args["coords"] = coords
     if dims is not None:
         extra_args["dims"] = dims
+    if index_origin is None:
+        index_origin = rcParams["data.index_origin"]
     posterior = convert_to_dataset(data, group="posterior", **extra_args)
     var_names = _var_names(var_names, posterior)
     posterior = posterior if var_names is None else posterior[var_names]

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -372,7 +372,7 @@ def flat_inference_data_to_dict(
                                    str: dim_separator_start,
                                    str: dim_separator_end)
                         group_info: (str: group separator start, str: group separator end)
-                Example: ((",", "[", "]"), "_", "")
+                Example: ((",", "[", "]"), ("_", ""))
                     - add_group_info == False: theta[0,0]
                     - add_group_info == True: theta_posterior[0,0]
     index_origin : int, optional
@@ -398,11 +398,15 @@ def flat_inference_data_to_dict(
 
     if dimensions is None:
         dimensions = "chain", "draw"
+    elif isinstance(dimensions, str):
+        dimensions = (dimensions,)
 
     if var_name_format is None:
         var_name_format = "brackets"
 
-    var_name_format = var_name_format.lower()
+    if isinstance(var_name_format, str):
+        var_name_format = var_name_format.lower()
+
     if var_name_format == "brackets":
         dim_join_separator, dim_separator_start, dim_separator_end = ",", "[", "]"
         group_separator_start, group_separator_end = "_", ""
@@ -416,7 +420,7 @@ def flat_inference_data_to_dict(
             "",
         )
         group_separator_start, group_separator_end = "_ARVIZ_GROUP_", ""
-    elif isinstance(str, var_name_format):
+    elif isinstance(var_name_format, str):
         msg = 'Invalid predefined format. Select one {"brackets", "underscore", "cds"}'
         raise TypeError(msg)
     else:

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -341,7 +341,7 @@ def flat_inference_data_to_dict(
     data : obj
         Any object that can be converted to an az.InferenceData object
         Refer to documentation of az.convert_to_inference_data for details
-    var_names : list of variable names, optional
+    var_names : str or list of str, optional
         Variables to be processed, if None all variables are processed.
     groups : str or list of str, optional
         Select groups for CDS. Default groups are {"posterior_groups", "prior_groups"}
@@ -349,7 +349,7 @@ def flat_inference_data_to_dict(
             - prior_groups: prior, posterior_predictive, sample_stats_prior
     ignore_groups : str or list of str, optional
         Ignore specific groups from CDS.
-    dimension : list, optional
+    dimension : str, or list of str, optional
         Select dimensions along to slice the data. By default uses ("chain", "draw").
     group_info : bool
         Add group info for `var_name_format`

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -346,7 +346,7 @@ def flat_inference_data_to_dict(
     groups : str or list of str, optional
         Select groups for CDS. Default groups are {"posterior_groups", "prior_groups"}
             - posterior_groups: posterior, posterior_predictive, sample_stats
-            - prior_groups: prior, posterior_predictive, sample_stats_prior
+            - prior_groups: prior, prior_predictive, sample_stats_prior
     ignore_groups : str or list of str, optional
         Ignore specific groups from CDS.
     dimension : str, or list of str, optional

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-nested-blocks
 """General utilities."""
 import importlib
 import functools
@@ -353,7 +354,8 @@ def flat_inference_data_to_dict(
     group_info : bool
         Add group info for `var_name_format`
     var_name_format : str or tuple of tuple of string, optional
-        Select column name format for non-scalar input. Predefined {"brackets", "underscore", "cds"}
+        Select column name format for non-scalar input.
+        Predefined options are {"brackets", "underscore", "cds"}
             "brackets":
                 - add_group_info == False: theta[0,0]
                 - add_group_info == True: theta_posterior[0,0]
@@ -366,7 +368,9 @@ def flat_inference_data_to_dict(
             tuple:
                 Structure:
                     tuple: (dim_info, group_info)
-                        dim_info: (str: `.join` separator, str: dim_separator_start, str: dim_separator_end)
+                        dim_info: (str: `.join` separator,
+                                   str: dim_separator_start,
+                                   str: dim_separator_end)
                         group_info: (str: group separator start, str: group separator end)
                 Example: ((",", "[", "]"), "_", "")
                     - add_group_info == False: theta[0,0]

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -376,7 +376,7 @@ def flat_inference_data_to_dict(
                     - add_group_info == False: theta[0,0]
                     - add_group_info == True: theta_posterior[0,0]
     index_origin : int, optional
-        Start parameter indeces from `index_origin`. Either 0 or 1.
+        Start parameter indices from `index_origin`. Either 0 or 1.
 
     Returns
     -------

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -437,6 +437,7 @@ def flat_inference_data_to_dict(
         if hasattr(data, group):
             group_data = getattr(data, group).stack(stack_dimension=dimensions)
             for var_name, var in group_data.data_vars.items():
+                var_values = var.values
                 if var_names is not None and var_name not in var_names:
                     continue
                 for dim_name in dimensions:
@@ -485,5 +486,5 @@ def flat_inference_data_to_dict(
                                 dim_separator_end=dim_separator_end,
                             )
 
-                        data_dict[var_name_dim] = var[loc].values
+                        data_dict[var_name_dim] = var_values[loc]
     return data_dict

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -6,6 +6,8 @@ import numpy as np
 from numpy import newaxis
 import matplotlib.pyplot as plt
 
+from .rcparams import rcParams
+
 
 def _var_names(var_names, data):
     """Handle var_names input across arviz.
@@ -320,3 +322,151 @@ def expand_dims(x):
 def full(shape, x, dtype=None):
     """Jitting numpy full."""
     return np.full(shape, x, dtype=dtype)
+
+
+def inference_data_to_dict(
+    data,
+    var_names=None,
+    groups=None,
+    dimensions=None,
+    add_group_info=False,
+    var_name_format=None,
+    index_origin=None,
+):
+    """Transform data to dictionary.
+
+    Parameters
+    ----------
+    data : obj
+        Any object that can be converted to an az.InferenceData object
+        Refer to documentation of az.convert_to_inference_data for details
+    var_names : list of variable names, optional
+        Variables to be processed, if None all variables are processed.
+    groups : str or list of str, optional
+        Select groups for CDS. Default groups are {"posterior_groups", "prior_groups"}
+            - posterior_groups: posterior, posterior_predictive, sample_stats
+            - prior_groups: prior, posterior_predictive, sample_stats_prior
+    ignore_groups : str or list of str, optional
+        Ignore specific groups from CDS.
+    dimension : list, optional
+        Select dimensions along to slice the data. By default uses ("chain", "draw").
+    add_group_info : bool
+        Add group info for `var_name_format`
+    var_name_format : str or tuple of tuple of string, optional
+        Select column name format for non-scalar input. Predefined {"brackets", "underscore", "cds"}
+            "brackets":
+                - add_group_info == False: theta[0,0]
+                - add_group_info == True: theta_posterior[0,0]
+            "underscore":
+                - add_group_info == False: theta_0_0
+                - add_group_info == True: theta_posterior_0_0_
+            "cds":
+                - add_group_info == False: theta_ARVIZ_CDS_SELECTION_0_0
+                - add_group_info == True: theta_ARVIZ_GROUP_posterior__ARVIZ_CDS_SELECTION_0_0
+            tuple:
+                Structure:
+                    tuple: (dim_info, group_info)
+                        dim_info: (str: `.join` separator, str: dim_separator_start, str: dim_separator_end)
+                        group_info: (str: group separator start, str: group separator end)
+                Example: ((",", "[", "]"), "_", "")
+                    - add_group_info == False: theta[0,0]
+                    - add_group_info == True: theta_posterior[0,0]
+    index_origin : int, optional
+        Start parameter indeces from `index_origin`. Either 0 or 1.
+
+    Returns
+    -------
+    dict
+    """
+    from .data import convert_to_inference_data
+
+    data = convert_to_inference_data(data)
+
+    if groups is None:
+        groups = ["posterior", "posterior_predictive", "sample_stats"]
+    elif isinstance(groups, str):
+        if groups.lower() == "posterior_groups":
+            groups = ["posterior", "posterior_predictive", "sample_stats"]
+        elif groups.lower() == "prior_groups":
+            groups = ["prior", "prior_predictive", "sample_stats_prior"]
+        else:
+            raise TypeError("Valid predefined groups are {posterior_groups, prior_groups}")
+
+    if dimensions is None:
+        dimensions = "chain", "draw"
+
+    if var_name_format is None:
+        var_name_format = "brackets"
+
+    var_name_format = var_name_format.lower()
+    if var_name_format == "brackets":
+        dim_join_separator, dim_separator_start, dim_separator_end = ",", "[", "]"
+        group_separator_start, group_separator_end = "_", ""
+    elif var_name_format == "underscore":
+        dim_join_separator, dim_separator_start, dim_separator_end = "_", "_", ""
+        group_separator_start, group_separator_end = "_", ""
+    elif var_name_format == "cds":
+        dim_join_separator, dim_separator_start, dim_separator_end = (
+            "_",
+            "_ARVIZ_CDS_SELECTION_",
+            "",
+        )
+        group_separator_start, group_separator_end = "_ARVIZ_GROUP_", ""
+    elif isinstance(str, var_name_format):
+        raise TypeError('Invalid predefined format. Select one {"brackets", "underscore", "cds"}')
+    else:
+        (
+            (dim_join_separator, dim_separator_start, dim_separator_end),
+            (group_separator_start, group_separator_end),
+        ) = var_name_format
+
+    if index_origin is None:
+        index_origin = rcParams["data.index_origin"]
+
+    data_dict = {}
+    for group in groups:
+        if hasattr(data, group):
+            group_data = getattr(data, group).stack(samples=dimensions)
+            for var_name, var in group_data.data_vars.items():
+                if var_names is not None and var_name not in var_names:
+                    continue
+                for dim_name in dimensions:
+                    if dim_name not in data_dict:
+                        data_dict[dim_name] = var.coords.get(dim_name).values
+                if len(var.shape) == 1:
+                    if add_group_info:
+                        var_name_dim = "{var_name}{group_separator_start}{group}{group_separator_end}".format(
+                            var_name=var_name,
+                            group_separator_start=group_separator_start,
+                            group=group,
+                            group_separator_end=group_separator_end,
+                        )
+                    else:
+                        var_name_dim = "{var_name}".format(var_name=var_name)
+                    data_dict[var_name_dim] = var.values
+                else:
+                    for loc in np.ndindex(var.shape[:-1]):
+                        if add_group_info:
+                            var_name_dim = "{var_name}{group_separator_start}{group}{group_separator_end}{dim_separator_start}{dim_join}{dim_separator_end}".format(
+                                var_name=var_name,
+                                group_separator_start=group_separator_start,
+                                group=group,
+                                group_separator_end=group_separator_end,
+                                dim_separator_start=dim_separator_start,
+                                dim_join=dim_join_separator.join(
+                                    (str(item + index_origin) for item in loc)
+                                ),
+                                dim_separator_end=dim_separator_end,
+                            )
+                        else:
+                            var_name_dim = "{var_name}{dim_separator_start}{dim_join}{dim_separator_end}".format(
+                                var_name=var_name,
+                                dim_separator_start=dim_separator_start,
+                                dim_join=dim_join_separator.join(
+                                    (str(item + index_origin) for item in loc)
+                                ),
+                                dim_separator_end=dim_separator_end,
+                            )
+
+                        data_dict[var_name_dim] = var[loc].values
+    return data_dict


### PR DESCRIPTION
This PR creates ColumnDataSource from the inference_data.

utils:
   function to transform inference data groups to dictionary (flattened against selected dimensions)

backends:
    function to create CDS object. Data as DataFrame.

The main idea is to create CDS either from `posterior_groups` or `prior_groups` so a user can plot multiple bokeh plots with the same CDS, which enables linked select.