### PR TITLE
Remove hpd redundant copy

### DIFF
--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -395,7 +395,6 @@ def hpd(ary, credible_interval=None, circular=False, multimodal=False, skipna=Fa
         hpd_intervals = np.array(hpd_intervals)
 
     else:
-        ary = ary.copy()
         if skipna:
             nans = np.isnan(ary)
             if not nans.all():


### PR DESCRIPTION
## Description
`hpd` makes a redundant copy for the unimodal use case since the input array is not being modified. 

Wrote some code just to double check:
```
a = np.random.random((5000,))
b = a.copy()
hpd(b, 0.9)
assert np.array_equal(a, b)
```

## Checklist
- [X] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format