### PR TITLE
extend make_ufunc and improve wrap_xarray_ufunc defaults

### DIFF
--- a/arviz/stats/stats_utils.py
+++ b/arviz/stats/stats_utils.py
@@ -209,7 +209,7 @@ def wrap_xarray_ufunc(
         func_kwargs = {}
 
     kwargs.setdefault(
-        "input_core_dims", tuple(("chain", "draw") for _ in range(len(func_args) + 1))
+        "input_core_dims", tuple(("chain", "draw") for _ in range(len(func_args) + len(datasets)))
     )
     ufunc_kwargs.setdefault("n_dims", len(kwargs["input_core_dims"][-1]))
     kwargs.setdefault("output_core_dims", tuple([] for _ in range(ufunc_kwargs.get("n_output", 1))))

--- a/arviz/stats/stats_utils.py
+++ b/arviz/stats/stats_utils.py
@@ -208,13 +208,12 @@ def wrap_xarray_ufunc(
     if func_kwargs is None:
         func_kwargs = {}
 
-
     kwargs.setdefault(
         "input_core_dims", tuple(("chain", "draw") for _ in range(len(func_args) + 1))
     )
     ufunc_kwargs.setdefault("n_dims", len(kwargs["input_core_dims"][-1]))
     kwargs.setdefault("output_core_dims", tuple([] for _ in range(ufunc_kwargs.get("n_output", 1))))
-    
+
     callable_ufunc = make_ufunc(ufunc, **ufunc_kwargs)
 
     return apply_ufunc(callable_ufunc, *datasets, *func_args, kwargs=func_kwargs, **kwargs)


### PR DESCRIPTION
## Description
Currently `az.hpd` uses a recursive pattern to compute hpd values for 1d or 2d arrays. It would be great to create an `_hpd` function that is then used by `az.hpd` via `wrap_xarray_ufunc` (like it is done with ess, rhat...). 

I have realized that `make_ufunc` does not support the function returning extra output dimensions, which would be needed for hpd to work and return a single array. This extends `make_ufunc` and improves slightly the defaults for `wrap_xarray_ufunc`. 

There is one drawback/divergence from the ufunc default arguments. `xr.apply_ufunc` performs a separate call of the ufunc for each data variable (in the case of datasets) but the kwargs passed to the ufunc are always the same for all data variables. This behaviour makes the `out` argument not usable when the shapes of each data variable differ, the same out array is passed to all calls. To sort this out I thought about adding an `out_shape` argument which will be present to all ufuncs generated with `make_ufunc`. This argument indicates the shape of the extra dims (i.e. in hpd, `out_shape=(2,)`). 

Therefore, this PR allows to do things like:

```python
import arviz as az
data = az.load_arviz_data("centered_eight").posterior
az.wrap_xarray_ufunc(
    az.hpd, 
    data, 
    output_core_dims =[['hpd']], 
    func_kwargs={"out_shape": (2,)}
)
# <xarray.Dataset>
# Dimensions:  (hpd: 2, school: 8)
# Coordinates:
#  * school   (school) object 'Choate' 'Deerfield' ... "St. Paul's" 'Mt. Hermon'
# Dimensions without coordinates: hpd
# Data variables:
#     mu       (hpd) float64 -2.118 10.4
#     theta    (school, hpd) float64 -3.707 17.34 -4.039 ... 16.92 -5.665 15.27
#     tau      (hpd) float64 0.5692 9.386

az.wrap_xarray_ufunc(
    az.hpd, data, 
    input_core_dims=[["draw"]], 
    output_core_dims =[['hpd']], 
    func_kwargs={"out_shape": (2,)}
)
# <xarray.Dataset>
# Dimensions:  (chain: 4, hpd: 2, school: 8)
# Coordinates:
#   * chain    (chain) int64 0 1 2 3
#   * school   (school) object 'Choate' 'Deerfield' ... "St. Paul's" 'Mt. Hermon'
# Dimensions without coordinates: hpd
# Data variables:
#     mu       (chain, hpd) float64 -1.996 9.312 -2.358 ... 11.52 -0.7842 9.985
#     theta    (chain, school, hpd) float64 -4.077 17.44 -3.104 ... -3.708 14.21
#     tau      (chain, hpd) float64 0.6768 8.881 1.013 9.1 ... 10.64 0.5001 8.994
```

It should be feasible to convert current `az.hpd` to `_hpd` removing the recursion and adding a flatten and create a new `az.hpd` that like `ess` accepts either arrays, datasets or inference data objects, coordinate values for hpd dim could also be added... The two examples above showcase that it could even have a `combined` argument to allow users to make the calculation on a per chain basis without using wrap_xarray_ufunc directly.

The PR has no tests yet, maybe we could add them in another PR? Or someone wants to hijack the PR and add the tests here? I'm not sure I'll have much time to thoroughly test this in the near future.

Related to #855. cc @percygautam @ahartikainen @aloctavodia 

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] New features are properly documented (with an example if appropriate)? **DOES NOT!**
- [ ] Includes new or updated tests to cover the new feature **DOES NOT!**
- [ ] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/master/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
