### PR TITLE
Allow xarray.Dataarray input to plots.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add out-of-sample groups (`predictions` and `predictions_constant_data`) and `constant_data` group to pyro translation #1090
 * Add `num_chains` and `pred_dims` arguments to io_pyro #1090
 * Integrate jointplot into pairplot, add point-estimate and overlay of plot kinds (#1079)
+* Allow xarray.Dataarray input for plots.(#1120)
 ### Maintenance and fixes
 * Fixed behaviour of `credible_interval=None` in `plot_posterior` (#1115)
 * Fixed hist kind of `plot_dist` with multidimensional input (#1115)

--- a/arviz/data/converters.py
+++ b/arviz/data/converters.py
@@ -33,7 +33,8 @@ def convert_to_inference_data(obj, *, group="posterior", coords=None, dims=None,
             | emcee sampler: Automatically extracts data
             | pyro MCMC: Automatically extracts data
             | xarray.Dataset: adds to InferenceData as only group
-            | xarray.DataArray: creates an xarray dataset as the only group
+            | xarray.DataArray: creates an xarray dataset as the only group, gives the
+                         array an arbitrary name, if name not set
             | dict: creates an xarray dataset as the only group
             | numpy array: creates an xarray dataset as the only group, gives the
                          array an arbitrary name
@@ -99,6 +100,8 @@ def convert_to_inference_data(obj, *, group="posterior", coords=None, dims=None,
     if isinstance(obj, xr.Dataset):
         dataset = obj
     elif isinstance(obj, xr.DataArray):
+        if obj.name is None:
+            obj.name = 'plot'
         dataset = obj.to_dataset()
     elif isinstance(obj, dict):
         dataset = dict_to_dataset(obj, coords=coords, dims=dims)
@@ -153,7 +156,8 @@ def convert_to_dataset(obj, *, group="posterior", coords=None, dims=None):
             pystan fit: Automatically extracts data
             pymc3 trace: Automatically extracts data
             xarray.Dataset: adds to InferenceData as only group
-            xarray.DataArray: creates an xarray dataset as the only group
+            xarray.DataArray: creates an xarray dataset as the only group, gives the
+                         array an arbitrary name, if name not set
             dict: creates an xarray dataset as the only group
             numpy array: creates an xarray dataset as the only group, gives the
                          array an arbitrary name

--- a/arviz/data/converters.py
+++ b/arviz/data/converters.py
@@ -101,7 +101,7 @@ def convert_to_inference_data(obj, *, group="posterior", coords=None, dims=None,
         dataset = obj
     elif isinstance(obj, xr.DataArray):
         if obj.name is None:
-            obj.name = 'plot'
+            obj.name = 'x'
         dataset = obj.to_dataset()
     elif isinstance(obj, dict):
         dataset = dict_to_dataset(obj, coords=coords, dims=dims)

--- a/arviz/data/converters.py
+++ b/arviz/data/converters.py
@@ -33,6 +33,7 @@ def convert_to_inference_data(obj, *, group="posterior", coords=None, dims=None,
             | emcee sampler: Automatically extracts data
             | pyro MCMC: Automatically extracts data
             | xarray.Dataset: adds to InferenceData as only group
+            | xarray.DataArray: creates an xarray dataset as the only group
             | dict: creates an xarray dataset as the only group
             | numpy array: creates an xarray dataset as the only group, gives the
                          array an arbitrary name
@@ -152,6 +153,7 @@ def convert_to_dataset(obj, *, group="posterior", coords=None, dims=None):
             pystan fit: Automatically extracts data
             pymc3 trace: Automatically extracts data
             xarray.Dataset: adds to InferenceData as only group
+            xarray.DataArray: creates an xarray dataset as the only group
             dict: creates an xarray dataset as the only group
             numpy array: creates an xarray dataset as the only group, gives the
                          array an arbitrary name

--- a/arviz/data/converters.py
+++ b/arviz/data/converters.py
@@ -97,6 +97,8 @@ def convert_to_inference_data(obj, *, group="posterior", coords=None, dims=None,
     # Cases that convert to xarray
     if isinstance(obj, xr.Dataset):
         dataset = obj
+    elif isinstance(obj, xr.DataArray):
+        dataset = obj.to_dataset()
     elif isinstance(obj, dict):
         dataset = dict_to_dataset(obj, coords=coords, dims=dims)
     elif isinstance(obj, np.ndarray):
@@ -109,6 +111,7 @@ def convert_to_inference_data(obj, *, group="posterior", coords=None, dims=None,
         return from_cmdstan(**kwargs)
     else:
         allowable_types = (
+            "xarray dataarray",
             "xarray dataset",
             "dict",
             "netcdf filename",

--- a/arviz/tests/base_tests/test_data.py
+++ b/arviz/tests/base_tests/test_data.py
@@ -892,9 +892,9 @@ class TestDataArrayToDataset:
         dataset = convert_to_dataset(
             xr.DataArray(np.random.randn(*shape),
             dims=('chain', 'draw', 'dim_0', 'dim_1', 'dim_2')))
-        assert len(dataset.data_vars) == 1
         var_name = list(dataset.data_vars)[0]
 
+        assert len(dataset.data_vars) == 1
         assert dataset.chain.shape == shape[:1]
         assert dataset.draw.shape == shape[1:2]
         assert dataset[var_name].shape == shape
@@ -904,10 +904,10 @@ class TestDataArrayToDataset:
         inference_data = convert_to_inference_data(
             xr.DataArray(np.random.randn(*shape),
             dims=('chain', 'draw', 'dim_0', 'dim_1', 'dim_2')), group="prior")
-        assert hasattr(inference_data, "prior")
-        assert len(inference_data.prior.data_vars) == 1
         var_name = list(inference_data.prior.data_vars)[0]
 
+        assert hasattr(inference_data, "prior")
+        assert len(inference_data.prior.data_vars) == 1
         assert inference_data.prior.chain.shape == shape[:1]
         assert inference_data.prior.draw.shape == shape[1:2]
         assert inference_data.prior[var_name].shape == shape

--- a/arviz/tests/base_tests/test_data.py
+++ b/arviz/tests/base_tests/test_data.py
@@ -879,7 +879,8 @@ class TestConversions:
 class TestDataArrayToDataset:
     def test_1d_dataset(self):
         size = 100
-        dataset = convert_to_dataset(xr.DataArray(np.random.randn(1, size), name="plot", dims=('chain', 'draw')))
+        dataset = convert_to_dataset(xr.DataArray(np.random.randn(1, size),
+                                                  name="plot", dims=('chain', 'draw')))
         assert len(dataset.data_vars) == 1
         assert dataset.variables.get("plot") is not None
         assert dataset.chain.shape == (1, )

--- a/arviz/tests/base_tests/test_data.py
+++ b/arviz/tests/base_tests/test_data.py
@@ -875,23 +875,22 @@ class TestConversions:
         assert inference_data.posterior["theta"].dims == ("chain", "draw", "Ivies")
 
 
-
 class TestDataArrayToDataset:
     def test_1d_dataset(self):
         size = 100
-        dataset = convert_to_dataset(xr.DataArray(np.random.randn(1, size),
-                                                  name="plot", dims=('chain', 'draw')))
+        dataset = convert_to_dataset(
+            xr.DataArray(np.random.randn(1, size), name="plot", dims=("chain", "draw"))
+        )
         assert len(dataset.data_vars) == 1
         assert "plot" in dataset.data_vars
-        assert dataset.chain.shape == (1, )
-        assert dataset.draw.shape == (size, )
-
+        assert dataset.chain.shape == (1,)
+        assert dataset.draw.shape == (size,)
 
     def test_nd_to_dataset(self):
         shape = (1, 2, 3, 4, 5)
         dataset = convert_to_dataset(
-            xr.DataArray(np.random.randn(*shape),
-            dims=('chain', 'draw', 'dim_0', 'dim_1', 'dim_2')))
+            xr.DataArray(np.random.randn(*shape), dims=("chain", "draw", "dim_0", "dim_1", "dim_2"))
+        )
         var_name = list(dataset.data_vars)[0]
 
         assert len(dataset.data_vars) == 1
@@ -902,8 +901,11 @@ class TestDataArrayToDataset:
     def test_nd_to_inference_data(self):
         shape = (1, 2, 3, 4, 5)
         inference_data = convert_to_inference_data(
-            xr.DataArray(np.random.randn(*shape),
-            dims=('chain', 'draw', 'dim_0', 'dim_1', 'dim_2')), group="prior")
+            xr.DataArray(
+                np.random.randn(*shape), dims=("chain", "draw", "dim_0", "dim_1", "dim_2")
+            ),
+            group="prior",
+        )
         var_name = list(inference_data.prior.data_vars)[0]
 
         assert hasattr(inference_data, "prior")

--- a/arviz/tests/base_tests/test_data.py
+++ b/arviz/tests/base_tests/test_data.py
@@ -882,7 +882,7 @@ class TestDataArrayToDataset:
         dataset = convert_to_dataset(xr.DataArray(np.random.randn(1, size),
                                                   name="plot", dims=('chain', 'draw')))
         assert len(dataset.data_vars) == 1
-        assert dataset.variables.get("plot") is not None
+        assert "plot" in dataset.data_vars
         assert dataset.chain.shape == (1, )
         assert dataset.draw.shape == (size, )
 

--- a/arviz/tests/base_tests/test_data.py
+++ b/arviz/tests/base_tests/test_data.py
@@ -879,9 +879,9 @@ class TestConversions:
 class TestDataArrayToDataset:
     def test_1d_dataset(self):
         size = 100
-        dataset = convert_to_dataset(xr.DataArray(np.random.randn(1, size), dims=('chain', 'draw')))
+        dataset = convert_to_dataset(xr.DataArray(np.random.randn(1, size), name="plot", dims=('chain', 'draw')))
         assert len(dataset.data_vars) == 1
-
+        assert dataset.variables.get("plot") is not None
         assert dataset.chain.shape == (1, )
         assert dataset.draw.shape == (size, )
 
@@ -910,4 +910,3 @@ class TestDataArrayToDataset:
         assert inference_data.prior.chain.shape == shape[:1]
         assert inference_data.prior.draw.shape == shape[1:2]
         assert inference_data.prior[var_name].shape == shape
-        assert repr(inference_data).startswith("Inference data with groups")

--- a/arviz/tests/base_tests/test_data.py
+++ b/arviz/tests/base_tests/test_data.py
@@ -879,16 +879,18 @@ class TestConversions:
 class TestDataArrayToDataset:
     def test_1d_dataset(self):
         size = 100
-        dataset = convert_to_dataset(xr.DataArray(np.random.randn(1,size),dims=('chain','draw')))
+        dataset = convert_to_dataset(xr.DataArray(np.random.randn(1, size), dims=('chain', 'draw')))
         assert len(dataset.data_vars) == 1
 
-        assert dataset.chain.shape == (1,)
-        assert dataset.draw.shape == (size,)
+        assert dataset.chain.shape == (1, )
+        assert dataset.draw.shape == (size, )
 
 
     def test_nd_to_dataset(self):
         shape = (1, 2, 3, 4, 5)
-        dataset = convert_to_dataset(xr.DataArray(np.random.randn(*shape),dims=('chain','draw','dim_0','dim_1','dim_2')))
+        dataset = convert_to_dataset(
+            xr.DataArray(np.random.randn(*shape),
+            dims=('chain', 'draw', 'dim_0', 'dim_1', 'dim_2')))
         assert len(dataset.data_vars) == 1
         var_name = list(dataset.data_vars)[0]
 
@@ -898,7 +900,9 @@ class TestDataArrayToDataset:
 
     def test_nd_to_inference_data(self):
         shape = (1, 2, 3, 4, 5)
-        inference_data = convert_to_inference_data(xr.DataArray(np.random.randn(*shape),dims=('chain','draw','dim_0','dim_1','dim_2')), group="prior")
+        inference_data = convert_to_inference_data(
+            xr.DataArray(np.random.randn(*shape),
+            dims=('chain', 'draw', 'dim_0', 'dim_1', 'dim_2')), group="prior")
         assert hasattr(inference_data, "prior")
         assert len(inference_data.prior.data_vars) == 1
         var_name = list(inference_data.prior.data_vars)[0]


### PR DESCRIPTION
## Description
<!--
Thank you so much for your PR! To help us review your contribution, please consider the following points:

- The PR title should summarize the changes, for example "Add new group argument for the pair plot".
  Avoid non-descriptive titles such as "Addresses issue #348".

- The description should provide at least 1-2 sentences describing the pull request in detail and
  link to any relevant issues.

- Please prefix the title of incomplete contributions with [WIP] (to indicate a work in
  progress). WIPs may be useful to (1) indicate you are working on something to avoid
  duplicated work, (2) request broad review of functionality or API, or (3) seek collaborators. -->
This PR is not related to any issue but, as Discussed in #1104 I have made changes to converter.py to allow dataarray input
Consider following code snippet-
`import arviz as az`
`import numpy as np`
`import xarray as xr`
`xarr=xr.DataArray(np.random.randn(6,2),name="nm",dims=('chains', 'draw'),coords={'draw':[1,2]})`
`az.plot_posterior(xarr,var_names="nm")`

`
**Output without changes-**  
Traceback (most recent call last):
  

> File "/home/smit/gsoc/repro.py", line 6, in <module>
 az.plot_posterior(xarr,var_names="nm")
  File "/home/smit/gsoc/local/arv/lib/python3.6/site-packages/arviz-0.7.0-py3.6.egg/arviz/plots/posteriorplot.py", line 184, in plot_posterior
    data = convert_to_dataset(data, group=group)
  File "/home/smit/gsoc/local/arv/lib/python3.6/site-packages/arviz-0.7.0-py3.6.egg/arviz/data/converters.py", line 177, in convert_to_dataset
    inference_data = convert_to_inference_data(obj, group=group, coords=coords, dims=dims)
  File "/home/smit/gsoc/local/arv/lib/python3.6/site-packages/arviz-0.7.0-py3.6.egg/arviz/data/converters.py", line 132, in convert_to_inference_data
    ", ".join(allowable_types), obj.__class__.__name__
                                                                                                                                                   **ValueError**: Can only convert xarray dataset, dict, netcdf filename, numpy array, pystan fit, pymc3 trace, emcee fit, pyro mcmc fit, numpyro mcmc fit, cmdstan fit csv filename, cmdstanpy fit to InferenceData, not DataArray

After changes- 
![Figure_1](https://user-images.githubusercontent.com/46646070/76706013-5add2e00-670a-11ea-8130-8f24e6e54d3a.png)



## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [x] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/master/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
