### PR TITLE
not compute log_likelihood if vectorized trace cannot be obtained in Pyro

### DIFF
--- a/arviz/data/io_pyro.py
+++ b/arviz/data/io_pyro.py
@@ -89,18 +89,23 @@ class PyroConverter:
         # extract log_likelihood
         dims = None
         if self.observations is not None and len(self.observations) == 1:
-            obs_name = list(self.observations.keys())[0]
-            samples = self.posterior.get_samples(group_by_chain=False)
-            predictive = self.pyro.infer.Predictive(self.model, samples)
-            obs_site = predictive.get_vectorized_trace(*self._args, **self._kwargs).nodes[obs_name]
-            log_likelihood = obs_site["fn"].log_prob(obs_site["value"]).detach().cpu().numpy()
-            if self.dims is not None:
-                coord_name = self.dims.get("log_likelihood", self.dims.get(obs_name))
-            else:
-                coord_name = None
-            shape = (self.nchains, self.ndraws) + log_likelihood.shape[1:]
-            data["log_likelihood"] = np.reshape(log_likelihood, shape)
-            dims = {"log_likelihood": coord_name}
+            try:
+                obs_name = list(self.observations.keys())[0]
+                samples = self.posterior.get_samples(group_by_chain=False)
+                predictive = self.pyro.infer.Predictive(self.model, samples)
+                vectorized_trace = predictive.get_vectorized_trace(*self._args, **self._kwargs)
+                obs_site = vectorized_trace.nodes[obs_name]
+                log_likelihood = obs_site["fn"].log_prob(obs_site["value"]).detach().cpu().numpy()
+                if self.dims is not None:
+                    coord_name = self.dims.get("log_likelihood", self.dims.get(obs_name))
+                else:
+                    coord_name = None
+                shape = (self.nchains, self.ndraws) + log_likelihood.shape[1:]
+                data["log_likelihood"] = np.reshape(log_likelihood, shape)
+                dims = {"log_likelihood": coord_name}
+            except:
+                # cannot get vectorized trace
+                pass
         return dict_to_dataset(data, library=self.pyro, coords=self.coords, dims=dims)
 
     @requires("posterior_predictive")

--- a/arviz/data/io_pyro.py
+++ b/arviz/data/io_pyro.py
@@ -103,7 +103,7 @@ class PyroConverter:
                 shape = (self.nchains, self.ndraws) + log_likelihood.shape[1:]
                 data["log_likelihood"] = np.reshape(log_likelihood, shape)
                 dims = {"log_likelihood": coord_name}
-            except:
+            except:  # pylint: disable=bare-except
                 # cannot get vectorized trace
                 pass
         return dict_to_dataset(data, library=self.pyro, coords=self.coords, dims=dims)


### PR DESCRIPTION
This resolves the issue raized at pyro [forum](https://forum.pyro.ai/t/the-arviz-function-from-pyro-has-mismatching-dimensions/1515). In Pyro, each variable dimension should be declared as `independent` or `dependent`. MCMC class relaxes this restriction a bit so some incorrect Pyro models still work. However, utilities such as `get_vectorized_trace` (used in `sample_stats_to_xarray`) require that declaration. This PR disables log_likelihood computation for those incorrect Pyro models. Because there are many reasons to trigger the issue, I  add a universal `try ... except ...` here to capture all of them.