### PR TITLE
rename flat_inference_data_to_dict (fixes #999)

### DIFF
--- a/arviz/plots/backends/__init__.py
+++ b/arviz/plots/backends/__init__.py
@@ -63,12 +63,12 @@ def to_cds(
     -------
     bokeh.models.ColumnDataSource object
     """
-    from ...utils import flat_inference_data_to_dict
+    from ...utils import flatten_inference_data_to_dict
 
     if var_name_format is None:
         var_name_format = "cds"
 
-    cds_dict = flat_inference_data_to_dict(
+    cds_dict = flatten_inference_data_to_dict(
         data=data,
         var_names=var_names,
         groups=groups,

--- a/arviz/tests/test_utils.py
+++ b/arviz/tests/test_utils.py
@@ -16,7 +16,7 @@ from ..utils import (
     one_de,
     two_de,
     expand_dims,
-    flat_inference_data_to_dict,
+    flatten_inference_data_to_dict,
 )
 from ..data import load_arviz_data, from_dict
 from ..stats.stats_utils import stats_variance_2d as svar
@@ -275,11 +275,11 @@ def test_expand_dims(data):
     "var_name_format", [None, "brackets", "underscore", "cds", ((",", "[", "]"), ("_", ""))]
 )
 @pytest.mark.parametrize("index_origin", [None, 0, 1])
-def test_flat_inference_data_to_dict(
+def test_flatten_inference_data_to_dict(
     inference_data, var_names, groups, dimensions, group_info, var_name_format, index_origin
 ):
     """Test flattening (stacking) inference data (subgroups) for dictionary."""
-    res_dict = flat_inference_data_to_dict(
+    res_dict = flatten_inference_data_to_dict(
         data=inference_data,
         var_names=var_names,
         groups=groups,

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -325,7 +325,7 @@ def full(shape, x, dtype=None):
     return np.full(shape, x, dtype=dtype)
 
 
-def flat_inference_data_to_dict(
+def flatten_inference_data_to_dict(
     data,
     var_names=None,
     groups=None,


### PR DESCRIPTION
Renamed ```flat_inference_data_to_dict``` to ```flatten_inference_data_to_dict```.

fixes #999 