### PR TITLE
use black as linter

### DIFF
--- a/.azure-pipelines/azure-pipelines-external.yml
+++ b/.azure-pipelines/azure-pipelines-external.yml
@@ -117,8 +117,8 @@ jobs:
     displayName: 'pydocstyle'
 
   - script: |
-      python -m black arviz
-      python -m black examples
+      python -m black --check arviz
+      python -m black --check examples
     displayName: 'black'
 
   - task: PublishTestResults@2

--- a/examples/bokeh/bokeh_plot_joint.py
+++ b/examples/bokeh/bokeh_plot_joint.py
@@ -15,7 +15,7 @@ ax = az.plot_pair(
     kind="hexbin",
     figsize=(8, 8),
     diagonal=True,
-    marginal_kwargs={'plot_kwargs' : {'line_width' : 3, 'line_color' : 'black'}},
-    hexbin_kwargs={'size' : 1.5},
+    marginal_kwargs={"plot_kwargs": {"line_width": 3, "line_color": "black"}},
+    hexbin_kwargs={"size": 1.5},
     backend="bokeh",
 )

--- a/examples/bokeh/bokeh_plot_pair_point_estimate.py
+++ b/examples/bokeh/bokeh_plot_pair_point_estimate.py
@@ -13,13 +13,14 @@ centered = az.load_arviz_data("centered_eight")
 coords = {"school": ["Choate", "Deerfield"]}
 ax = az.plot_pair(
     centered,
-    var_names=["mu", 'theta'],
-    kind =['scatter', 'kde'], 
-    kde_kwargs={'fill_last':False},
+    var_names=["mu", "theta"],
+    kind=["scatter", "kde"],
+    kde_kwargs={"fill_last": False},
     diagonal=True,
     coords=coords,
-    point_estimate='median', 
-    figsize=(10,8), 
-    backend='bokeh')
+    point_estimate="median",
+    figsize=(10, 8),
+    backend="bokeh",
+)
 
 plt.show()

--- a/examples/matplotlib/mpl_plot_pair_point_estimate.py
+++ b/examples/matplotlib/mpl_plot_pair_point_estimate.py
@@ -13,12 +13,13 @@ centered = az.load_arviz_data("centered_eight")
 coords = {"school": ["Choate", "Deerfield"]}
 ax = az.plot_pair(
     centered,
-    var_names=["mu", 'theta'],
-    kind =['scatter', 'kde'], 
-    kde_kwargs={'fill_last':False},
+    var_names=["mu", "theta"],
+    kind=["scatter", "kde"],
+    kde_kwargs={"fill_last": False},
     diagonal=True,
     coords=coords,
-    point_estimate='median', 
-    figsize=(10,8))
+    point_estimate="median",
+    figsize=(10, 8),
+)
 
 plt.show()


### PR DESCRIPTION
## Description
CI currently uses black as formatter, code is formatted but changes are not saved and bad formatting does not fail CI jobs.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Code style  correct (follows pylint and black guidelines)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/master/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
