### PR TITLE
Convert all instances of SyntaxWarning to UserWarning

### DIFF
--- a/arviz/data/base.py
+++ b/arviz/data/base.py
@@ -82,7 +82,7 @@ def generate_dims_coords(shape, var_name, dims=None, coords=None, default_dims=N
                 shape_len=len(shape),
                 defaults=",".join(default_dims) + ", " if default_dims is not None else "",
             ),
-            SyntaxWarning,
+            UserWarning,
         )
     if coords is None:
         coords = {}
@@ -142,7 +142,7 @@ def numpy_to_data_array(ary, *, var_name="data", coords=None, dims=None):
             "Passed array should have shape (chains, draws, *shape)".format(
                 n_chains=n_chains, n_samples=n_samples
             ),
-            SyntaxWarning,
+            UserWarning,
         )
 
     dims, coords = generate_dims_coords(

--- a/arviz/data/io_dict.py
+++ b/arviz/data/io_dict.py
@@ -44,7 +44,7 @@ class DictConverter:
             warnings.warn(
                 "log_likelihood found in posterior."
                 " For stats functions log_likelihood needs to be in sample_stats.",
-                SyntaxWarning,
+                UserWarning,
             )
 
         return dict_to_dataset(data, library=None, coords=self.coords, dims=self.dims)

--- a/arviz/data/io_emcee.py
+++ b/arviz/data/io_emcee.py
@@ -55,11 +55,11 @@ def _verify_names(sampler, var_names, arg_names, slices):
         warnings.warn(
             "Check slices: Not all parameters in chain captured. "
             "{} are present, and {} have been captured.".format(ndim, len(slicing_try)),
-            SyntaxWarning,
+            UserWarning,
         )
     if len(slicing_try) != len(set(slicing_try)):
         warnings.warn(
-            "Overlapping slices. Check the index present: {}".format(slicing_try), SyntaxWarning
+            "Overlapping slices. Check the index present: {}".format(slicing_try), UserWarning
         )
 
     if var_names is None:

--- a/arviz/plots/backends/bokeh/elpdplot.py
+++ b/arviz/plots/backends/bokeh/elpdplot.py
@@ -69,7 +69,7 @@ def plot_elpd(
                 "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "
                 "of resulting ELPD pairwise plots with these variables, generating only a "
                 "{side}x{side} grid".format(max_plots=max_plots, side=vars_to_plot),
-                SyntaxWarning,
+                UserWarning,
             )
             numvars = vars_to_plot
 

--- a/arviz/plots/backends/bokeh/pairplot.py
+++ b/arviz/plots/backends/bokeh/pairplot.py
@@ -125,7 +125,7 @@ def plot_pair(
                 "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "
                 "of resulting pair plots with these variables, generating only a "
                 "{side}x{side} grid".format(max_plots=max_plots, side=vars_to_plot),
-                SyntaxWarning,
+                UserWarning,
             )
             numvars = vars_to_plot
 

--- a/arviz/plots/backends/matplotlib/elpdplot.py
+++ b/arviz/plots/backends/matplotlib/elpdplot.py
@@ -91,7 +91,7 @@ def plot_elpd(
                 "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "
                 "of resulting ELPD pairwise plots with these variables, generating only a "
                 "{side}x{side} grid".format(max_plots=max_plots, side=vars_to_plot),
-                SyntaxWarning,
+                UserWarning,
             )
             numvars = vars_to_plot
 

--- a/arviz/plots/backends/matplotlib/pairplot.py
+++ b/arviz/plots/backends/matplotlib/pairplot.py
@@ -89,7 +89,7 @@ def plot_pair(
                 "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "
                 "of resulting pair plots with these variables, generating only a "
                 "{side}x{side} grid".format(max_plots=max_plots, side=vars_to_plot),
-                SyntaxWarning,
+                UserWarning,
             )
             numvars = vars_to_plot
 

--- a/arviz/plots/densityplot.py
+++ b/arviz/plots/densityplot.py
@@ -196,7 +196,7 @@ def plot_density(
             "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "
             "of variables to plot ({len_plotters}) in plot_density, generating only "
             "{max_plots} plots".format(max_plots=max_plots, len_plotters=length_plotters),
-            SyntaxWarning,
+            UserWarning,
         )
         all_labels = all_labels[:max_plots]
         to_plot = [

--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -178,7 +178,7 @@ def plot_pair(
                 "Make sure the sample method provides divergences data and "
                 "that it is present in the `diverging` field of `sample_stats` "
                 "or `sample_stats_prior` or set divergences=False",
-                SyntaxWarning,
+                UserWarning,
             )
 
     if gridsize == "auto":

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -632,7 +632,7 @@ def filter_plotters_list(plotters, plot_kind):
             "{max_plots} plots".format(
                 max_plots=max_plots, len_plotters=len(plotters), plot_kind=plot_kind
             ),
-            SyntaxWarning,
+            UserWarning,
         )
         return plotters[:max_plots]
     return plotters

--- a/arviz/plots/traceplot.py
+++ b/arviz/plots/traceplot.py
@@ -165,7 +165,7 @@ def plot_trace(
             "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "
             "of variables to plot ({len_plotters}), generating only {max_plots} "
             "plots".format(max_plots=max_plots, len_plotters=len(plotters)),
-            SyntaxWarning,
+            UserWarning,
         )
         plotters = plotters[:max_plots]
 

--- a/arviz/tests/test_data.py
+++ b/arviz/tests/test_data.py
@@ -142,7 +142,7 @@ def test_dims_coords():
 def test_dims_coords_extra_dims():
     shape = 4, 20
     var_name = "x"
-    with pytest.warns(SyntaxWarning):
+    with pytest.warns(UserWarning):
         dims, coords = generate_dims_coords(shape, var_name, dims=["xx", "xy", "xz"])
     assert "xx" in dims
     assert "xy" in dims
@@ -419,7 +419,7 @@ class TestNumpyToDataArray:
 
     def test_warns_bad_shape(self):
         # Shape should be (chain, draw, *shape)
-        with pytest.warns(SyntaxWarning):
+        with pytest.warns(UserWarning):
             convert_to_dataset(np.random.randn(100, 4))
 
     def test_nd_to_dataset(self):
@@ -448,7 +448,7 @@ class TestNumpyToDataArray:
 
     def test_more_chains_than_draws(self):
         shape = (10, 4)
-        with pytest.warns(SyntaxWarning):
+        with pytest.warns(UserWarning):
             inference_data = convert_to_inference_data(np.random.randn(*shape), group="foo")
         assert hasattr(inference_data, "foo")
         assert len(inference_data.foo.data_vars) == 1
@@ -688,7 +688,7 @@ class TestDataDict:
 
     def test_from_dict_warning(self):
         bad_posterior_dict = {"log_likelihood": np.ones((5, 1000, 2))}
-        with pytest.warns(SyntaxWarning):
+        with pytest.warns(UserWarning):
             from_dict(posterior=bad_posterior_dict)
 
 

--- a/arviz/tests/test_data_emcee.py
+++ b/arviz/tests/test_data_emcee.py
@@ -109,7 +109,7 @@ class TestDataEmcee:
 
     @pytest.mark.parametrize("slices", [[0, 0, slice(2, None)], [0, 1, slice(1, None)]])
     def test_slices_warning(self, data, slices):
-        with pytest.warns(SyntaxWarning):
+        with pytest.warns(UserWarning):
             from_emcee(data.obj, slices=slices)
 
     def test_no_blobs_error(self):

--- a/arviz/tests/test_plot_utils.py
+++ b/arviz/tests/test_plot_utils.py
@@ -188,7 +188,7 @@ def test_filter_plotter_list():
 def test_filter_plotter_list_warning():
     plotters = list(range(7))
     with rc_context({"plot.max_subplots": 5}):
-        with pytest.warns(SyntaxWarning, match="test warning"):
+        with pytest.warns(UserWarning, match="test warning"):
             plotters_filtered = filter_plotters_list(plotters, "test warning")
     assert len(plotters_filtered) == 5
 

--- a/arviz/tests/test_plots_bokeh.py
+++ b/arviz/tests/test_plots_bokeh.py
@@ -133,7 +133,7 @@ def test_plot_trace_discrete(discrete_model):
 
 
 def test_plot_trace_max_subplots_warning(models):
-    with pytest.warns(SyntaxWarning):
+    with pytest.warns(UserWarning):
         with rc_context(rc={"plot.max_subplots": 1}):
             axes = plot_trace(models.model_1, backend="bokeh", show=False)
     assert axes.shape
@@ -724,7 +724,7 @@ def test_plot_pair_divergences_warning(has_sample_stats):
     else:
         # sample_stats missing
         data = data.posterior  # pylint: disable=no-member
-    with pytest.warns(SyntaxWarning):
+    with pytest.warns(UserWarning):
         ax = plot_pair(data, divergences=True, backend="bokeh", show=False)
     assert np.any(ax)
 

--- a/arviz/tests/test_plots_matplotlib.py
+++ b/arviz/tests/test_plots_matplotlib.py
@@ -150,7 +150,7 @@ def test_plot_trace_discrete(discrete_model):
 
 
 def test_plot_trace_max_subplots_warning(models):
-    with pytest.warns(SyntaxWarning):
+    with pytest.warns(UserWarning):
         with rc_context(rc={"plot.max_subplots": 1}):
             axes = plot_trace(models.model_1)
     assert axes.shape
@@ -400,7 +400,7 @@ def test_plot_pair_divergences_warning(has_sample_stats):
     else:
         # sample_stats missing
         data = data.posterior  # pylint: disable=no-member
-    with pytest.warns(SyntaxWarning):
+    with pytest.warns(UserWarning):
         ax = plot_pair(data, divergences=True)
     assert np.all(ax)
 


### PR DESCRIPTION
This addresses issue #104, by converting every instance of `SyntaxWarning` in the codebase into `UserWarning`. (There are only 23 instances in the end, not the 54 I initially thought; I don't know how I came up with 54 yesterday when I opened the issue!)

For the record, here's the command I ran to do this:

```shell
$ grep -rl SyntaxWarning . | xargs sed -i '' 's/SyntaxWarning/UserWarning/g'
```

Tests are passing locally in docker following the instructions in `CONTRIBUTING.md`, as is pylint.