### PR TITLE
Normalize dataframe dtypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * Stabilize covariance matrix for `plot_kde_2d` (#1075)
 * Removed extra dim in `prior` data in `from_pyro` (#1071)
 * Moved CI and docs (build & deploy) to Azure Pipelines and started using codecov (#1080)
+* Normalize pandas dataframe dtypes (#1092)
 
 ### Deprecation
 * `from_pymc3` now requires PyMC3>=3.8

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -20,6 +20,7 @@ from .stats_utils import (
     wrap_xarray_ufunc as _wrap_xarray_ufunc,
     logsumexp as _logsumexp,
     ELPDData,
+    normalize_dtypes as _normalize_dtypes,
     stats_variance_2d as svar,
     histogram,
     _circular_standard_deviation,
@@ -284,6 +285,8 @@ def compare(
                 res["warning"],
                 res[scale_col],
             )
+
+    df_comp = _normalize_dtypes(df_comp)
 
     return df_comp.sort_values(by=ic, ascending=ascending)
 
@@ -1094,11 +1097,11 @@ def summary(
                 df.index = list(df.index)
                 df = df.T
             dfs.append(df)
-        summary_df = pd.concat(dfs, sort=False)
+        summary_df = _normalize_dtypes(pd.concat(dfs, sort=False))
     elif fmt.lower() == "long":
         df = joined.to_dataframe().reset_index().set_index("metric")
         df.index = list(df.index)
-        summary_df = df
+        summary_df = _normalize_dtypes(df)
     else:
         # format is 'xarray'
         summary_df = joined

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -20,7 +20,7 @@ from .stats_utils import (
     wrap_xarray_ufunc as _wrap_xarray_ufunc,
     logsumexp as _logsumexp,
     ELPDData,
-    normalize_dtypes as _normalize_dtypes,
+    normalize_dataframe_dtypes as _normalize_dataframe_dtypes,
     stats_variance_2d as svar,
     histogram,
     _circular_standard_deviation,
@@ -286,7 +286,7 @@ def compare(
                 res[scale_col],
             )
 
-    df_comp = _normalize_dtypes(df_comp)
+    df_comp = _normalize_dataframe_dtypes(df_comp)
 
     return df_comp.sort_values(by=ic, ascending=ascending)
 
@@ -1097,11 +1097,11 @@ def summary(
                 df.index = list(df.index)
                 df = df.T
             dfs.append(df)
-        summary_df = _normalize_dtypes(pd.concat(dfs, sort=False))
+        summary_df = _normalize_dataframe_dtypes(pd.concat(dfs, sort=False))
     elif fmt.lower() == "long":
         df = joined.to_dataframe().reset_index().set_index("metric")
         df.index = list(df.index)
-        summary_df = _normalize_dtypes(df)
+        summary_df = _normalize_dataframe_dtypes(df)
     else:
         # format is 'xarray'
         summary_df = joined

--- a/arviz/stats/stats_utils.py
+++ b/arviz/stats/stats_utils.py
@@ -563,15 +563,15 @@ def _circular_standard_deviation(samples, high=2 * np.pi, low=0, skipna=False, a
     return ((high - low) / 2.0 / np.pi) * np.sqrt(-2 * np.log(r_r))
 
 
-def normalize_dtypes(dataframe):
+def normalize_dataframe_dtypes(dataframe):
     """Normalize dataframe dtypes for common cases."""
     columns = dataframe.columns
     for column in columns:
         dtype = dataframe[column].dtype
-        if isinstance(dtype, np.floating):
+        if np.issubdtype(dtype, np.floating):
             if dtype != np.dtype("float64"):
                 dataframe[column] = dataframe[column].astype("float64")
-        elif isinstance(dtype, np.integer):
+        elif np.issubdtype(dtype, np.integer):
             if dtype != np.dtype("int64"):
                 dataframe[column] = dataframe[column].astype("int64")
     return dataframe

--- a/arviz/stats/stats_utils.py
+++ b/arviz/stats/stats_utils.py
@@ -561,3 +561,17 @@ def _circular_standard_deviation(samples, high=2 * np.pi, low=0, skipna=False, a
     c_c = np.cos(ang).mean(axis=axis)
     r_r = np.hypot(s_s, c_c)
     return ((high - low) / 2.0 / np.pi) * np.sqrt(-2 * np.log(r_r))
+
+
+def normalize_dtypes(dataframe):
+    """Normalize dataframe dtypes for common cases."""
+    columns = dataframe.columns
+    for column in columns:
+        dtype = dataframe[column].dtype
+        if isinstance(dtype, np.floating):
+            if dtype != np.dtype("float64"):
+                dataframe[column] = dataframe[column].astype("float64")
+        elif isinstance(dtype, np.integer):
+            if dtype != np.dtype("int64"):
+                dataframe[column] = dataframe[column].astype("int64")
+    return dataframe

--- a/arviz/tests/base_tests/test_stats_utils.py
+++ b/arviz/tests/base_tests/test_stats_utils.py
@@ -2,6 +2,7 @@
 #  pylint: disable=no-member
 import numpy as np
 from numpy.testing import assert_array_almost_equal
+import pandas as pd
 import pytest
 from scipy.special import logsumexp
 from scipy.stats import circstd
@@ -13,6 +14,7 @@ from ...stats.stats_utils import (
     wrap_xarray_ufunc,
     not_valid,
     ELPDData,
+    normalize_dtypes,
     stats_variance_2d,
     histogram,
     _sqrt,
@@ -293,3 +295,17 @@ def test_circular_standard_deviation_1d(data):
     assert np.allclose(
         _circular_standard_deviation(data, high=high, low=low), circstd(data, high=high, low=low),
     )
+
+
+def test_normalize_dataframe_dtypes():
+    dataframe = pd.DataFrame(
+        {
+            "int": np.array([1, 2, 3], dtype=np.int32),
+            "float": np.array([1, 2, 3], dtype=np.float32),
+            "bool": np.array([1, 0, 0], dtype=np.bool),
+        }
+    )
+    dataframe = normalize_dataframe_dtypes(dataframe)
+    assert dataframe["int"].dtype == np.int64
+    assert dataframe["float"].dtype == np.float64
+    assert dataframe["bool"].dtype == np.bool

--- a/arviz/tests/base_tests/test_stats_utils.py
+++ b/arviz/tests/base_tests/test_stats_utils.py
@@ -14,7 +14,7 @@ from ...stats.stats_utils import (
     wrap_xarray_ufunc,
     not_valid,
     ELPDData,
-    normalize_dtypes,
+    normalize_dataframe_dtypes,
     stats_variance_2d,
     histogram,
     _sqrt,


### PR DESCRIPTION
## Description

Normalize pandas dataframe columns.

Main points are:
- `int32` --> `int64` 
- `float32` --> `float64`

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [ ] New features are properly documented (with an example if appropriate)?
- [ ] Includes new or updated tests to cover the new feature
- [ ] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/master/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
