### PR TITLE
Fix arviz conversion of incomplete pymc3 traces

### DIFF
--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -80,7 +80,9 @@ class PyMC3Converter:  # pylint: disable=too-many-instance-attributes
         # way to access the model from the trace.
         if trace is not None:
             if self.model is None:
-                self.model = list(self.trace._straces.values())[0].model  # pylint: disable=protected-access
+                self.model = list(self.trace._straces.values())[  # pylint: disable=protected-access
+                    0
+                ].model
             self.nchains = trace.nchains if hasattr(trace, "nchains") else 1
             self.ndraws = len(trace)
         else:

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -80,7 +80,7 @@ class PyMC3Converter:  # pylint: disable=too-many-instance-attributes
         # way to access the model from the trace.
         if trace is not None:
             if self.model is None:
-                self.model = self.trace._straces[0].model  # pylint: disable=protected-access
+                self.model = list(self.trace._straces.values())[0].model  # pylint: disable=protected-access
             self.nchains = trace.nchains if hasattr(trace, "nchains") else 1
             self.ndraws = len(trace)
         else:


### PR DESCRIPTION
If sampling in pymc3 is aborted with Ctrl-C, it might create a trace that does not include chain 0.