### PR TITLE
add skipna argument to hpd and summary (only for stats)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Violinplot: rug-plot option (#997)
 * Integrated rcParams `plot.point_estimate` (#994), `stats.ic_scale` (#993) and `stats.credible_interval` (#1017)
 * Added `group` argument to `plot_ppc` (#1008), `plot_pair` (#1009) and `plot_joint` (#1012)
+* Add `skipna` argument to `hpd` and `summary` (#1035)
 
 ### Maintenance and fixes
 * Fixed bug in extracting prior samples for cmdstanpy (#979)

--- a/arviz/stats/diagnostics.py
+++ b/arviz/stats/diagnostics.py
@@ -18,7 +18,7 @@ from .stats_utils import (
     _sqrt,
 )
 from ..data import convert_to_dataset
-from ..utils import _var_names, conditional_jit, conditional_vect, Numba, _numba_var, _stack
+from ..utils import _var_names, conditional_jit, Numba, _numba_var, _stack
 
 __all__ = ["bfmi", "ess", "rhat", "mcse", "geweke"]
 

--- a/arviz/stats/diagnostics.py
+++ b/arviz/stats/diagnostics.py
@@ -14,6 +14,8 @@ from .stats_utils import (
     wrap_xarray_ufunc as _wrap_xarray_ufunc,
     stats_variance_2d as svar,
     histogram,
+    _circular_standard_deviation,
+    _sqrt,
 )
 from ..data import convert_to_dataset
 from ..utils import _var_names, conditional_jit, conditional_vect, Numba, _numba_var, _stack
@@ -382,11 +384,6 @@ def mcse(data, *, var_names=None, method="mean", prob=None):
     return _wrap_xarray_ufunc(
         mcse_func, dataset, ufunc_kwargs=ufunc_kwargs, func_kwargs=func_kwargs
     )
-
-
-@conditional_vect
-def _sqrt(a_a, b_b):
-    return (a_a + b_b) ** 0.5
 
 
 @conditional_jit(forceobj=True)
@@ -872,28 +869,6 @@ def _mcse_quantile(ary, prob):
         return np.nan
     mcse_q, *_ = _conv_quantile(ary, prob)
     return mcse_q
-
-
-def _circfunc(samples, high, low):
-    samples = np.asarray(samples)
-    if samples.size == 0:
-        return np.nan, np.nan
-    return samples, _angle(samples, low, high, np.pi)
-
-
-@conditional_vect
-def _angle(samples, low, high, p_i=np.pi):
-    ang = (samples - low) * 2.0 * p_i / (high - low)
-    return ang
-
-
-def _circular_standard_deviation(samples, high=2 * np.pi, low=0, axis=None):
-    p_i = np.pi
-    samples, ang = _circfunc(samples, high, low)
-    s_s = np.sin(ang).mean(axis=axis)
-    c_c = np.cos(ang).mean(axis=axis)
-    r_r = np.hypot(s_s, c_c)
-    return ((high - low) / 2.0 / p_i) * np.sqrt(-2 * np.log(r_r))
 
 
 def _mc_error(ary, batches=5, circular=False):

--- a/arviz/tests/test_diagnostics.py
+++ b/arviz/tests/test_diagnostics.py
@@ -4,7 +4,6 @@ import os
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_almost_equal
 import pandas as pd
-from scipy.stats import circstd
 import pytest
 
 from ..data import load_arviz_data, from_cmdstan
@@ -21,10 +20,6 @@ from ..stats.diagnostics import (
     _z_scale,
     _conv_quantile,
     _split_chains,
-    _sqrt,
-    _angle,
-    _circfunc,
-    _circular_standard_deviation,
 )
 from ..utils import Numba
 from ..rcparams import rcParams
@@ -209,30 +204,6 @@ class TestDiagnostics:
     def test_rhat_ndarray(self):
         with pytest.raises(TypeError):
             rhat(np.random.randn(2, 300, 10))
-
-    def test_angle(self):
-        x = np.random.randn(100)
-        high = 8
-        low = 4
-        res = (x - low) * 2 * np.pi / (high - low)
-        assert np.allclose(_angle(x, low, high, np.pi), res)
-
-    def test_circfunc(self):
-        school = load_arviz_data("centered_eight").posterior["mu"].values
-        a_a, b_b = _circfunc(school, 8, 4)
-        assert np.allclose(a_a, school)
-        assert np.allclose(b_b, _angle(school, 4, 8, np.pi))
-
-    @pytest.mark.parametrize(
-        "data", (np.random.randn(100), np.random.randn(100, 100), np.random.randn(100, 100, 100))
-    )
-    def test_circular_standard_deviation_1d(self, data):
-        high = 8
-        low = 4
-        assert np.allclose(
-            _circular_standard_deviation(data, high=high, low=low),
-            circstd(data, high=high, low=low),
-        )
 
     @pytest.mark.parametrize(
         "method",
@@ -503,11 +474,6 @@ class TestDiagnostics:
 
         assert gw_stat.shape[0] == intervals
         assert 100000 * last - gw_stat[:, 0].max() == 1
-
-    def test_sqrt(self):
-        x = np.random.rand(100)
-        y = np.random.rand(100)
-        assert np.allclose(_sqrt(x, y), np.sqrt(x + y))
 
     def test_geweke_bad_interval(self):
         # lower bound

--- a/arviz/tests/test_stats.py
+++ b/arviz/tests/test_stats.py
@@ -67,6 +67,14 @@ def test_hpd_bad_ci():
         hpd(normal_sample, credible_interval=2)
 
 
+def test_hpd_skipna():
+    normal_sample = np.random.randn(500)
+    interval = hpd(normal_sample[10:])
+    normal_sample[:10] = np.nan
+    interval_ = hpd(normal_sample, skipna=True)
+    assert_array_almost_equal(interval, interval_)
+
+
 def test_r2_score():
     x = np.linspace(0, 1, 100)
     y = np.random.normal(x, 1)
@@ -241,6 +249,16 @@ def test_summary_nan(centered_eight):
         .all()
         .all()
     )
+
+
+def test_summary_skip_nan(centered_eight):
+    centered_eight = deepcopy(centered_eight)
+    centered_eight.posterior.theta[:, :10, 1] = np.nan
+    summary_xarray = summary(centered_eight)
+    theta_1 = summary_xarray.loc["theta[1]"].isnull()
+    assert summary_xarray is not None
+    assert ~theta_1[:4].all()
+    assert theta_1[4:].all()
 
 
 @pytest.mark.parametrize("fmt", [1, "bad_fmt"])


### PR DESCRIPTION
I also moved some functions (`_sqrt`,  `_angle`, `_circfunc`, `_circular_standard_deviation`) from `diagnostics` to `stats_utils`. The original motivation was to reproduce and example from statistical rethinking [code 7.42](https://github.com/pymc-devs/resources/blob/master/Rethinking_2/Chp_04.ipynb).

- [x] Does the PR follow [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format?
- [x] Is the new feature properly documented with an example?
- [x] Does the PR include new or updated tests to cover the new feature (using [pytest fixture pattern](
      https://docs.pytest.org/en/latest/fixture.html#fixture))?
- [x] Is the code style correct (follows pylint and black guidelines)?
- [x] Is the change listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased )?