### PR TITLE
Use valid codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,7 +7,6 @@ codecov:
 
 comment:
     behavior: default
-    after_n_builds: 5
     branches:
         - "master"
 


### PR DESCRIPTION
## Description
`after_n_builds` is not valid in `comment` section. According to [codecov community](https://community.codecov.io/t/how-to-troubleshoot-ignored-yaml-file/1102/2), this should solve the issue (codecov is currently ignoring the yaml basically)

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/master/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
