### PR TITLE
ensure interpolation for plot_hpd always works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Violinplot: fix histogram (#997)
 * Convert all instances of SyntaxWarning to UserWarning (#1016)
 * Fix `point_estimate` in `plot_posterior` (#1038)
+* Fix interpolation `hpd_plot` (#1039)
 
 ### Deprecation
 

--- a/arviz/plots/hpdplot.py
+++ b/arviz/plots/hpdplot.py
@@ -102,7 +102,8 @@ def plot_hpd(
             smooth_kwargs = {}
         smooth_kwargs.setdefault("window_length", 55)
         smooth_kwargs.setdefault("polyorder", 2)
-        x_data = np.linspace(x.min(), x.max(), 200)
+        eps = np.finfo(float).eps
+        x_data = np.linspace(x.min() + eps, x.max() - eps, 200)
         hpd_interp = griddata(x, hpd_, x_data)
         y_data = savgol_filter(hpd_interp, axis=0, **smooth_kwargs)
     else:


### PR DESCRIPTION
 plot_hpd performs a linear interpolation before smoothing a hpd interval. This fix ensures that the points were the interpolation is evaluated are "inside" the data. 


- [x] Does the PR follow [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format?
- [x] Has included a sample plot to visually illustrate the changes? (only for plot-related functions)
- [x] Is the code style correct (follows pylint and black guidelines)?
- [x] Is the change listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased )?

Before
![old](https://user-images.githubusercontent.com/1338958/73490423-44ae2500-438b-11ea-9ac0-de41c0375e18.png)


after
![new](https://user-images.githubusercontent.com/1338958/73490429-4972d900-438b-11ea-9852-adedabf5b66f.png)

