### PR TITLE
Fix bug in `transform` arg when InferenceData is List or Tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Maintenance and fixes
 * Fixed behaviour of `credible_interval=None` in `plot_posterior` (#1115)
 * Fixed hist kind of `plot_dist` with multidimensional input (#1115)
+* Fixed `TypeError` in `transform` argument of `plot_density` and `plot_forest` when `InferenceData is a list or tuple (#1121)`
 ### Deprecation
 
 ### Documentation

--- a/arviz/plots/densityplot.py
+++ b/arviz/plots/densityplot.py
@@ -151,7 +151,6 @@ def plot_density(
 
         >>> az.plot_density([centered, non_centered], var_names=["mu"], bw=.9)
     """
-
     if not isinstance(data, (list, tuple)):
         datasets = [convert_to_dataset(data, group=group)]
     else:

--- a/arviz/plots/densityplot.py
+++ b/arviz/plots/densityplot.py
@@ -151,11 +151,14 @@ def plot_density(
 
         >>> az.plot_density([centered, non_centered], var_names=["mu"], bw=.9)
     """
-    if transform is not None:
-        data = transform(data)
+
     if not isinstance(data, (list, tuple)):
+        if transform is not None:
+            data = transform(data)
         datasets = [convert_to_dataset(data, group=group)]
     else:
+        if transform is not None:
+            data = [transform(datum) for datum in data]
         datasets = [convert_to_dataset(datum, group=group) for datum in data]
 
     var_names = _var_names(var_names, datasets)

--- a/arviz/plots/densityplot.py
+++ b/arviz/plots/densityplot.py
@@ -153,13 +153,12 @@ def plot_density(
     """
 
     if not isinstance(data, (list, tuple)):
-        if transform is not None:
-            data = transform(data)
         datasets = [convert_to_dataset(data, group=group)]
     else:
-        if transform is not None:
-            data = [transform(datum) for datum in data]
         datasets = [convert_to_dataset(datum, group=group) for datum in data]
+
+    if transform is not None:
+        datasets = [transform(dataset) for dataset in datasets]
 
     var_names = _var_names(var_names, datasets)
     n_data = len(datasets)

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -146,7 +146,7 @@ def plot_forest(
     if not isinstance(data, (list, tuple)):
         data = [data]
     if transform is not None:
-        data = transform(data)
+        data = [transform(datum) for datum in data]
 
     if coords is None:
         coords = {}

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -146,14 +146,14 @@ def plot_forest(
     if not isinstance(data, (list, tuple)):
         data = [data]
 
-    if transform is not None:
-        data = [transform(datum) for datum in data]
-
     if coords is None:
         coords = {}
+
+    datasets = [convert_to_dataset(datum) for datum in reversed(data)]
+    if transform is not None:
+        datasets = [transform(dataset) for dataset in datasets]
     datasets = get_coords(
-        [convert_to_dataset(datum) for datum in reversed(data)],
-        list(reversed(coords)) if isinstance(coords, (list, tuple)) else coords,
+        datasets, list(reversed(coords)) if isinstance(coords, (list, tuple)) else coords
     )
 
     var_names = _var_names(var_names, datasets)

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -145,6 +145,7 @@ def plot_forest(
     """
     if not isinstance(data, (list, tuple)):
         data = [data]
+
     if transform is not None:
         data = [transform(datum) for datum in data]
 

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -99,6 +99,7 @@ def fig_ax():
         {"colors": "k"},
         {"hpd_markers": ["v"]},
         {"shade": 1},
+        {"transform": lambda x: x + 1},
     ],
 )
 def test_plot_density_float(models, kwargs):
@@ -205,7 +206,7 @@ def test_plot_trace_bad_lines_value(models, bad_kwargs):
     "args_expected",
     [
         ({}, 1),
-        ({"var_names": "mu"}, 1),
+        ({"var_names": "mu", "transform": lambda x: x + 1}, 1),
         ({"var_names": "mu", "rope": (-1, 1)}, 1),
         ({"r_hat": True, "quartiles": False}, 2),
         ({"var_names": ["mu"], "colors": "C0", "ess": True, "combined": True}, 2),


### PR DESCRIPTION
## Description
`plot_density` and `plot_forest` both accept a list or tuple of InferenceData, but the `transform` argument was not iterating through the list or tuple when it should. This was causing something like `az.plot_forest(idata var_names=["a"], transform=scipy.special.expit)` to raise a `TypeError: ufunc 'expit' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''`.

I think the modifications I made will fix this issue -- please tell me if you have any comment.
Thanks and cheers 🖖 
