### PR TITLE
use get_bins function to compute bins for density and posterior plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * Add `skipna` argument to `hpd` and `summary` (#1035)
 
 ### Maintenance and fixes
+* Fixed bug in density and posterior plot bin computation (#1049)
+* Fixed bug in density plot ax argument (#1049)
 * Fixed bug in extracting prior samples for cmdstanpy (#979)
 * Fix erroneous warning in traceplot (#989)
 * Correct bfmi denominator (#991)

--- a/arviz/plots/backends/bokeh/densityplot.py
+++ b/arviz/plots/backends/bokeh/densityplot.py
@@ -10,6 +10,7 @@ from ...plot_utils import (
     _create_axes_grid,
     calculate_point_estimate,
     _fast_kde,
+    get_bins,
 )
 from ....stats import hpd
 from ....stats.stats_utils import histogram
@@ -159,7 +160,7 @@ def _d_helper(
 
     else:
         xmin, xmax = hpd(vec, credible_interval, multimodal=False)
-        bins = range(xmin, xmax + 2)
+        bins = get_bins(vec)
 
         _, hist, edges = histogram(vec, bins=bins)
 

--- a/arviz/plots/backends/bokeh/posteriorplot.py
+++ b/arviz/plots/backends/bokeh/posteriorplot.py
@@ -15,6 +15,7 @@ from ...plot_utils import (
     format_sig_figs,
     round_num,
     calculate_point_estimate,
+    get_bins,
 )
 from ....stats import hpd
 
@@ -245,9 +246,7 @@ def _plot_posterior_op(
     else:
         if bins is None:
             if values.dtype.kind == "i":
-                xmin = values.min()
-                xmax = values.max()
-                bins = range(xmin, xmax + 2)
+                bins = get_bins(values)
             else:
                 bins = "auto"
         kwargs.setdefault("align", "left")

--- a/arviz/plots/backends/matplotlib/densityplot.py
+++ b/arviz/plots/backends/matplotlib/densityplot.py
@@ -9,6 +9,7 @@ from ...plot_utils import (
     _create_axes_grid,
     calculate_point_estimate,
     _fast_kde,
+    get_bins,
 )
 
 
@@ -150,7 +151,7 @@ def _d_helper(
 
     else:
         xmin, xmax = hpd(vec, credible_interval, multimodal=False)
-        bins = range(xmin, xmax + 2)
+        bins = get_bins(vec)
         if outline:
             ax.hist(vec, bins=bins, color=color, histtype="step", align="left")
         if shade:

--- a/arviz/plots/backends/matplotlib/densityplot.py
+++ b/arviz/plots/backends/matplotlib/densityplot.py
@@ -50,9 +50,8 @@ def plot_density(
         )
     else:
         ax = np.atleast_2d(ax)
-    
-    axis_map = {label: ax_ for label, ax_ in zip(all_labels, np.ravel(ax))}
 
+    axis_map = {label: ax_ for label, ax_ in zip(all_labels, np.ravel(ax))}
 
     for m_idx, plotters in enumerate(to_plot):
         for var_name, selection, values in plotters:

--- a/arviz/plots/backends/matplotlib/densityplot.py
+++ b/arviz/plots/backends/matplotlib/densityplot.py
@@ -38,16 +38,21 @@ def plot_density(
     show,
 ):
     """Matplotlib densityplot."""
-    _, ax = _create_axes_grid(
-        length_plotters,
-        rows,
-        cols,
-        figsize=figsize,
-        squeeze=False,
-        backend="matplotlib",
-        backend_kwargs=backend_kwargs,
-    )
-    axis_map = {label: ax_ for label, ax_ in zip(all_labels, ax.flatten())}
+    if ax is None:
+        _, ax = _create_axes_grid(
+            length_plotters,
+            rows,
+            cols,
+            figsize=figsize,
+            squeeze=False,
+            backend="matplotlib",
+            backend_kwargs=backend_kwargs,
+        )
+    else:
+        ax = np.atleast_2d(ax)
+    
+    axis_map = {label: ax_ for label, ax_ in zip(all_labels, np.ravel(ax))}
+
 
     for m_idx, plotters in enumerate(to_plot):
         for var_name, selection, values in plotters:

--- a/arviz/plots/backends/matplotlib/posteriorplot.py
+++ b/arviz/plots/backends/matplotlib/posteriorplot.py
@@ -13,6 +13,7 @@ from ...plot_utils import (
     format_sig_figs,
     round_num,
     calculate_point_estimate,
+    get_bins
 )
 
 
@@ -258,7 +259,7 @@ def _plot_posterior_op(
             if values.dtype.kind == "i":
                 xmin = values.min()
                 xmax = values.max()
-                bins = range(xmin, xmax + 2)
+                bins = get_bins(values)
                 ax.set_xlim(xmin - 0.5, xmax + 0.5)
             else:
                 bins = "auto"

--- a/arviz/plots/backends/matplotlib/posteriorplot.py
+++ b/arviz/plots/backends/matplotlib/posteriorplot.py
@@ -13,7 +13,7 @@ from ...plot_utils import (
     format_sig_figs,
     round_num,
     calculate_point_estimate,
-    get_bins
+    get_bins,
 )
 
 


### PR DESCRIPTION
Hello everyone. I have made some changes in density and posterior plot. Bins were not computed using the `get_bins` function. Also `plot_density` did not take the `ax` argument.

Before
![density_before](https://user-images.githubusercontent.com/8028618/73939011-49ad3000-48c7-11ea-830e-63ee357226f7.png)
![posterior_before](https://user-images.githubusercontent.com/8028618/73939013-4b76f380-48c7-11ea-84fc-688cde5b67b9.png)

After
![density_after](https://user-images.githubusercontent.com/8028618/73939030-53369800-48c7-11ea-8cd6-16763ab252ef.png)
![posterior_after](https://user-images.githubusercontent.com/8028618/73939034-55005b80-48c7-11ea-8740-2b19feff115d.png)





