### PR TITLE
Fix yaml formatting in paper.md

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -29,7 +29,7 @@ affiliations:
   index: 4
 date: 21 November 2018
 bibliography: paper.bib
---- 
+---
 
 # Summary
 


### PR DESCRIPTION
I'm doing some analyses of all JOSS papers, and discovered that the `yaml` header of yours is not quite formatted properly - there was a stray white space following the end `---`, which this PR fixes.