### PR TITLE
Fix io_pyro prior dims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * Fix several inconsistencies between schema and `from_pymc3` implementation
   in groups `prior`, `prior_predictive` and `observed_data` (#1045)
 * Stabilize covariance matrix for `plot_kde_2d` (#1075)
+* Removed extra dim in `prior` data in `from_pyro` (#1071)
 
 ### Deprecation
 

--- a/arviz/data/io_pyro.py
+++ b/arviz/data/io_pyro.py
@@ -144,7 +144,10 @@ class PyroConverter:
                 None
                 if var_names is None
                 else dict_to_dataset(
-                    {k: utils.expand_dims(self.prior[k].detach().cpu().numpy()) for k in var_names},
+                    {
+                        k: utils.expand_dims(np.squeeze(self.prior[k].detach().cpu().numpy()))
+                        for k in var_names
+                    },
                     library=self.pyro,
                     coords=self.coords,
                     dims=self.dims,


### PR DESCRIPTION
## Description
<!--
Thank you so much for your PR! To help us review your contribution, please consider the following points:

- The PR title should summarize the changes, for example "Add new group argument for the pair plot".
  Avoid non-descriptive titles such as "Addresses issue #348".

- The description should provide at least 1-2 sentences describing the pull request in detail and
  link to any relevant issues.

- Please prefix the title of incomplete contributions with [WIP] (to indicate a work in
  progress). WIPs may be useful to (1) indicate you are working on something to avoid
  duplicated work, (2) request broad review of functionality or API, or (3) seek collaborators. -->
Currently, ```io_pyro``` adds an extra dim to the data variables in ```prior```. This is because the pyro data is 2D (column vector) and calling ```expand_dims``` on this creates a 3D variable with an unwanted dim.
This is to fix that behaviour.
## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Code style  correct (follows pylint and black guidelines)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/master/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
