### PR TITLE
add option to display rank plots instead of trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@
 ## v0.x.x Unreleased
 
 ### New features
-* Integrate jointplot into pairplot, add point-estimate and overlay of plot kinds #1079
 * Add out-of-sample groups (`predictions` and `predictions_constant_data`) and `constant_data` group to pyro translation #1090
 * Add `num_chains` and `pred_dims` arguments to io_pyro #1090
 * Integrate jointplot into pairplot, add point-estimate and overlay of plot kinds (#1079)
 * Allow xarray.Dataarray input for plots.(#1120)
 * Skip test for optional/extra dependencies when not installed (#1113)
+* Add option to display rank plots instead of trace (#1134)
 ### Maintenance and fixes
 * Fixed behaviour of `credible_interval=None` in `plot_posterior` (#1115)
 * Fixed hist kind of `plot_dist` with multidimensional input (#1115)

--- a/arviz/plots/backends/matplotlib/traceplot.py
+++ b/arviz/plots/backends/matplotlib/traceplot.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from . import backend_kwarg_defaults, backend_show
 from ...distplot import plot_dist
+from ...rankplot import plot_rank
 from ...plot_utils import _scale_fig_size, get_bins, make_label, format_coords_as_labels
 
 
@@ -15,6 +16,7 @@ def plot_trace(
     data,
     var_names,  # pylint: disable=unused-argument
     divergences,
+    kind,
     figsize,
     rug,
     lines,
@@ -27,6 +29,7 @@ def plot_trace(
     rug_kwargs,
     hist_kwargs,
     trace_kwargs,
+    rank_kwargs,
     plotters,
     divergence_data,
     axes,
@@ -47,6 +50,8 @@ def plot_trace(
         One or more variables to be plotted.
     divergences : {"bottom", "top", None, False}
         Plot location of divergences on the traceplots. Options are "bottom", "top", or False-y.
+    kind : {"trace", "rank_bar", "rank_vlines"}, optional
+        Choose between plotting sampled values per iteration and rank plots.
     figsize : figure size tuple
         If None, size is (12, variables * 2)
     rug : bool
@@ -70,6 +75,8 @@ def plot_trace(
         Extra keyword arguments passed to `arviz.plot_dist`. Only affects discrete variables.
     trace_kwargs : dict
         Extra keyword arguments passed to `plt.plot`
+    rank_kwargs : dict
+        Extra keyword arguments passed to `arviz.plot_rank`
     Returns
     -------
     axes : matplotlib axes
@@ -160,11 +167,13 @@ def plot_trace(
                 combined,
                 xt_labelsize,
                 rug,
+                kind,
                 trace_kwargs,
                 hist_kwargs,
                 plot_kwargs,
                 fill_kwargs,
                 rug_kwargs,
+                rank_kwargs,
             )
             if compact_prop:
                 plot_kwargs.pop(compact_prop[0])
@@ -197,11 +206,13 @@ def plot_trace(
                     combined,
                     xt_labelsize,
                     rug,
+                    kind,
                     trace_kwargs,
                     hist_kwargs,
                     plot_kwargs,
                     fill_kwargs,
                     rug_kwargs,
+                    rank_kwargs,
                 )
                 if legend:
                     handles.append(
@@ -241,18 +252,19 @@ def plot_trace(
                     else:
                         ylocs = [ylim[0] for ylim in ylims]
                     values = value[chain, div_idxs]
-                    axes[idx, 1].plot(
-                        div_draws,
-                        np.zeros_like(div_idxs) + ylocs[1],
-                        marker="|",
-                        color="black",
-                        markeredgewidth=1.5,
-                        markersize=30,
-                        linestyle="None",
-                        alpha=hist_kwargs["alpha"],
-                        zorder=-5,
-                    )
-                    axes[idx, 1].set_ylim(*ylims[1])
+                    if kind == "trace":
+                        axes[idx, 1].plot(
+                            div_draws,
+                            np.zeros_like(div_idxs) + ylocs[1],
+                            marker="|",
+                            color="black",
+                            markeredgewidth=1.5,
+                            markersize=30,
+                            linestyle="None",
+                            alpha=hist_kwargs["alpha"],
+                            zorder=-5,
+                        )
+                        axes[idx, 1].set_ylim(*ylims[1])
                     axes[idx, 0].plot(
                         values,
                         np.zeros_like(values) + ylocs[0],
@@ -276,12 +288,18 @@ def plot_trace(
                         "line-positions should be numeric, found {}".format(line_values)
                     )
             axes[idx, 0].vlines(line_values, *ylims[0], colors="black", linewidth=1.5, alpha=0.75)
-            axes[idx, 1].hlines(
-                line_values, *xlims[1], colors="black", linewidth=1.5, alpha=trace_kwargs["alpha"]
-            )
+            if kind == "trace":
+                axes[idx, 1].hlines(
+                    line_values,
+                    *xlims[1],
+                    colors="black",
+                    linewidth=1.5,
+                    alpha=trace_kwargs["alpha"]
+                )
         axes[idx, 0].set_ylim(bottom=0, top=ylims[0][1])
-        axes[idx, 1].set_xlim(left=data.draw.min(), right=data.draw.max())
-        axes[idx, 1].set_ylim(*ylims[1])
+        if kind == "trace":
+            axes[idx, 1].set_xlim(left=data.draw.min(), right=data.draw.max())
+            axes[idx, 1].set_ylim(*ylims[1])
     if legend:
         legend_kwargs = trace_kwargs if combined else plot_kwargs
         handles = [
@@ -295,7 +313,7 @@ def plot_trace(
                     [], [], label="combined", **{chain_prop[0]: chain_prop[1][-1]}, **plot_kwargs
                 ),
             )
-        axes[0, 1].legend(handles=handles, title="chain")
+        axes[0, 0].legend(handles=handles, title="chain")
 
     if backend_show(show):
         plt.show()
@@ -312,16 +330,19 @@ def _plot_chains_mpl(
     combined,
     xt_labelsize,
     rug,
+    kind,
     trace_kwargs,
     hist_kwargs,
     plot_kwargs,
     fill_kwargs,
     rug_kwargs,
+    rank_kwargs,
 ):
     for chain_idx, row in enumerate(value):
-        axes[idx, 1].plot(
-            data.draw.values, row, **{chain_prop[0]: chain_prop[1][chain_idx]}, **trace_kwargs
-        )
+        if kind == "trace":
+            axes[idx, 1].plot(
+                data.draw.values, row, **{chain_prop[0]: chain_prop[1][chain_idx]}, **trace_kwargs
+            )
 
         if not combined:
             plot_kwargs[chain_prop[0]] = chain_prop[1][chain_idx]
@@ -338,6 +359,11 @@ def _plot_chains_mpl(
                 show=False,
             )
             plot_kwargs.pop(chain_prop[0])
+
+    if kind == "rank_bars":
+        plot_rank(data=value, kind="bars", axes=axes[idx, 1], **rank_kwargs)
+    elif kind == "rank_vlines":
+        plot_rank(data=value, kind="vlines", axes=axes[idx, 1], **rank_kwargs)
 
     if combined:
         plot_kwargs[chain_prop[0]] = chain_prop[1][-1]

--- a/arviz/plots/traceplot.py
+++ b/arviz/plots/traceplot.py
@@ -23,6 +23,7 @@ def plot_trace(
     transform: Optional[Callable] = None,
     coords: Optional[CoordSpec] = None,
     divergences: Optional[str] = "bottom",
+    kind: Optional[str] = "trace",
     figsize: Optional[Tuple[float, float]] = None,
     rug: bool = False,
     lines: Optional[List[Tuple[str, CoordSpec, Any]]] = None,
@@ -36,13 +37,14 @@ def plot_trace(
     rug_kwargs: Optional[KwargSpec] = None,
     hist_kwargs: Optional[KwargSpec] = None,
     trace_kwargs: Optional[KwargSpec] = None,
+    rank_kwargs: Optional[KwargSpec] = None,
     ax=None,
     backend: Optional[str] = None,
     backend_config: Optional[KwargSpec] = None,
     backend_kwargs: Optional[KwargSpec] = None,
     show: Optional[bool] = None,
 ):
-    """Plot distribution (histogram or kernel density estimates) and sampled values.
+    """Plot distribution (histogram or kernel density estimates) and sampled values or rank plot.
 
     If `divergences` data is available in `sample_stats`, will plot the location of divergences as
     dashed vertical lines.
@@ -58,6 +60,8 @@ def plot_trace(
         Coordinates of var_names to be plotted. Passed to `Dataset.sel`
     divergences : {"bottom", "top", None}, optional
         Plot location of divergences on the traceplots.
+    kind : {"trace", "rank_bar", "rank_vlines"}, optional
+        Choose between plotting sampled values per iteration and rank plots.
     transform : callable, optional
         Function to transform data (defaults to None i.e.the identity function)
     figsize : tuple of (float, float), optional
@@ -118,6 +122,13 @@ def plot_trace(
 
         >>> az.plot_trace(data, compact=True)
 
+    Display a rank plot instead of trace
+
+    .. plot::
+        :context: close-figs
+
+        >>> az.plot_trace(data, var_names=["mu", "tau"], kind="rank_bars")
+
     Combine all chains into one distribution
 
     .. plot::
@@ -135,6 +146,9 @@ def plot_trace(
         >>> az.plot_trace(data, var_names=('theta_t', 'theta'), coords=coords, lines=lines)
 
     """
+    if kind not in {"trace", "rank_vlines", "rank_bars"}:
+        raise ValueError("The value of kind must be either trace, rank_vlines or rank_bars.")
+
     if divergences:
         try:
             divergence_data = convert_to_dataset(data, group="sample_stats").diverging
@@ -235,6 +249,8 @@ def plot_trace(
         fill_kwargs = {}
     if rug_kwargs is None:
         rug_kwargs = {}
+    if rank_kwargs is None:
+        rank_kwargs = {}
 
     # TODO: Check if this can be further simplified
     trace_plot_args = dict(
@@ -243,6 +259,7 @@ def plot_trace(
         var_names=var_names,
         # coords = coords,
         divergences=divergences,
+        kind=kind,
         figsize=figsize,
         rug=rug,
         lines=lines,
@@ -251,6 +268,7 @@ def plot_trace(
         rug_kwargs=rug_kwargs,
         hist_kwargs=hist_kwargs,
         trace_kwargs=trace_kwargs,
+        rank_kwargs=rank_kwargs,
         compact_prop=compact_prop,
         combined=combined,
         chain_prop=chain_prop,

--- a/arviz/tests/base_tests/test_plots_bokeh.py
+++ b/arviz/tests/base_tests/test_plots_bokeh.py
@@ -131,6 +131,8 @@ def test_plot_density_bad_kwargs(models):
         {"combined": True, "compact": True, "legend": True},
         {"divergences": "top"},
         {"divergences": False},
+        {"kind": "rank_vlines"},
+        {"kind": "rank_bars"},
         {"lines": [("mu", {}, [1, 2])]},
         {"lines": [("mu", {}, 8)]},
     ],

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -144,6 +144,8 @@ def test_plot_density_bad_kwargs(models):
         {"combined": True, "compact": True, "legend": True},
         {"divergences": "top", "legend": True},
         {"divergences": False},
+        {"kind": "rank_vlines"},
+        {"kind": "rank_bars"},
         {"lines": [("mu", {}, [1, 2])]},
         {"lines": [("mu", {}, 8)]},
     ],
@@ -160,7 +162,7 @@ def test_plot_trace_legend(compact, combined):
     axes = plot_trace(
         idata, var_names=["home", "atts_star"], compact=compact, combined=combined, legend=True
     )
-    assert axes[0, 1].get_legend()
+    assert axes[0, 0].get_legend()
     compact_legend = axes[1, 0].get_legend()
     if compact:
         assert axes.shape == (2, 2)

--- a/examples/bokeh/bokeh_plot_trace_bars.py
+++ b/examples/bokeh/bokeh_plot_trace_bars.py
@@ -1,0 +1,10 @@
+"""
+Traceplot rank_bars Bokeh
+===============
+
+_thumb: .1, .8
+"""
+import arviz as az
+
+data = az.load_arviz_data("non_centered_eight")
+ax = az.plot_trace(data, var_names=("tau", "mu"), kind="rank_bars", backend="bokeh")

--- a/examples/bokeh/bokeh_plot_trace_vlines.py
+++ b/examples/bokeh/bokeh_plot_trace_vlines.py
@@ -1,0 +1,10 @@
+"""
+Traceplot rank_vlines Bokeh
+===============
+
+_thumb: .1, .8
+"""
+import arviz as az
+
+data = az.load_arviz_data("non_centered_eight")
+ax = az.plot_trace(data, var_names=("tau", "mu"), kind="rank_vlines", backend="bokeh")

--- a/examples/matplotlib/mpl_plot_trace_bars.py
+++ b/examples/matplotlib/mpl_plot_trace_bars.py
@@ -1,0 +1,15 @@
+"""
+Traceplot rank_bars
+=========
+
+_thumb: .1, .8
+"""
+import matplotlib.pyplot as plt
+import arviz as az
+
+az.style.use("arviz-darkgrid")
+
+data = az.load_arviz_data("non_centered_eight")
+az.plot_trace(data, var_names=("tau", "mu"), kind="rank_bars")
+
+plt.show()

--- a/examples/matplotlib/mpl_plot_trace_vlines.py
+++ b/examples/matplotlib/mpl_plot_trace_vlines.py
@@ -1,0 +1,15 @@
+"""
+Traceplot rank_vlines
+=========
+
+_thumb: .1, .8
+"""
+import matplotlib.pyplot as plt
+import arviz as az
+
+az.style.use("arviz-darkgrid")
+
+data = az.load_arviz_data("non_centered_eight")
+az.plot_trace(data, var_names=("tau", "mu"), kind="rank_vlines")
+
+plt.show()


### PR DESCRIPTION
Integrates rank plots into `plot_trace` via the new keyword `kind`, defaults to `kind=trace`

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [x] New features are properly documented (with an example if appropriate)?
- [x] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)


`kind=rank_vlines`
![rank_vlines](https://user-images.githubusercontent.com/1338958/78187012-12c94580-7444-11ea-9dc8-d5ef452dcbd9.png)

`kind=rank_bars` 
![rank_bars](https://user-images.githubusercontent.com/1338958/78187033-1b218080-7444-11ea-97a3-89806d99a892.png)

