### PR TITLE
Codecov follow-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="https://arviz-devs.github.io/arviz/_static/logo.png" height=100></img>
 
 [![Azure Build Status](https://dev.azure.com/ArviZ/ArviZ/_apis/build/status/arviz-devs.arviz?branchName=master)](https://dev.azure.com/ArviZ/ArviZ/_build/latest?definitionId=1&branchName=master)
-[![Coverage Status](https://coveralls.io/repos/github/arviz-devs/arviz/badge.svg?branch=master)](https://coveralls.io/github/arviz-devs/arviz?branch=master)
+[![codecov](https://codecov.io/gh/arviz-devs/arviz/branch/master/graph/badge.svg)](https://codecov.io/gh/arviz-devs/arviz)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/arviz-devs/community)
 [![DOI](http://joss.theoj.org/papers/10.21105/joss.01143/status.svg)](https://doi.org/10.21105/joss.01143) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2540945.svg)](https://doi.org/10.5281/zenodo.2540945)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,5 @@
 ignore:
   - arviz/tests/
+
+comment:
+  after_n_builds: 5

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -171,7 +171,7 @@ Here is the citation in BibTeX format
     </div>
 
 
-.. |Build Status| image:: https://travis-ci.org/arviz-devs/arviz.png?branch=master
-   :target: https://travis-ci.org/arviz-devs/arviz
-.. |Coverage Status| image:: https://coveralls.io/repos/github/arviz-devs/arviz/badge.svg?branch=master
-   :target: https://coveralls.io/github/arviz-devs/arviz?branch=master
+.. |Build Status| image:: https://dev.azure.com/ArviZ/ArviZ/_apis/build/status/arviz-devs.arviz?branchName=master
+   :target: https://dev.azure.com/ArviZ/ArviZ/_build/latest?definitionId=1&branchName=master
+.. |Coverage Status| image:: https://codecov.io/gh/arviz-devs/arviz/branch/master/graph/badge.svg
+  :target: https://codecov.io/gh/arviz-devs/arviz


### PR DESCRIPTION
## Description
I'd like to force codecov to wait before commenting. I find it can be quite confusing to new contributors to have a "this pr will decrease code coverage a 14%" for several minutes (from the end of base tests to the end of external tests)

Also updated the badge.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/master/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
