### PR TITLE
Revise docstring for plot_density().

### DIFF
--- a/arviz/plots/autocorrplot.py
+++ b/arviz/plots/autocorrplot.py
@@ -47,8 +47,9 @@ def plot_autocorr(
     textsize: float
         Text size scaling factor for labels, titles and lines. If None it will be autoscaled based
         on figsize.
-    ax: axes, optional
-        Matplotlib axes or bokeh figures.
+    ax: numpy array of matplotlib axes or bokeh figures, optional
+        A 2D array of locations into which to plot the densities. If not supplied, Arviz will create
+        its own array of plot areas (and return it).
     backend: str, optional
         Select plotting backend {"matplotlib","bokeh"}. Default "matplotlib".
     backend_config: dict, optional

--- a/arviz/plots/autocorrplot.py
+++ b/arviz/plots/autocorrplot.py
@@ -47,7 +47,7 @@ def plot_autocorr(
     textsize: float
         Text size scaling factor for labels, titles and lines. If None it will be autoscaled based
         on figsize.
-    ax: numpy array of matplotlib axes or bokeh figures, optional
+    ax: numpy array-like of matplotlib axes or bokeh figures, optional
         A 2D array of locations into which to plot the densities. If not supplied, Arviz will create
         its own array of plot areas (and return it).
     backend: str, optional

--- a/arviz/plots/densityplot.py
+++ b/arviz/plots/densityplot.py
@@ -88,7 +88,7 @@ def plot_density(
     textsize: Optional[float]
         Text size scaling factor for labels, titles and lines. If None it will be autoscaled based
         on figsize.
-    ax: numpy array of matplotlib axes or bokeh figures, optional
+    ax: numpy array-like of matplotlib axes or bokeh figures, optional
         A 2D array of locations into which to plot the densities. If not supplied, Arviz will create
         its own array of plot areas (and return it).
     backend: str, optional

--- a/arviz/plots/densityplot.py
+++ b/arviz/plots/densityplot.py
@@ -89,8 +89,8 @@ def plot_density(
         Text size scaling factor for labels, titles and lines. If None it will be autoscaled based
         on figsize.
     ax: numpy array of matplotlib axes or bokeh figures, optional
-        Array of locations into which to plot the densities. If not supplied, Arviz will create its
-        own array of plot areas (and return it).
+        A 2D array of locations into which to plot the densities. If not supplied, Arviz will create
+        its own array of plot areas (and return it).
     backend: str, optional
         Select plotting backend {"matplotlib","bokeh"}. Default "matplotlib".
     backend_kwargs: bool, optional

--- a/arviz/plots/densityplot.py
+++ b/arviz/plots/densityplot.py
@@ -88,8 +88,9 @@ def plot_density(
     textsize: Optional[float]
         Text size scaling factor for labels, titles and lines. If None it will be autoscaled based
         on figsize.
-    ax: axes, optional
-        Matplotlib axes or Bokeh figures.
+    ax: numpy array of matplotlib axes or bokeh figures, optional
+        Array of locations into which to plot the densities. If not supplied, Arviz will create its
+        own array of plot areas (and return it).
     backend: str, optional
         Select plotting backend {"matplotlib","bokeh"}. Default "matplotlib".
     backend_kwargs: bool, optional

--- a/arviz/plots/essplot.py
+++ b/arviz/plots/essplot.py
@@ -71,7 +71,7 @@ def plot_ess(
         Plot mean and sd ESS as horizontal lines. Not taken into account in evolution kind
     min_ess : int
         Minimum number of ESS desired.
-    ax: numpy array of matplotlib axes or bokeh figures, optional
+    ax: numpy array-like of matplotlib axes or bokeh figures, optional
         A 2D array of locations into which to plot the densities. If not supplied, Arviz will create
         its own array of plot areas (and return it).
     extra_kwargs : dict, optional

--- a/arviz/plots/essplot.py
+++ b/arviz/plots/essplot.py
@@ -71,8 +71,9 @@ def plot_ess(
         Plot mean and sd ESS as horizontal lines. Not taken into account in evolution kind
     min_ess : int
         Minimum number of ESS desired.
-    ax: axes, optional
-        Matplotlib axes or bokeh figures.
+    ax: numpy array of matplotlib axes or bokeh figures, optional
+        A 2D array of locations into which to plot the densities. If not supplied, Arviz will create
+        its own array of plot areas (and return it).
     extra_kwargs : dict, optional
         If evolution plot, extra_kwargs is used to plot ess tail and differentiate it
         from ess bulk. Otherwise, passed to extra methods lines.

--- a/arviz/plots/mcseplot.py
+++ b/arviz/plots/mcseplot.py
@@ -65,7 +65,7 @@ def plot_mcse(
     n_points : int
         Number of points for which to plot their quantile/local ess or number of subsets
         in the evolution plot.
-    ax: numpy array of matplotlib axes or bokeh figures, optional
+    ax: numpy array-like of matplotlib axes or bokeh figures, optional
         A 2D array of locations into which to plot the densities. If not supplied, Arviz will create
         its own array of plot areas (and return it).
     rug_kwargs : dict

--- a/arviz/plots/mcseplot.py
+++ b/arviz/plots/mcseplot.py
@@ -65,8 +65,9 @@ def plot_mcse(
     n_points : int
         Number of points for which to plot their quantile/local ess or number of subsets
         in the evolution plot.
-    ax: axes, optional
-        Matplotlib axes or bokeh figures.
+    ax: numpy array of matplotlib axes or bokeh figures, optional
+        A 2D array of locations into which to plot the densities. If not supplied, Arviz will create
+        its own array of plot areas (and return it).
     rug_kwargs : dict
         kwargs passed to rug plot.
     extra_kwargs : dict, optional

--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -46,8 +46,8 @@ def plot_pair(
         Refer to documentation of az.convert_to_dataset for details
     group : str, optional
         Specifies which InferenceData group should be plotted.  Defaults to 'posterior'.
-    var_names : list of variable names
-        Variables to be plotted, if None all variable are plotted
+    var_names : list of variable names, optional
+        Variables to be plotted, if ``None`` all variables are plotted
     coords : mapping, optional
         Coordinates of var_names to be plotted. Passed to `Dataset.sel`
     figsize : figure size tuple

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -86,7 +86,7 @@ def plot_posterior(
         Controls the number of bins, accepts the same keywords `matplotlib.hist()` does. Only works
         if `kind == hist`. If None (default) it will use `auto` for continuous variables and
         `range(xmin, xmax + 1)` for discrete variables.
-    ax: numpy array of matplotlib axes or bokeh figures, optional
+    ax: numpy array-like of matplotlib axes or bokeh figures, optional
         A 2D array of locations into which to plot the densities. If not supplied, Arviz will create
         its own array of plot areas (and return it).
     backend: str, optional

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -86,8 +86,9 @@ def plot_posterior(
         Controls the number of bins, accepts the same keywords `matplotlib.hist()` does. Only works
         if `kind == hist`. If None (default) it will use `auto` for continuous variables and
         `range(xmin, xmax + 1)` for discrete variables.
-    ax: axes, optional
-        Matplotlib axes or bokeh figures.
+    ax: numpy array of matplotlib axes or bokeh figures, optional
+        A 2D array of locations into which to plot the densities. If not supplied, Arviz will create
+        its own array of plot areas (and return it).
     backend: str, optional
         Select plotting backend {"matplotlib","bokeh"}. Default "matplotlib".
     backend_kwargs: bool, optional

--- a/arviz/plots/ppcplot.py
+++ b/arviz/plots/ppcplot.py
@@ -104,7 +104,7 @@ def plot_ppc(
         Keywords passed to `animation.FuncAnimation`.
     legend : bool
         Add legend to figure. By default True.
-    ax: numpy array of matplotlib axes or bokeh figures, optional
+    ax: numpy array-like of matplotlib axes or bokeh figures, optional
         A 2D array of locations into which to plot the densities. If not supplied, Arviz will create
         its own array of plot areas (and return it).
     backend: str, optional

--- a/arviz/plots/ppcplot.py
+++ b/arviz/plots/ppcplot.py
@@ -104,8 +104,9 @@ def plot_ppc(
         Keywords passed to `animation.FuncAnimation`.
     legend : bool
         Add legend to figure. By default True.
-    ax: axes, optional
-        Matplotlib axes or bokeh figures.
+    ax: numpy array of matplotlib axes or bokeh figures, optional
+        A 2D array of locations into which to plot the densities. If not supplied, Arviz will create
+        its own array of plot areas (and return it).
     backend: str, optional
         Select plotting backend {"matplotlib","bokeh"}. Default "matplotlib".
     backend_kwargs: bool, optional

--- a/arviz/plots/rankplot.py
+++ b/arviz/plots/rankplot.py
@@ -73,7 +73,7 @@ def plot_rank(
         wheter to plot or not the x and y labels, defaults to True
     figsize : tuple
         Figure size. If None it will be defined automatically.
-    ax: numpy array of matplotlib axes or bokeh figures, optional
+    ax: numpy array-like of matplotlib axes or bokeh figures, optional
         A 2D array of locations into which to plot the densities. If not supplied, Arviz will create
         its own array of plot areas (and return it).
     backend: str, optional

--- a/arviz/plots/rankplot.py
+++ b/arviz/plots/rankplot.py
@@ -73,8 +73,9 @@ def plot_rank(
         wheter to plot or not the x and y labels, defaults to True
     figsize : tuple
         Figure size. If None it will be defined automatically.
-    ax: axes, optional
-        Matplotlib axes or bokeh figures.
+    ax: numpy array of matplotlib axes or bokeh figures, optional
+        A 2D array of locations into which to plot the densities. If not supplied, Arviz will create
+        its own array of plot areas (and return it).
     backend: str, optional
         Select plotting backend {"matplotlib","bokeh"}. Default "matplotlib".
     backend_kwargs: bool, optional

--- a/arviz/plots/violinplot.py
+++ b/arviz/plots/violinplot.py
@@ -70,7 +70,7 @@ def plot_violin(
         Defaults to True, violinplots share a common x-axis scale.
     sharey : bool
         Defaults to True, violinplots share a common y-axis scale.
-    ax: numpy array of matplotlib axes or bokeh figures, optional
+    ax: numpy array-like of matplotlib axes or bokeh figures, optional
         A 2D array of locations into which to plot the densities. If not supplied, Arviz will create
         its own array of plot areas (and return it).
     shade_kwargs : dicts, optional

--- a/arviz/plots/violinplot.py
+++ b/arviz/plots/violinplot.py
@@ -70,8 +70,9 @@ def plot_violin(
         Defaults to True, violinplots share a common x-axis scale.
     sharey : bool
         Defaults to True, violinplots share a common y-axis scale.
-    ax: axes, optional
-        Matplotlib axes or bokeh figures.
+    ax: numpy array of matplotlib axes or bokeh figures, optional
+        A 2D array of locations into which to plot the densities. If not supplied, Arviz will create
+        its own array of plot areas (and return it).
     shade_kwargs : dicts, optional
         Additional keywords passed to `fill_between`, or `barh` to control the shade.
     rug_kwargs : dict


### PR DESCRIPTION
Previously, this specified the `ax` argument as taking an (optional)
axes.  This is incorrect: it takes a 2D array of axes or bokeh figures.

Perhaps we should explicitly point out that a 2D array is required.  The code requires *at least* 2D, but I'm not sure what would happen if one passed a higher-dimensional array.