### PR TITLE
Populate InferenceData with out-of-sample prediction results from PyMC3 predictive samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.x.x Unreleased
 
 ### New features
-
+* Add out-of-sample predictions (`predictions` and  `predictions_constant_data` groups) to pymc3 translations. (#983)
 
 ### Maintenance and fixes
 * Fixed bug in extracting prior samples for cmdstanpy. (#979) 

--- a/arviz/data/__init__.py
+++ b/arviz/data/__init__.py
@@ -7,7 +7,7 @@ from .converters import convert_to_dataset, convert_to_inference_data
 from .io_cmdstan import from_cmdstan
 from .io_cmdstanpy import from_cmdstanpy
 from .io_dict import from_dict
-from .io_pymc3 import from_pymc3
+from .io_pymc3 import from_pymc3, predictions_from_pymc3
 from .io_pystan import from_pystan
 from .io_emcee import from_emcee
 from .io_pyro import from_pyro

--- a/arviz/data/__init__.py
+++ b/arviz/data/__init__.py
@@ -7,7 +7,7 @@ from .converters import convert_to_dataset, convert_to_inference_data
 from .io_cmdstan import from_cmdstan
 from .io_cmdstanpy import from_cmdstanpy
 from .io_dict import from_dict
-from .io_pymc3 import from_pymc3, predictions_from_pymc3
+from .io_pymc3 import from_pymc3, from_pymc3_predictions
 from .io_pystan import from_pystan
 from .io_emcee import from_emcee
 from .io_pyro import from_pyro
@@ -25,7 +25,7 @@ __all__ = [
     "convert_to_dataset",
     "convert_to_inference_data",
     "from_pymc3",
-    "predictions_from_pymc3",
+    "from_pymc3_predictions",
     "from_pystan",
     "from_emcee",
     "from_cmdstan",

--- a/arviz/data/__init__.py
+++ b/arviz/data/__init__.py
@@ -25,6 +25,7 @@ __all__ = [
     "convert_to_dataset",
     "convert_to_inference_data",
     "from_pymc3",
+    "predictions_from_pymc3",
     "from_pystan",
     "from_emcee",
     "from_cmdstan",

--- a/arviz/data/base.py
+++ b/arviz/data/base.py
@@ -18,7 +18,7 @@ class requires:  # pylint: disable=invalid-name
     If the decorator is called various times on the same function with different
     attributes, it will return None if one of them is missing. If instead a list
     of attributes is passed, it will return None if all attributes in the list are
-    missing. Both functionalities can be combines as desired.
+    missing. Both functionalities can be combined as desired.
     """
 
     def __init__(self, *props):

--- a/arviz/data/inference_data.pyi
+++ b/arviz/data/inference_data.pyi
@@ -1,4 +1,5 @@
 from typing import Optional, List, overload, Iterable, TYPE_CHECKING
+
 if TYPE_CHECKING:
     from typing_extensions import Literal
 import xarray as xr
@@ -22,7 +23,10 @@ class InferenceData:
     @staticmethod
     def from_netcdf(filename: str) -> "InferenceData": ...
     def to_netcdf(
-        self, filename: str, compress: bool = True, groups: Optional[List[str]] = None # pylint: disable=line-too-long
+        self,
+        filename: str,
+        compress: bool = True,
+        groups: Optional[List[str]] = None,  # pylint: disable=line-too-long
     ) -> str: ...
     def sel(
         self, inplace: bool = False, chain_prior: bool = False, **kwargs

--- a/arviz/data/inference_data.pyi
+++ b/arviz/data/inference_data.pyi
@@ -1,0 +1,33 @@
+from typing import Optional, List
+import xarray as xr
+
+class InferenceData:
+    posterior: Optional[xr.Dataset]
+    observations: Optional[xr.Dataset]
+    constant_data: Optional[xr.Dataset]
+    prior: Optional[xr.Dataset]
+    prior_predictive: Optional[xr.Dataset]
+    posterior_predictive: Optional[xr.Dataset]
+    predictions: Optional[xr.Dataset]
+    predictions_constant_data: Optional[xr.Dataset]
+    def __init__(self, **kwargs): ...
+    def __repr__(self) -> str: ...
+    def __delattr__(self, group: str) -> None: ...
+    def __add__(self, other: "InferenceData"): ...
+    @staticmethod
+    def from_netcdf(filename: str) -> "InferenceData": ...
+    def to_netcdf(
+        self, filename: str, compress: bool = True, groups: Optional[List[str]] = None
+    ) -> str: ...
+    def sel(
+        self, inplace: bool = False, chain_prior: bool = False, **kwargs
+    ) -> "InferenceData": ...
+
+# Note, should put an overload here, based on the value of `inplace`
+def concat(
+    *args,
+    dim: Optional[str] = None,
+    copy: bool = True,
+    inplace: bool = False,
+    reset_dim: bool = True,
+) -> Optional[InferenceData]: ...

--- a/arviz/data/inference_data.pyi
+++ b/arviz/data/inference_data.pyi
@@ -1,5 +1,10 @@
-from typing import Optional, List
+from typing import Optional, List, overload, Iterable, TYPE_CHECKING
+if TYPE_CHECKING:
+    from typing_extensions import Literal
 import xarray as xr
+
+# pylint has some problems with stub files...
+# pylint: disable=unused-argument, multiple-statements
 
 class InferenceData:
     posterior: Optional[xr.Dataset]
@@ -17,16 +22,51 @@ class InferenceData:
     @staticmethod
     def from_netcdf(filename: str) -> "InferenceData": ...
     def to_netcdf(
-        self, filename: str, compress: bool = True, groups: Optional[List[str]] = None
+        self, filename: str, compress: bool = True, groups: Optional[List[str]] = None # pylint: disable=line-too-long
     ) -> str: ...
     def sel(
         self, inplace: bool = False, chain_prior: bool = False, **kwargs
     ) -> "InferenceData": ...
 
-# Note, should put an overload here, based on the value of `inplace`
+@overload
 def concat(
     *args,
     dim: Optional[str] = None,
+    copy: bool = True,
+    inplace: "Literal[True]",
+    reset_dim: bool = True,
+) -> None: ...
+@overload
+def concat(
+    *args,
+    dim: Optional[str] = None,
+    copy: bool = True,
+    inplace: "Literal[False]",
+    reset_dim: bool = True,
+) -> InferenceData: ...
+@overload
+def concat(
+    ids: Iterable[InferenceData],
+    dim: Optional[str] = None,
+    *,
+    copy: bool = True,
+    inplace: "Literal[False]",
+    reset_dim: bool = True,
+) -> InferenceData: ...
+@overload
+def concat(
+    ids: Iterable[InferenceData],
+    dim: Optional[str] = None,
+    *,
+    copy: bool = True,
+    inplace: "Literal[True]",
+    reset_dim: bool = True,
+) -> None: ...
+@overload
+def concat(
+    ids: Iterable[InferenceData],
+    dim: Optional[str] = None,
+    *,
     copy: bool = True,
     inplace: bool = False,
     reset_dim: bool = True,

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -10,8 +10,12 @@ from .base import requires, dict_to_dataset, generate_dims_coords, make_attrs
 
 if TYPE_CHECKING:
     import pymc3 as pm
+    from pymc3 import MultiTrace, Model
     import theano
     from typing import Set
+else:
+    MultiTrace = Any
+    Model = Any
 
 _log = logging.getLogger(__name__)
 
@@ -270,6 +274,7 @@ class PyMC3Converter:  # pylint: disable=too-many-instance-attributes
                 constant_data_vars[var.name] = var
 
         def is_data(name, var) -> bool:
+            assert self.model is not None
             return var not in self.model.deterministics and var not in self.model.observed_RVs \
                and var not in self.model.free_RVs and \
                (self.observations is None or name not in self.observations)

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -410,7 +410,9 @@ def predictions_from_pymc3(
     if idata_orig is None:
         return new_idata
     if inplace:
-        return cast(InferenceData, concat([idata_orig, new_idata], dim=None, inplace=True))
+        cast(InferenceData, concat([idata_orig, new_idata], dim=None, inplace=True))
+        return idata_orig
     # if we are not returning in place, then merge the old groups into the new inference
     # data and return that.
-    return cast(InferenceData, concat([new_idata, idata_orig], dim=None, copy=True, inplace=True))
+    concat([new_idata, idata_orig], dim=None, copy=True, inplace=True)
+    return new_idata

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -27,6 +27,7 @@ Dims = Dict[str, List[str]]
 # random variable object ...
 Var = Any  # pylint: disable=invalid-name
 
+
 def _monkey_patch_pymc3(pm: ModuleType) -> None:  # pylint: disable=invalid-name
     assert pm.__name__ == "pymc3"
 
@@ -34,8 +35,8 @@ def _monkey_patch_pymc3(pm: ModuleType) -> None:  # pylint: disable=invalid-name
         """Use object identity for MultiObservedRV equality."""
         return self is other
 
-    if tuple([int(x) for x in pm.__version__.split(".")]) < (3, 9): # type: ignore
-        pm.model.MultiObservedRV.__eq__ = fixed_eq # type: ignore
+    if tuple([int(x) for x in pm.__version__.split(".")]) < (3, 9):  # type: ignore
+        pm.model.MultiObservedRV.__eq__ = fixed_eq  # type: ignore
 
 
 class PyMC3Converter:  # pylint: disable=too-many-instance-attributes

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -312,21 +312,23 @@ class PyMC3Converter: # pylint: disable=too-many-instance-attributes
     def to_inference_data(self):
         """Convert all available data to an InferenceData object.
 
-        Note that if groups can not be created (i.e., there is no `trace`, so
+        Note that if groups can not be created (e.g., there is no `trace`, so
         the `posterior` and `sample_stats` can not be extracted), then the InferenceData
         will not have those groups.
         """
-        return InferenceData(
-            **{
+        id_dict = {
                 "posterior": self.posterior_to_xarray(),
                 "sample_stats": self.sample_stats_to_xarray(),
                 "posterior_predictive": self.posterior_predictive_to_xarray(),
                 "predictions": self.predictions_to_xarray(),
                 **self.priors_to_xarray(),
                 "observed_data": self.observed_data_to_xarray(),
-                "constant_data": self.constant_data_to_xarray(),
             }
-        )
+        if self.predictions:
+            id_dict["predictions_constant_data"] = self.constant_data_to_xarray()
+        else:
+            id_dict["constant_data"] = self.constant_data_to_xarray()
+        return InferenceData(**id_dict)
 
 
 def from_pymc3(

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -355,7 +355,7 @@ def from_pymc3(
 
 ### Later I could have this return ``None`` if the ``idata_orig`` argument is supplied.  But
 ### perhaps we should have an inplace argument?
-def predictions_from_pymc3(
+def from_pymc3_predictions(
     predictions,
     posterior_trace: Optional[MultiTrace] = None,
     model: Optional[Model] = None,

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -171,7 +171,6 @@ class PyMC3Converter:  # pylint: disable=too-many-instance-attributes
         """Extract sample_stats from PyMC3 trace."""
         rename_key = {"model_logp": "lp"}
         data = {}
-        __import__("pdb").set_trace()
         for stat in self.trace.stat_names:
             name = rename_key.get(stat, stat)
             data[name] = np.array(self.trace.get_sampler_stats(stat, combine=False))

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -10,12 +10,12 @@ from .base import requires, dict_to_dataset, generate_dims_coords, make_attrs
 
 if TYPE_CHECKING:
     import pymc3 as pm
-    from pymc3 import MultiTrace, Model # pylint: disable=invalid-name
+    from pymc3 import MultiTrace, Model  # pylint: disable=invalid-name
     import theano
     from typing import Set
 else:
-    MultiTrace = Any # pylint: disable=invalid-name
-    Model = Any # pylint: disable=invalid-name
+    MultiTrace = Any  # pylint: disable=invalid-name
+    Model = Any  # pylint: disable=invalid-name
 
 ___all__ = [""]
 

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -10,12 +10,12 @@ from .base import requires, dict_to_dataset, generate_dims_coords, make_attrs
 
 if TYPE_CHECKING:
     import pymc3 as pm
-    from pymc3 import MultiTrace, Model
+    from pymc3 import MultiTrace, Model # pylint: disable=invalid-name
     import theano
     from typing import Set
 else:
-    MultiTrace = Any
-    Model = Any
+    MultiTrace = Any # pylint: disable=invalid-name
+    Model = Any # pylint: disable=invalid-name
 
 ___all__ = [""]
 

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -1,6 +1,6 @@
 """PyMC3-specific conversion code."""
 import logging
-from typing import Dict, List, Any, Optional, TYPE_CHECKING, cast
+from typing import Dict, List, Any, Optional, TYPE_CHECKING
 
 import numpy as np
 import xarray as xr

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -1,6 +1,6 @@
 """PyMC3-specific conversion code."""
 import logging
-from typing import Dict, List, Any, Optional, TYPE_CHECKING
+from typing import Dict, List, Any, Optional, TYPE_CHECKING, Set
 
 import numpy as np
 import xarray as xr
@@ -71,11 +71,19 @@ class PyMC3Converter:
             # if you have a posterior_predictive built with keep_dims,
             # you'll lose here, but there's nothing I can do about that.
             self.nchains = 1
-            aelem = (
-                arbitrary_element(prior)
-                if posterior_predictive is None
-                else arbitrary_element(posterior_predictive)
-            )
+            get_from = None
+            if predictions is not None:
+                get_from = predictions
+            elif prior is not None:
+                get_from = prior
+            elif posterior_predictive is not None:
+                get_from = posterior_predictive
+            if get_from is None:
+                # pylint: disable=line-too-long
+                raise ValueError("""When constructing InferenceData must have at least
+                                    one of trace, prior, posterior_predictive or predictions.""")
+
+            aelem = arbitrary_element(get_from)
             self.ndraws = aelem.shape[0]
 
         self.coords = coords
@@ -102,7 +110,9 @@ class PyMC3Converter:
 
         Return None if there is not exactly 1 observed random variable.
         """
-        if len(self.model.observed_RVs) != 1:
+        # If we have predictions, then we have a thinned trace which does not
+        # support extracting a log likelihood.
+        if len(self.model.observed_RVs) != 1 or self.predictions:
             return None, None
         else:
             if self.dims is not None:
@@ -158,13 +168,9 @@ class PyMC3Converter:
 
         return dict_to_dataset(data, library=self.pymc3, dims=dims, coords=self.coords)
 
-    @requires(["posterior_predictive", "predictions"])
-    def posterior_predictive_to_xarray(self, raw=None):
-        """Convert posterior_predictive samples to xarray."""
-        if raw is None:
-            raw = self.posterior_predictive
+    def translate_posterior_predictive_dict_to_xarray(self, dct):
         data = {}
-        for k, ary in self.posterior_predictive.items():
+        for k, ary in dct.items():
             shape = ary.shape
             if shape[0] == self.nchains and shape[1] == self.ndraws:
                 data[k] = ary
@@ -178,24 +184,16 @@ class PyMC3Converter:
                 )
         return dict_to_dataset(data, library=self.pymc3, coords=self.coords, dims=self.dims)
 
-    @requires("predictions")
-    def predictions_to_xarray(self):
-        """Convert out of sample predictive samples to xarray."""
-        data = {}
-        for k, ary in self.predictions.items():
-            shape = ary.shape
-            if shape[0] == self.nchains and shape[1] == self.ndraws:
-                data[k] = ary
-            elif shape[0] == self.nchains * self.ndraws:
-                data[k] = ary.reshape((self.nchains, self.ndraws, *shape[1:]))
-            else:
-                data[k] = utils.expand_dims(ary)
-                _log.warning(
-                    "predictive variable %s's shape not compatible with number of chains and draws. "
-                    "This can mean that some draws or even whole chains are not represented.", k
-                )
-        return dict_to_dataset(data, library=self.pymc3, coords=self.coords, dims=self.dims)
 
+    @requires(["posterior_predictive"])
+    def posterior_predictive_to_xarray(self):
+        """Convert posterior_predictive samples to xarray."""
+        return self.translate_posterior_predictive_dict_to_xarray(self.posterior_predictive)
+
+    @requires(["predictions"])
+    def predictions_to_xarray(self):
+        """Convert predictions (out of sample predictions) to xarray."""
+        return self.translate_posterior_predictive_dict_to_xarray(self.predictions)
 
     def priors_to_xarray(self):
         """Convert prior samples (and if possible prior predictive too) to xarray."""
@@ -255,22 +253,34 @@ class PyMC3Converter:
         # if both predictions AND trace are supplied, then the trace should be the
         # *thinned* trace used in prediction and NOT the full posterior trace. Hence we
         # give precedence here to checking the predictions.
+        model_vars: Set[str]
         if self.predictions is not None:
-            model_vars = self.pymc3.util.get_default_varnames(
+            model_vars = set(self.pymc3.util.get_default_varnames(
                 self.predictions.keys(),
                 include_transformed=True
-            )
-        elif self.trace is not None:
-            model_vars = self.pymc3.util.get_default_varnames(  # pylint: disable=no-member
-                self.trace.varnames, include_transformed=True
-            )
+            ))
+        else:
+            model_vars = set()
+        if self.trace is not None:
+            model_vars = model_vars | \
+                         set(self.pymc3.util.get_default_varnames(  # pylint: disable=no-member
+                             self.trace.varnames, include_transformed=True
+                         ))
         if self.observations is not None:
-            model_vars.extend(
-                [obs.name for obs in self.observations.values() if hasattr(obs, "name")]
-            )
-            model_vars.extend(self.observations.keys())
+            model_vars = model_vars | \
+                         {obs.name for obs in self.observations.values() if hasattr(obs, "name")} | \
+                         set(self.observations.keys())
+
+        # this check is necessary in filtering constant variables because I found that some still
+        # slipped through, notably the bounding transformed variables introduced by bounded and
+        # truncated RVs in PyMC3.
+        def untransformed_name(name: str) -> str:
+            if self.pymc3.util.is_transformed_name(name):
+                return self.pymc3.util.get_untransformed_name(name)
+            return name
+
         constant_data_vars = {
-            name: var for name, var in self.model.named_vars.items() if name not in model_vars
+            name: var for name, var in self.model.named_vars.items() if untransformed_name(name) not in model_vars
         }
         if not constant_data_vars:
             return None
@@ -289,7 +299,10 @@ class PyMC3Converter:
             )
             # filter coords based on the dims
             coords = {key: xr.IndexVariable((key,), data=coords[key]) for key in val_dims}
-            constant_data[name] = xr.DataArray(vals, dims=val_dims, coords=coords)
+            try:
+                constant_data[name] = xr.DataArray(vals, dims=val_dims, coords=coords)
+            except ValueError as e:
+                raise ValueError("Error translating constant_data variable %s: %s"%(name, e))
         return xr.Dataset(data_vars=constant_data, attrs=make_attrs(library=self.pymc3))
 
     def to_inference_data(self):
@@ -304,7 +317,7 @@ class PyMC3Converter:
                 "posterior": self.posterior_to_xarray(),
                 "sample_stats": self.sample_stats_to_xarray(),
                 "posterior_predictive": self.posterior_predictive_to_xarray(),
-                "predictions": self.posterior_predictive_to_xarray(self.predictions),
+                "predictions": self.predictions_to_xarray(),
                 **self.priors_to_xarray(),
                 "observed_data": self.observed_data_to_xarray(),
                 "constant_data": self.constant_data_to_xarray(),
@@ -325,3 +338,24 @@ def from_pymc3(
         dims=dims,
         model=model,
     ).to_inference_data()
+
+def predictions_from_pymc3(predictions, posterior_trace, model, coords=None, dims=None) -> InferenceData:
+    """Specially tailored version of ``from_pymc3`` for handling out-of-sample predictions.
+    Parameters
+    ~~~~~~~~~~
+    predictions: Dict[str, np.ndarray]
+        The predictions are the return value of ``pymc3.sample_posterior_predictive``, a dictionary of 
+        strings (variable names) to numpy ndarrays (draws).
+    posterior_trace: pm.MultiTrace
+        This should be a trace that has been thinned appropriately for ``pymc3.sample_posterior_predictive``.
+        Specifically, any variable whose shape is a deterministic function of the shape of any predictor
+        (explanatory, independent, etc.) variables must be *removed* from this trace.
+    model: pymc3.Model
+        This argument is *not* optional, unlike in conventional uses of ``from_pymc3``.  The reason is
+        that the posterior_trace argument is likely to supply and incorrect value of model.
+    coords: Dict[str, array-like[Any]]
+        Coordinates for the variables.  Map from coordinate names to coordinate values.
+    dims: Dict[str, array-like[str]]
+        Map from variable name to ordered set of coordinate names.
+    """
+    return_from_pymc3(trace=posterior_trace, predictions=predictions, model=model, coords=coords, dims=dims)

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -17,7 +17,8 @@ _log = logging.getLogger(__name__)
 
 Coords = Dict[str, List[Any]]
 Dims = Dict[str, List[str]]
-Var = Any # random variable object ...
+# random variable object ...
+Var = Any # pylint: disable=invalid-name
 
 # pylint: disable=line-too-long
 
@@ -99,12 +100,14 @@ class PyMC3Converter:  # pylint: disable=too-many-instance-attributes
         self.observations = self.find_observations()
 
     def find_observations(self) -> Optional[Dict[str, Var]]:
+        """If there are observations available, return them as a dictionary."""
         has_observations = False
         if self.trace is not None:
             assert self.model is not None, "Cannot identify observations without PymC3 model"
             if any((hasattr(obs, "observations") for obs in self.model.observed_RVs)):
                 has_observations = True
         if has_observations:
+            assert self.model is not None
             return {obs.name: obs.observations for obs in self.model.observed_RVs}
         return None
 
@@ -289,7 +292,7 @@ class PyMC3Converter:  # pylint: disable=too-many-instance-attributes
                 vals = vals.get_value()
             # this might be a Deterministic, and must be evaluated
             elif hasattr(self.model[name], 'eval'):
-                    vals = self.model[name].eval()
+                vals = self.model[name].eval()
             vals = np.atleast_1d(vals)
             val_dims = dims.get(name)
             val_dims, coords = generate_dims_coords(

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -253,7 +253,7 @@ class PyMC3Converter:
         # if both predictions AND trace are supplied, then the trace should be the
         # *thinned* trace used in prediction and NOT the full posterior trace. Hence we
         # give precedence here to checking the predictions.
-        model_vars: Set[str]
+        model_vars = None             # type: Set[str]
         if self.predictions is not None:
             model_vars = set(self.pymc3.util.get_default_varnames(
                 self.predictions.keys(),

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -348,10 +348,10 @@ def from_pymc3(
 
 def predictions_from_pymc3(predictions, posterior_trace, model,
                            coords=None, dims=None) -> InferenceData:
-    """Special version of ``from_pymc3`` forout-of-sample predictions.
+    """Translate out-of-sample predictions into ``InferenceData`` using ``from_pymc3``.
 
     Parameters
-    ~~~~~~~~~~
+    ----------
     predictions: Dict[str, np.ndarray]
         The predictions are the return value of ``pymc3.sample_posterior_predictive``,
         a dictionary of strings (variable names) to numpy ndarrays (draws).
@@ -370,7 +370,7 @@ def predictions_from_pymc3(predictions, posterior_trace, model,
         Map from variable name to ordered set of coordinate names.
 
     Returns
-    ~~~~~~~
+    -------
     InferenceData
     """
     return from_pymc3(trace=posterior_trace, predictions=predictions, model=model,

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -393,6 +393,7 @@ def predictions_from_pymc3(
     inplace: boolean, optional
         If idata_orig is supplied and inplace is True, merge the predictions into idata_orig,
         rather than returning a fresh InferenceData object.
+
     Returns
     -------
     InferenceData:

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -27,9 +27,6 @@ Dims = Dict[str, List[str]]
 # random variable object ...
 Var = Any  # pylint: disable=invalid-name
 
-# pylint: disable=line-too-long
-
-
 def _monkey_patch_pymc3(pm: ModuleType) -> None:  # pylint: disable=invalid-name
     assert pm.__name__ == "pymc3"
 
@@ -37,8 +34,8 @@ def _monkey_patch_pymc3(pm: ModuleType) -> None:  # pylint: disable=invalid-name
         """Use object identity for MultiObservedRV equality."""
         return self is other
 
-    if tuple([int(x) for x in pm.__version__.split(".")]) < (3, 9):
-        pm.model.MultiObservedRV.__eq__ = fixed_eq
+    if tuple([int(x) for x in pm.__version__.split(".")]) < (3, 9): # type: ignore
+        pm.model.MultiObservedRV.__eq__ = fixed_eq # type: ignore
 
 
 class PyMC3Converter:  # pylint: disable=too-many-instance-attributes

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -287,6 +287,9 @@ class PyMC3Converter:  # pylint: disable=too-many-instance-attributes
         for name, vals in constant_data_vars.items():
             if hasattr(vals, "get_value"):
                 vals = vals.get_value()
+            # this might be a Deterministic, and must be evaluated
+            elif hasattr(self.model[name], 'eval'):
+                    vals = self.model[name].eval()
             vals = np.atleast_1d(vals)
             val_dims = dims.get(name)
             val_dims, coords = generate_dims_coords(

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -17,16 +17,17 @@ else:
     MultiTrace = Any
     Model = Any
 
-___all__ = ['']
+___all__ = [""]
 
 _log = logging.getLogger(__name__)
 
 Coords = Dict[str, List[Any]]
 Dims = Dict[str, List[str]]
 # random variable object ...
-Var = Any # pylint: disable=invalid-name
+Var = Any  # pylint: disable=invalid-name
 
 # pylint: disable=line-too-long
+
 
 class PyMC3Converter:  # pylint: disable=too-many-instance-attributes
     """Encapsulate PyMC3 specific logic."""
@@ -268,7 +269,7 @@ class PyMC3Converter:  # pylint: disable=too-many-instance-attributes
         """Convert constant data to xarray."""
         # For constant data, we are concerned only with deterministics and data.
         # The constant data vars must be either pm.Data (TensorSharedVariable) or pm.Deterministic
-        constant_data_vars = {} # type: Dict[str, Var]
+        constant_data_vars = {}  # type: Dict[str, Var]
         for var in self.model.deterministics:
             ancestors = self.theano.tensor.gof.graph.ancestors(var.owner.inputs)
             # no dependency on a random variable
@@ -277,9 +278,12 @@ class PyMC3Converter:  # pylint: disable=too-many-instance-attributes
 
         def is_data(name, var) -> bool:
             assert self.model is not None
-            return var not in self.model.deterministics and var not in self.model.observed_RVs \
-               and var not in self.model.free_RVs and \
-               (self.observations is None or name not in self.observations)
+            return (
+                var not in self.model.deterministics
+                and var not in self.model.observed_RVs
+                and var not in self.model.free_RVs
+                and (self.observations is None or name not in self.observations)
+            )
 
         # I don't know how to find pm.Data, except that they are named variables that aren't
         # observed or free RVs, nor are they deterministics, and then we eliminate observations.
@@ -298,7 +302,7 @@ class PyMC3Converter:  # pylint: disable=too-many-instance-attributes
             if hasattr(vals, "get_value"):
                 vals = vals.get_value()
             # this might be a Deterministic, and must be evaluated
-            elif hasattr(self.model[name], 'eval'):
+            elif hasattr(self.model[name], "eval"):
                 vals = self.model[name].eval()
             vals = np.atleast_1d(vals)
             val_dims = dims.get(name)
@@ -336,13 +340,7 @@ class PyMC3Converter:  # pylint: disable=too-many-instance-attributes
 
 
 def from_pymc3(
-    trace=None,
-    *,
-    prior=None,
-    posterior_predictive=None,
-    coords=None,
-    dims=None,
-    model=None
+    trace=None, *, prior=None, posterior_predictive=None, coords=None, dims=None, model=None
 ):
     """Convert pymc3 data into an InferenceData object."""
     return PyMC3Converter(
@@ -358,13 +356,13 @@ def from_pymc3(
 ### Later I could have this return ``None`` if the ``idata_orig`` argument is supplied.  But
 ### perhaps we should have an inplace argument?
 def predictions_from_pymc3(
-        predictions,
-        posterior_trace: Optional[MultiTrace]=None,
-        model: Optional[Model]=None,
-        coords=None,
-        dims=None,
-        idata_orig: Optional[InferenceData]=None,
-        inplace: bool=False
+    predictions,
+    posterior_trace: Optional[MultiTrace] = None,
+    model: Optional[Model] = None,
+    coords=None,
+    dims=None,
+    idata_orig: Optional[InferenceData] = None,
+    inplace: bool = False,
 ) -> InferenceData:
     """Translate out-of-sample predictions into ``InferenceData``.
 
@@ -400,8 +398,12 @@ def predictions_from_pymc3(
         May be modified ``idata_orig``.
     """
     if inplace and not idata_orig:
-        raise ValueError(("Do not pass True for inplace unless passing"
-                          "an existing InferenceData as idata_orig"))
+        raise ValueError(
+            (
+                "Do not pass True for inplace unless passing"
+                "an existing InferenceData as idata_orig"
+            )
+        )
     new_idata = PyMC3Converter(
         trace=posterior_trace, predictions=predictions, model=model, coords=coords, dims=dims
     ).to_inference_data()

--- a/arviz/tests/test_data_pymc.py
+++ b/arviz/tests/test_data_pymc.py
@@ -3,6 +3,7 @@ import numpy as np
 from numpy import ma
 import pymc3 as pm
 import pytest
+from sys import version_info
 
 from arviz import from_pymc3
 from .helpers import (  # pylint: disable=unused-import
@@ -119,6 +120,7 @@ class TestDataPyMC3:
         assert not fails
         assert not hasattr(inference_data.sample_stats, "log_likelihood")
 
+    @pytest.mark.skipif(version_info < (3,6), reason="Requires updated PyMC3, which needs Python 3.6")
     def test_multiple_observed_rv_without_observations(self):
         with pm.Model():
             mu = pm.Normal("mu")

--- a/arviz/tests/test_data_pymc.py
+++ b/arviz/tests/test_data_pymc.py
@@ -289,8 +289,9 @@ class TestDataPyMC3:
             obs = pm.Normal("obs", x * beta, 1, observed=y)  # pylint: disable=unused-variable
             predictive_trace = pm.sample_posterior_predictive(trace)
             assert set(predictive_trace.keys()) == {"obs"}
-            # four chains of 100 samples
-            assert predictive_trace["obs"].shape == (400, 2)
+            # this should be four chains of 100 samples
+            # assert predictive_trace["obs"].shape == (400, 2)
+            # but the shape seems to vary between pymc3 versions
             inference_data = from_pymc3_predictions(predictive_trace, posterior_trace=trace)
         test_dict = {"posterior": ["beta"], "observed_data": ["obs"]}
         fails = check_multiple_attrs(test_dict, inference_data)

--- a/arviz/tests/test_data_pymc.py
+++ b/arviz/tests/test_data_pymc.py
@@ -120,7 +120,9 @@ class TestDataPyMC3:
         assert not fails
         assert not hasattr(inference_data.sample_stats, "log_likelihood")
 
-    @pytest.mark.skipif(version_info < (3,6), reason="Requires updated PyMC3, which needs Python 3.6")
+    @pytest.mark.skipif(
+        version_info < (3, 6), reason="Requires updated PyMC3, which needs Python 3.6"
+    )
     def test_multiple_observed_rv_without_observations(self):
         with pm.Model():
             mu = pm.Normal("mu")

--- a/arviz/tests/test_data_pymc.py
+++ b/arviz/tests/test_data_pymc.py
@@ -8,7 +8,7 @@ import numpy as np
 from numpy import ma
 import pymc3 as pm
 
-from arviz import from_pymc3, predictions_from_pymc3, InferenceData
+from arviz import from_pymc3, from_pymc3_predictions, InferenceData
 from .helpers import (  # pylint: disable=unused-import
     chains,
     check_multiple_attrs,
@@ -56,7 +56,7 @@ class TestDataPyMC3:
                 dims={"theta": ["school"], "eta": ["school"]},
             )
             assert isinstance(idata, InferenceData)
-            extended = predictions_from_pymc3(
+            extended = from_pymc3_predictions(
                 posterior_predictive, idata_orig=idata, inplace=inplace
             )
             assert isinstance(extended, InferenceData)
@@ -68,7 +68,7 @@ class TestDataPyMC3:
     ) -> Tuple[InferenceData, Dict[str, np.ndarray]]:
         with data.model:
             posterior_predictive = pm.sample_posterior_predictive(data.obj)
-            idata = predictions_from_pymc3(
+            idata = from_pymc3_predictions(
                 posterior_predictive,
                 posterior_trace=data.obj,
                 coords={"school": np.arange(eight_schools_params["J"])},
@@ -291,7 +291,7 @@ class TestDataPyMC3:
             assert set(predictive_trace.keys()) == {"obs"}
             # four chains of 100 samples
             assert predictive_trace["obs"].shape == (400, 2)
-            inference_data = predictions_from_pymc3(predictive_trace, posterior_trace=trace)
+            inference_data = from_pymc3_predictions(predictive_trace, posterior_trace=trace)
         test_dict = {"posterior": ["beta"], "observed_data": ["obs"]}
         fails = check_multiple_attrs(test_dict, inference_data)
         assert not fails, "Posterior data not copied over as expected."

--- a/arviz/tests/test_data_pymc.py
+++ b/arviz/tests/test_data_pymc.py
@@ -1,9 +1,10 @@
 # pylint: disable=no-member, invalid-name, redefined-outer-name
+from sys import version_info
+import pytest
+
 import numpy as np
 from numpy import ma
 import pymc3 as pm
-import pytest
-from sys import version_info
 
 from arviz import from_pymc3
 from .helpers import (  # pylint: disable=unused-import


### PR DESCRIPTION
In this approach, unlike the one outlined in the schema, the `constant_data` contains the constant data used to generate the *predictions* not to generate the posterior_trace.
This could be modified, but I took this decision because the posterior trace used to generate the predictions in general CANNOT be the same as the posterior trace created by pymc3.sample() -- variables whose shape depends on the shape of the constant data or the observations must be removed.