### PR TITLE
Move pointwise log likelihood data to log_likelihood group (Pyro + NumPyro)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ matrix:
     - name: "Python 3.6 Unit Test"
       python: 3.6
       env: PYTHON_VERSION=3.6 PYSTAN_VERSION=latest PYRO_VERSION=latest EMCEE_VERSION=latest COVERALLS_PARALLEL=true NAME="UNIT"
-    - name: "Python 3.6 Unit Test - PyStan=3 Pyro=0.5.1 Emcee=2 TF=1"
+    - name: "Python 3.6 Unit Test - PyStan=3 Pyro=1.0.0 Emcee=2 TF=1"
       python: 3.6
-      env: PYTHON_VERSION=3.6 PYSTAN_VERSION=preview PYRO_VERSION=0.5.1 PYTORCH_VERSION=1.3.0 EMCEE_VERSION=2 TF_VERSION=1 COVERALLS_PARALLEL=true NAME="UNIT"
+      env: PYTHON_VERSION=3.6 PYSTAN_VERSION=preview PYRO_VERSION=1.0.0 PYTORCH_VERSION=1.3.0 EMCEE_VERSION=2 TF_VERSION=1 COVERALLS_PARALLEL=true NAME="UNIT"
     - name: "Python 3.5 Unit Test"
       python: 3.5
       env: PYTHON_VERSION=3.5 PYSTAN_VERSION=latest PYRO_VERSION=latest EMCEE_VERSION=latest PYMC3_VERSION=3.8 COVERALLS_PARALLEL=true NAME="UNIT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New features
 * Add out-of-sample predictions (`predictions` and  `predictions_constant_data` groups) to pymc3 and pystan translations (#983 and #1032)
-* Started adding pointwise log likelihood storage support (#794)
+* Started adding pointwise log likelihood storage support (#794, #1044)
 * Violinplot: rug-plot option (#997)
 * Integrated rcParams `plot.point_estimate` (#994), `stats.ic_scale` (#993) and `stats.credible_interval` (#1017)
 * Added `group` argument to `plot_ppc` (#1008), `plot_pair` (#1009) and `plot_joint` (#1012)

--- a/arviz/data/io_numpyro.py
+++ b/arviz/data/io_numpyro.py
@@ -104,7 +104,7 @@ class NumPyroConverter:
             if stat == "num_steps":
                 data["depth"] = np.log2(value).astype(int) + 1
         return dict_to_dataset(data, library=self.numpyro, dims=None, coords=self.coords)
-                
+
     @requires("posterior")
     @requires("model")
     def log_likelihood_to_xarray(self):

--- a/arviz/data/io_numpyro.py
+++ b/arviz/data/io_numpyro.py
@@ -103,24 +103,22 @@ class NumPyroConverter:
             data[name] = value
             if stat == "num_steps":
                 data["depth"] = np.log2(value).astype(int) + 1
-
-        # extract log_likelihood
-        dims = None
-        if self.observations is not None and len(self.observations) == 1:
+        return dict_to_dataset(data, library=self.numpyro, dims=None, coords=self.coords)
+                
+    @requires("posterior")
+    @requires("model")
+    def log_likelihood_to_xarray(self):
+        """Extract log likelihood from NumPyro posterior."""
+        data = {}
+        if self.observations is not None:
             samples = self.posterior.get_samples(group_by_chain=False)
-            log_likelihood = self.numpyro.infer.log_likelihood(
+            log_likelihood_dict = self.numpyro.infer.log_likelihood(
                 self.model, samples, *self._args, **self._kwargs
             )
-            obs_name, log_likelihood = list(log_likelihood.items())[0]
-            if self.dims is not None:
-                coord_name = self.dims.get("log_likelihood", self.dims.get(obs_name))
-            else:
-                coord_name = None
-            shape = (self.nchains, self.ndraws) + log_likelihood.shape[1:]
-            data["log_likelihood"] = np.reshape(log_likelihood.copy(), shape)
-            dims = {"log_likelihood": coord_name}
-
-        return dict_to_dataset(data, library=self.numpyro, dims=dims, coords=self.coords)
+            for obs_name, log_like in log_likelihood_dict.items():
+                shape = (self.nchains, self.ndraws) + log_like.shape[1:]
+                data[obs_name] = np.reshape(log_like.copy(), shape)
+        return dict_to_dataset(data, library=self.numpyro, dims=self.dims, coords=self.coords)
 
     @requires("posterior_predictive")
     def posterior_predictive_to_xarray(self):
@@ -197,6 +195,7 @@ class NumPyroConverter:
             **{
                 "posterior": self.posterior_to_xarray(),
                 "sample_stats": self.sample_stats_to_xarray(),
+                "log_likelihood": self.log_likelihood_to_xarray(),
                 "posterior_predictive": self.posterior_predictive_to_xarray(),
                 **self.priors_to_xarray(),
                 "observed_data": self.observed_data_to_xarray(),

--- a/arviz/data/io_pyro.py
+++ b/arviz/data/io_pyro.py
@@ -91,13 +91,13 @@ class PyroConverter:
     @requires("model")
     def log_likelihood_to_xarray(self):
         """Extract log likelihood from Pyro posterior."""
+        data = {}
         dims = None
         if self.observations is not None:
             try:
                 samples = self.posterior.get_samples(group_by_chain=False)
                 predictive = self.pyro.infer.Predictive(self.model, samples)
                 vectorized_trace = predictive.get_vectorized_trace(*self._args, **self._kwargs)
-                data = {}
                 for obs_name in self.observations.keys():
                     obs_site = vectorized_trace.nodes[obs_name]
                     log_like = obs_site["fn"].log_prob(obs_site["value"]).detach().cpu().numpy()
@@ -105,7 +105,7 @@ class PyroConverter:
                     data[obs_name] = np.reshape(log_like, shape)
             except:  # pylint: disable=bare-except
                 # cannot get vectorized trace
-                pass
+                return None
         return dict_to_dataset(data, library=self.pyro, coords=self.coords, dims=dims)
 
     @requires("posterior_predictive")

--- a/arviz/data/io_pyro.py
+++ b/arviz/data/io_pyro.py
@@ -91,7 +91,6 @@ class PyroConverter:
     @requires("model")
     def log_likelihood_to_xarray(self):
         """Extract log likelihood from Pyro posterior."""
-        data = {}
         dims = None
         if self.observations is not None:
             try:
@@ -101,9 +100,9 @@ class PyroConverter:
                 data = {}
                 for obs_name in self.observations.keys():
                     obs_site = vectorized_trace.nodes[obs_name]
-                    log_likelihood = obs_site["fn"].log_prob(obs_site["value"]).detach().cpu().numpy()
-                    shape = (self.nchains, self.ndraws) + log_likelihood.shape[1:]
-                    data[obs_name] = np.reshape(log_likelihood.copy(), shape)
+                    log_like = obs_site["fn"].log_prob(obs_site["value"]).detach().cpu().numpy()
+                    shape = (self.nchains, self.ndraws) + log_like.shape[1:]
+                    data[obs_name] = np.reshape(log_like, shape)
             except:  # pylint: disable=bare-except
                 # cannot get vectorized trace
                 pass
@@ -123,7 +122,7 @@ class PyroConverter:
             else:
                 data[k] = utils.expand_dims(ary)
                 _log.warning(
-                    "posterior predictive shape not compatible with number of chains and draws. "
+                    "posterior predictive shape not compatible with number of chains and draws."
                     "This can mean that some draws or even whole chains are not represented."
                 )
         return dict_to_dataset(data, library=self.pyro, coords=self.coords, dims=self.dims)

--- a/arviz/tests/test_data_numpyro.py
+++ b/arviz/tests/test_data_numpyro.py
@@ -58,7 +58,6 @@ class TestDataNumPyro:
         import numpyro
         import numpyro.distributions as dist
         from numpyro.infer import MCMC, NUTS
-        
         y1 = np.random.randn(10)
         y2 = np.random.randn(100)
         def model_example_multiple_obs(y1=None, y2=None):
@@ -66,7 +65,7 @@ class TestDataNumPyro:
             numpyro.sample('y1', dist.Normal(x, 1), obs=y1)
             numpyro.sample('y2', dist.Normal(x, 1), obs=y2)
         nuts_kernel = NUTS(model_example_multiple_obs)
-        mcmc = MCMC(nuts_kernel, num_warmup=20, num_samples=20)
+        mcmc = MCMC(nuts_kernel, num_samples=10, num_warmup=2)
         mcmc.run(PRNGKey(0), y1=y1, y2=y2)
         inference_data = from_numpyro(mcmc)
         test_dict = {
@@ -76,10 +75,11 @@ class TestDataNumPyro:
             "observed_data": ["y1", "y2"],
         }
         fails = check_multiple_attrs(test_dict, inference_data)
-        waic_results = az.stats.waic(inference_data)
-        print(waic_results)
-        print(waic_results.keys())
-        print(waic_results.waic, waic_results.waic_se)
+#         from ..stats import waic
+#         waic_results = waic(inference_data)
+#         print(waic_results)
+#         print(waic_results.keys())
+#         print(waic_results.waic, waic_results.waic_se)
         assert not fails
         assert not hasattr(inference_data.sample_stats, "log_likelihood")
         

--- a/arviz/tests/test_data_numpyro.py
+++ b/arviz/tests/test_data_numpyro.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 from jax.random import PRNGKey
 from numpyro.infer import Predictive
+import jax.numpy
 
 from ..data.io_numpyro import from_numpyro
 from .helpers import (  # pylint: disable=unused-import
@@ -25,10 +26,10 @@ class TestDataNumPyro:
     def get_inference_data(self, data, eight_schools_params):
         posterior_samples = data.obj.get_samples()
         model = data.obj.sampler.model
-        posterior_predictive = Predictive(model, posterior_samples).get_samples(
+        posterior_predictive = Predictive(model, posterior_samples).__call__(
             PRNGKey(1), eight_schools_params["J"], eight_schools_params["sigma"]
         )
-        prior = Predictive(model, num_samples=500).get_samples(
+        prior = Predictive(model, num_samples=500).__call__(
             PRNGKey(2), eight_schools_params["J"], eight_schools_params["sigma"]
         )
         return from_numpyro(
@@ -43,7 +44,8 @@ class TestDataNumPyro:
         inference_data = self.get_inference_data(data, eight_schools_params)
         test_dict = {
             "posterior": ["mu", "tau", "eta"],
-            "sample_stats": ["diverging", "tree_size", "depth", "log_likelihood"],
+            "sample_stats": ["diverging", "tree_size", "depth"],
+            "log_likelihood": ["obs"],
             "posterior_predictive": ["obs"],
             "prior": ["mu", "tau", "eta"],
             "prior_predictive": ["obs"],
@@ -51,3 +53,33 @@ class TestDataNumPyro:
         }
         fails = check_multiple_attrs(test_dict, inference_data)
         assert not fails
+
+    def test_multiple_observed_rv(self):
+        import numpyro
+        import numpyro.distributions as dist
+        from numpyro.infer import MCMC, NUTS
+        
+        y1 = np.random.randn(10)
+        y2 = np.random.randn(100)
+        def model_example_multiple_obs(y1=None, y2=None):
+            x = numpyro.sample('x', dist.Normal(1, 3))
+            numpyro.sample('y1', dist.Normal(x, 1), obs=y1)
+            numpyro.sample('y2', dist.Normal(x, 1), obs=y2)
+        nuts_kernel = NUTS(model_example_multiple_obs)
+        mcmc = MCMC(nuts_kernel, num_warmup=20, num_samples=20)
+        mcmc.run(PRNGKey(0), y1=y1, y2=y2)
+        inference_data = from_numpyro(mcmc)
+        test_dict = {
+            "posterior": ["x"],
+            "sample_stats": ["diverging"],
+            "log_likelihood": ["y1", "y2"],
+            "observed_data": ["y1", "y2"],
+        }
+        fails = check_multiple_attrs(test_dict, inference_data)
+        waic_results = az.stats.waic(inference_data)
+        print(waic_results)
+        print(waic_results.keys())
+        print(waic_results.waic, waic_results.waic_se)
+        assert not fails
+        assert not hasattr(inference_data.sample_stats, "log_likelihood")
+        

--- a/arviz/tests/test_data_numpyro.py
+++ b/arviz/tests/test_data_numpyro.py
@@ -3,7 +3,6 @@ import numpy as np
 import pytest
 from jax.random import PRNGKey
 from numpyro.infer import Predictive
-import jax.numpy
 
 from ..data.io_numpyro import from_numpyro
 from .helpers import (  # pylint: disable=unused-import
@@ -26,10 +25,10 @@ class TestDataNumPyro:
     def get_inference_data(self, data, eight_schools_params):
         posterior_samples = data.obj.get_samples()
         model = data.obj.sampler.model
-        posterior_predictive = Predictive(model, posterior_samples).__call__(
+        posterior_predictive = Predictive(model, posterior_samples)(
             PRNGKey(1), eight_schools_params["J"], eight_schools_params["sigma"]
         )
-        prior = Predictive(model, num_samples=500).__call__(
+        prior = Predictive(model, num_samples=500)(
             PRNGKey(2), eight_schools_params["J"], eight_schools_params["sigma"]
         )
         return from_numpyro(
@@ -58,12 +57,15 @@ class TestDataNumPyro:
         import numpyro
         import numpyro.distributions as dist
         from numpyro.infer import MCMC, NUTS
+
         y1 = np.random.randn(10)
         y2 = np.random.randn(100)
+
         def model_example_multiple_obs(y1=None, y2=None):
-            x = numpyro.sample('x', dist.Normal(1, 3))
-            numpyro.sample('y1', dist.Normal(x, 1), obs=y1)
-            numpyro.sample('y2', dist.Normal(x, 1), obs=y2)
+            x = numpyro.sample("x", dist.Normal(1, 3))
+            numpyro.sample("y1", dist.Normal(x, 1), obs=y1)
+            numpyro.sample("y2", dist.Normal(x, 1), obs=y2)
+
         nuts_kernel = NUTS(model_example_multiple_obs)
         mcmc = MCMC(nuts_kernel, num_samples=10, num_warmup=2)
         mcmc.run(PRNGKey(0), y1=y1, y2=y2)
@@ -75,11 +77,10 @@ class TestDataNumPyro:
             "observed_data": ["y1", "y2"],
         }
         fails = check_multiple_attrs(test_dict, inference_data)
-#         from ..stats import waic
-#         waic_results = waic(inference_data)
-#         print(waic_results)
-#         print(waic_results.keys())
-#         print(waic_results.waic, waic_results.waic_se)
+        #         from ..stats import waic
+        #         waic_results = waic(inference_data)
+        #         print(waic_results)
+        #         print(waic_results.keys())
+        #         print(waic_results.waic, waic_results.waic_se)
         assert not fails
         assert not hasattr(inference_data.sample_stats, "log_likelihood")
-        

--- a/arviz/tests/test_data_pyro.py
+++ b/arviz/tests/test_data_pyro.py
@@ -38,7 +38,7 @@ class TestDataPyro:
             prior=prior,
             posterior_predictive=posterior_predictive,
             coords={"school": np.arange(eight_schools_params["J"])},
-            dims={"theta": ["school"], "eta": ["school"]},
+            dims={"theta": ["school"], "eta": ["school"]}
         )
 
     def test_inference_data(self, data, eight_schools_params):
@@ -99,16 +99,17 @@ class TestDataPyro:
         assert not fails
 
     def test_multiple_observed_rv(self):
-        import pyro
         import pyro.distributions as dist
         from pyro.infer import MCMC, NUTS
-        import torch
+
         y1 = torch.randn(10)
         y2 = torch.randn(10)
+
         def model_example_multiple_obs(y1=None, y2=None):
-            x = pyro.sample('x', dist.Normal(1, 3))
-            pyro.sample('y1', dist.Normal(x, 1), obs=y1)
-            pyro.sample('y2', dist.Normal(x, 1), obs=y2)
+            x = pyro.sample("x", dist.Normal(1, 3))
+            pyro.sample("y1", dist.Normal(x, 1), obs=y1)
+            pyro.sample("y2", dist.Normal(x, 1), obs=y2)
+
         nuts_kernel = NUTS(model_example_multiple_obs)
         mcmc = MCMC(nuts_kernel, num_samples=10)
         mcmc.run(y1=y1, y2=y2)

--- a/arviz/tests/test_data_pyro.py
+++ b/arviz/tests/test_data_pyro.py
@@ -104,7 +104,7 @@ class TestDataPyro:
         from pyro.infer import MCMC, NUTS
         import torch
         y1 = torch.randn(10)
-        y2 = torch.randn(10) #does not work with 100 instead of 10
+        y2 = torch.randn(10)
         def model_example_multiple_obs(y1=None, y2=None):
             x = pyro.sample('x', dist.Normal(1, 3))
             pyro.sample('y1', dist.Normal(x, 1), obs=y1)

--- a/arviz/tests/test_data_pyro.py
+++ b/arviz/tests/test_data_pyro.py
@@ -27,10 +27,10 @@ class TestDataPyro:
     def get_inference_data(self, data, eight_schools_params):
         posterior_samples = data.obj.get_samples()
         model = data.obj.kernel.model
-        posterior_predictive = Predictive(model, posterior_samples).forward(
+        posterior_predictive = Predictive(model, posterior_samples)(
             eight_schools_params["J"], torch.from_numpy(eight_schools_params["sigma"]).float()
         )
-        prior = Predictive(model, num_samples=500).forward(
+        prior = Predictive(model, num_samples=500)(
             eight_schools_params["J"], torch.from_numpy(eight_schools_params["sigma"]).float()
         )
         return from_pyro(
@@ -38,7 +38,7 @@ class TestDataPyro:
             prior=prior,
             posterior_predictive=posterior_predictive,
             coords={"school": np.arange(eight_schools_params["J"])},
-            dims={"theta": ["school"], "eta": ["school"]}
+            dims={"theta": ["school"], "eta": ["school"]},
         )
 
     def test_inference_data(self, data, eight_schools_params):
@@ -66,10 +66,10 @@ class TestDataPyro:
     def test_inference_data_no_posterior(self, data, eight_schools_params):
         posterior_samples = data.obj.get_samples()
         model = data.obj.kernel.model
-        posterior_predictive = Predictive(model, posterior_samples).forward(
+        posterior_predictive = Predictive(model, posterior_samples)(
             eight_schools_params["J"], torch.from_numpy(eight_schools_params["sigma"]).float()
         )
-        prior = Predictive(model, num_samples=500).forward(
+        prior = Predictive(model, num_samples=500)(
             eight_schools_params["J"], torch.from_numpy(eight_schools_params["sigma"]).float()
         )
         idata = from_pyro(

--- a/arviz/tests/test_data_pyro.py
+++ b/arviz/tests/test_data_pyro.py
@@ -27,10 +27,10 @@ class TestDataPyro:
     def get_inference_data(self, data, eight_schools_params):
         posterior_samples = data.obj.get_samples()
         model = data.obj.kernel.model
-        posterior_predictive = Predictive(model, posterior_samples).get_samples(
+        posterior_predictive = Predictive(model, posterior_samples).forward(
             eight_schools_params["J"], torch.from_numpy(eight_schools_params["sigma"]).float()
         )
-        prior = Predictive(model, num_samples=500).get_samples(
+        prior = Predictive(model, num_samples=500).forward(
             eight_schools_params["J"], torch.from_numpy(eight_schools_params["sigma"]).float()
         )
         return from_pyro(
@@ -66,10 +66,10 @@ class TestDataPyro:
     def test_inference_data_no_posterior(self, data, eight_schools_params):
         posterior_samples = data.obj.get_samples()
         model = data.obj.kernel.model
-        posterior_predictive = Predictive(model, posterior_samples).get_samples(
+        posterior_predictive = Predictive(model, posterior_samples).forward(
             eight_schools_params["J"], torch.from_numpy(eight_schools_params["sigma"]).float()
         )
-        prior = Predictive(model, num_samples=500).get_samples(
+        prior = Predictive(model, num_samples=500).forward(
             eight_schools_params["J"], torch.from_numpy(eight_schools_params["sigma"]).float()
         )
         idata = from_pyro(

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,10 +14,10 @@ jobs:
         PYRO_VERSION: "latest"
         EMCEE_VERSION: "latest"
         NAME: "UNIT"
-      Python_36_Unit_Test_PyStan_3_Pyro_0.5.1_Emcee_2_tf_1:
+      Python_36_Unit_Test_PyStan_3_Pyro_1.0.0_Emcee_2_tf_1:
         PYTHON_VERSION: 3.6
         PYSTAN_VERSION: "preview"
-        PYRO_VERSION: 0.5.1
+        PYRO_VERSION: 1.0.0
         PYTORCH_VERSION: 1.3.0
         EMCEE_VERSION: 2
         TF_VERSION: 1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ nbsphinx
 numpydoc
 pydocstyle<5.0
 pylint
-pyro-ppl>=0.5.1
+pyro-ppl>=1.0.0
 tensorflow
 tensorflow-probability
 pytest


### PR DESCRIPTION
Follows #796, for Pyro and NumPyro: I added "log_likelihood" to InferenceData, and added tests for multiple observed variables. 

Thanks for a Pyro/NumPyro expert to review this (@fehiepsi maybe?). Indeed, I am not entirely sure about the Pyro part: the test_multiple_observed_rv fails if y2 and y1 have different dimensions. 
For the rest, I copied io_pymc3.py, in particular for coord_name and dims.

Sorry in advance for the possible mistakes, it's my first commit.