### PR TITLE
Violinplot:  fix histogram, add rug

### DIFF
--- a/arviz/plots/backends/bokeh/violinplot.py
+++ b/arviz/plots/backends/bokeh/violinplot.py
@@ -97,7 +97,8 @@ def _violinplot(val, rug, shade, bw, ax, **shade_kwargs):
         x = np.concatenate([x, x[::-1]])
         density = np.concatenate([-density, density[::-1]])
 
-    ax.patch(density, x, fill_alpha=shade, line_width=0, **shade_kwargs)
+    ax.harea(y=x, x1=density, x2=np.zeros_like(density), fill_alpha=shade, **shade_kwargs)
+
     return density
 
 
@@ -110,20 +111,22 @@ def cat_hist(val, rug, shade, ax, **shade_kwargs):
     centers = 0.5 * (bin_edges + np.roll(bin_edges, 1))[:-1]
     heights = np.diff(bin_edges)
     centers = bin_edges[:-1] + heights.mean() / 2
-
-    lefts = -0.5 * binned_d
+    right = 0.5 * binned_d
 
     if rug:
-        pass
+        left = 0
+    else:
+        left = -right
 
     ax.hbar(
         y=centers,
-        left=lefts,
-        right=-lefts,
+        left=left,
+        right=right,
         height=heights,
         fill_alpha=shade,
         line_alpha=shade,
         line_color=None,
         **shade_kwargs
     )
+
     return binned_d

--- a/arviz/plots/backends/bokeh/violinplot.py
+++ b/arviz/plots/backends/bokeh/violinplot.py
@@ -17,9 +17,12 @@ def plot_violin(
     figsize,
     rows,
     cols,
+    sharex,
     sharey,
-    kwargs_shade,
+    shade_kwargs,
     shade,
+    rug,
+    rug_kwargs,
     bw,
     credible_interval,
     linewidth,
@@ -40,6 +43,7 @@ def plot_violin(
             len(plotters),
             rows,
             cols,
+            sharex=sharex,
             sharey=sharey,
             figsize=figsize,
             squeeze=False,
@@ -54,9 +58,13 @@ def plot_violin(
     ):
         val = x.flatten()
         if val[0].dtype.kind == "i":
-            cat_hist(val, shade, ax_, **kwargs_shade)
+            dens = cat_hist(val, rug, shade, ax_, **shade_kwargs)
         else:
-            _violinplot(val, shade, bw, ax_, **kwargs_shade)
+            dens = _violinplot(val, rug, shade, bw, ax_, **shade_kwargs)
+
+        if rug:
+            rug_x = -np.abs(np.random.normal(scale=np.std(dens), size=len(val)))
+            ax_.scatter(rug_x, val, **rug_kwargs)
 
         per = np.percentile(val, [25, 75, 50])
         hpd_intervals = hpd(val, credible_interval, multimodal=False)
@@ -80,18 +88,20 @@ def plot_violin(
     return ax
 
 
-def _violinplot(val, shade, bw, ax, **kwargs_shade):
+def _violinplot(val, rug, shade, bw, ax, **shade_kwargs):
     """Auxiliary function to plot violinplots."""
     density, low_b, up_b = _fast_kde(val, bw=bw)
     x = np.linspace(low_b, up_b, len(density))
 
-    x = np.concatenate([x, x[::-1]])
-    density = np.concatenate([-density, density[::-1]])
+    if not rug:
+        x = np.concatenate([x, x[::-1]])
+        density = np.concatenate([-density, density[::-1]])
 
-    ax.patch(density, x, fill_alpha=shade, line_width=0, **kwargs_shade)
+    ax.patch(density, x, fill_alpha=shade, line_width=0, **shade_kwargs)
+    return density
 
 
-def cat_hist(val, shade, ax, **kwargs_shade):
+def cat_hist(val, rug, shade, ax, **shade_kwargs):
     """Auxiliary function to plot discrete-violinplots."""
     bins = get_bins(val)
     _, binned_d, _ = histogram(val, bins=bins)
@@ -99,8 +109,12 @@ def cat_hist(val, shade, ax, **kwargs_shade):
     bin_edges = np.linspace(np.min(val), np.max(val), len(bins))
     centers = 0.5 * (bin_edges + np.roll(bin_edges, 1))[:-1]
     heights = np.diff(bin_edges)
+    centers = bin_edges[:-1] + heights.mean() / 2
 
     lefts = -0.5 * binned_d
+
+    if rug:
+        pass
 
     ax.hbar(
         y=centers,
@@ -110,5 +124,6 @@ def cat_hist(val, shade, ax, **kwargs_shade):
         fill_alpha=shade,
         line_alpha=shade,
         line_color=None,
-        **kwargs_shade
+        **shade_kwargs
     )
+    return binned_d

--- a/arviz/plots/backends/bokeh/violinplot.py
+++ b/arviz/plots/backends/bokeh/violinplot.py
@@ -63,16 +63,25 @@ def plot_violin(
             dens = _violinplot(val, rug, shade, bw, ax_, **shade_kwargs)
 
         if rug:
-            rug_x = -np.abs(np.random.normal(scale=np.std(dens), size=len(val)))
+            rug_x = -np.abs(np.random.normal(scale=max(dens) / 3.5, size=len(val)))
             ax_.scatter(rug_x, val, **rug_kwargs)
 
         per = np.percentile(val, [25, 75, 50])
         hpd_intervals = hpd(val, credible_interval, multimodal=False)
 
         if quartiles:
-            ax_.line([0, 0], per[:2], line_width=linewidth * 3, line_color="black")
-        ax_.line([0, 0], hpd_intervals, line_width=linewidth, line_color="black")
-        ax_.circle(0, per[-1])
+            ax_.line(
+                [0, 0], per[:2], line_width=linewidth * 3, line_color="black", line_cap="round"
+            )
+        ax_.line([0, 0], hpd_intervals, line_width=linewidth, line_color="black", line_cap="round")
+        ax_.circle(
+            0,
+            per[-1],
+            line_color="white",
+            fill_color="white",
+            size=linewidth * 1.5,
+            line_width=linewidth,
+        )
 
         _title = Title()
         _title.text = make_label(var_name, selection)
@@ -108,7 +117,6 @@ def cat_hist(val, rug, shade, ax, **shade_kwargs):
     _, binned_d, _ = histogram(val, bins=bins)
 
     bin_edges = np.linspace(np.min(val), np.max(val), len(bins))
-    centers = 0.5 * (bin_edges + np.roll(bin_edges, 1))[:-1]
     heights = np.diff(bin_edges)
     centers = bin_edges[:-1] + heights.mean() / 2
     right = 0.5 * binned_d

--- a/arviz/plots/backends/matplotlib/violinplot.py
+++ b/arviz/plots/backends/matplotlib/violinplot.py
@@ -97,12 +97,11 @@ def cat_hist(val, rug, shade, ax, **shade_kwargs):
 
     bin_edges = np.linspace(np.min(val), np.max(val), len(bins))
     heights = np.diff(bin_edges)
+    centers = bin_edges[:-1] + heights.mean() / 2
 
     if rug:
-        centers = bin_edges[:-1] + heights.mean() / 2
         left = None
     else:
-        centers = bin_edges[:-1] + heights.mean() / 2
         left = -0.5 * binned_d
 
     ax.barh(centers, binned_d, height=heights, left=left, alpha=shade, **shade_kwargs)

--- a/arviz/plots/backends/matplotlib/violinplot.py
+++ b/arviz/plots/backends/matplotlib/violinplot.py
@@ -15,9 +15,12 @@ def plot_violin(
     figsize,
     rows,
     cols,
+    sharex,
     sharey,
-    kwargs_shade,
+    shade_kwargs,
     shade,
+    rug,
+    rug_kwargs,
     bw,
     credible_interval,
     linewidth,
@@ -29,24 +32,31 @@ def plot_violin(
 ):
     """Matplotlib violin plot."""
     if ax is None:
-        _, ax = _create_axes_grid(
+        fig, ax = _create_axes_grid(
             len(plotters),
             rows,
             cols,
+            sharex=sharex,
             sharey=sharey,
             figsize=figsize,
             squeeze=False,
             backend_kwargs=backend_kwargs,
         )
+        fig.set_constrained_layout(False)
+        fig.subplots_adjust(wspace=0)
 
     ax = np.atleast_1d(ax)
 
     for (var_name, selection, x), ax_ in zip(plotters, ax.flatten()):
         val = x.flatten()
         if val[0].dtype.kind == "i":
-            cat_hist(val, shade, ax_, **kwargs_shade)
+            dens = cat_hist(val, rug, shade, ax_, **shade_kwargs)
         else:
-            _violinplot(val, shade, bw, ax_, **kwargs_shade)
+            dens = _violinplot(val, rug, shade, bw, ax_, **shade_kwargs)
+
+        if rug:
+            rug_x = -np.abs(np.random.normal(scale=max(dens) / 3, size=len(val)))
+            ax_.plot(rug_x, val, **rug_kwargs)
 
         per = np.percentile(val, [25, 75, 50])
         hpd_intervals = hpd(val, credible_interval, multimodal=False)
@@ -67,25 +77,33 @@ def plot_violin(
     return ax
 
 
-def _violinplot(val, shade, bw, ax, **kwargs_shade):
+def _violinplot(val, rug, shade, bw, ax, **shade_kwargs):
     """Auxiliary function to plot violinplots."""
     density, low_b, up_b = _fast_kde(val, bw=bw)
     x = np.linspace(low_b, up_b, len(density))
 
-    x = np.concatenate([x, x[::-1]])
-    density = np.concatenate([-density, density[::-1]])
+    if not rug:
+        x = np.concatenate([x, x[::-1]])
+        density = np.concatenate([-density, density[::-1]])
 
-    ax.fill_betweenx(x, density, alpha=shade, lw=0, **kwargs_shade)
+    ax.fill_betweenx(x, density, alpha=shade, lw=0, **shade_kwargs)
+    return density
 
 
-def cat_hist(val, shade, ax, **kwargs_shade):
+def cat_hist(val, rug, shade, ax, **shade_kwargs):
     """Auxiliary function to plot discrete-violinplots."""
     bins = get_bins(val)
     _, binned_d, _ = histogram(val, bins=bins)
 
     bin_edges = np.linspace(np.min(val), np.max(val), len(bins))
-    centers = 0.5 * (bin_edges + np.roll(bin_edges, 1))[:-1]
     heights = np.diff(bin_edges)
 
-    lefts = -0.5 * binned_d
-    ax.barh(centers, binned_d, height=heights, left=lefts, alpha=shade, **kwargs_shade)
+    if rug:
+        centers = bin_edges[:-1] + heights.mean() / 2
+        left = None
+    else:
+        centers = bin_edges[:-1] + heights.mean() / 2
+        left = -0.5 * binned_d
+
+    ax.barh(centers, binned_d, height=heights, left=left, alpha=shade, **shade_kwargs)
+    return binned_d

--- a/arviz/plots/backends/matplotlib/violinplot.py
+++ b/arviz/plots/backends/matplotlib/violinplot.py
@@ -55,7 +55,7 @@ def plot_violin(
             dens = _violinplot(val, rug, shade, bw, ax_, **shade_kwargs)
 
         if rug:
-            rug_x = -np.abs(np.random.normal(scale=max(dens) / 3, size=len(val)))
+            rug_x = -np.abs(np.random.normal(scale=max(dens) / 3.5, size=len(val)))
             ax_.plot(rug_x, val, **rug_kwargs)
 
         per = np.percentile(val, [25, 75, 50])

--- a/arviz/plots/violinplot.py
+++ b/arviz/plots/violinplot.py
@@ -14,14 +14,17 @@ def plot_violin(
     data,
     var_names=None,
     quartiles=True,
+    rug=False,
     credible_interval=0.94,
     shade=0.35,
     bw=4.5,
+    sharex=True,
     sharey=True,
     figsize=None,
     textsize=None,
     ax=None,
-    kwargs_shade=None,
+    shade_kwargs=None,
+    rug_kwargs=None,
     backend=None,
     backend_kwargs=None,
     show=None,
@@ -42,6 +45,8 @@ def plot_violin(
     quartiles : bool, optional
         Flag for plotting the interquartile range, in addition to the credible_interval*100%
         intervals. Defaults to True
+    rug : bool
+        If True adds a jittered rugplot. Defaults to False.
     credible_interval : float, optional
         Credible intervals. Defaults to 0.94.
     shade : float
@@ -56,12 +61,17 @@ def plot_violin(
     textsize: int
         Text size of the point_estimates, axis ticks, and HPD. If None it will be autoscaled
         based on figsize.
+    sharex : bool
+        Defaults to True, violinplots share a common x-axis scale.
     sharey : bool
         Defaults to True, violinplots share a common y-axis scale.
     ax: axes, optional
         Matplotlib axes or bokeh figures.
-    kwargs_shade : dicts, optional
+    shade_kwargs : dicts, optional
         Additional keywords passed to `fill_between`, or `barh` to control the shade.
+    rug_kwargs : dict
+        Keywords passed to the rug plot. If true only the righ half side of the violin will be
+        plotted.
     backend: str, optional
         Select plotting backend {"matplotlib","bokeh"}. Default "matplotlib".
     backend_kwargs: bool, optional
@@ -81,15 +91,21 @@ def plot_violin(
         list(xarray_var_iter(data, var_names=var_names, combined=True)), "plot_violin"
     )
 
-    if kwargs_shade is None:
-        kwargs_shade = {}
+    if shade_kwargs is None:
+        shade_kwargs = {}
 
     rows, cols = default_grid(len(plotters))
 
     (figsize, ax_labelsize, _, xt_labelsize, linewidth, _) = _scale_fig_size(
         figsize, textsize, rows, cols
     )
-    ax_labelsize *= 2
+
+    if rug_kwargs is None:
+        rug_kwargs = {}
+        rug_kwargs = {}
+    rug_kwargs.setdefault("alpha", 0.1)
+    rug_kwargs.setdefault("marker", ".")
+    rug_kwargs.setdefault("linestyle", "")
 
     violinplot_kwargs = dict(
         ax=ax,
@@ -97,9 +113,12 @@ def plot_violin(
         figsize=figsize,
         rows=rows,
         cols=cols,
+        sharex=sharex,
         sharey=sharey,
-        kwargs_shade=kwargs_shade,
+        shade_kwargs=shade_kwargs,
         shade=shade,
+        rug=rug,
+        rug_kwargs=rug_kwargs,
         bw=bw,
         credible_interval=credible_interval,
         linewidth=linewidth,

--- a/arviz/plots/violinplot.py
+++ b/arviz/plots/violinplot.py
@@ -102,10 +102,6 @@ def plot_violin(
 
     if rug_kwargs is None:
         rug_kwargs = {}
-        rug_kwargs = {}
-    rug_kwargs.setdefault("alpha", 0.1)
-    rug_kwargs.setdefault("marker", ".")
-    rug_kwargs.setdefault("linestyle", "")
 
     violinplot_kwargs = dict(
         ax=ax,
@@ -133,6 +129,14 @@ def plot_violin(
 
         violinplot_kwargs.pop("ax_labelsize")
         violinplot_kwargs.pop("xt_labelsize")
+
+        rug_kwargs.setdefault("fill_alpha", 0.1)
+        rug_kwargs.setdefault("line_alpha", 0.1)
+
+    else:
+        rug_kwargs.setdefault("alpha", 0.1)
+        rug_kwargs.setdefault("marker", ".")
+        rug_kwargs.setdefault("linestyle", "")
 
     # TODO: Add backend kwargs
     plot = get_plotting_function("plot_violin", "violinplot", backend)


### PR DESCRIPTION
The "violin" plot had problem for discrete variables. This fix it and also add the option to display a jittered "rug" plot (defaults to False).

![lala](https://user-images.githubusercontent.com/1338958/72361063-9db16400-36cf-11ea-932f-b45642c3d473.png)

I still needs to add the "rug" for bokeh