### PR TITLE
hardcode show=False in plot_posterior subplots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Moved `_fast_kde`, `_fast_kde_2d`, `get_bins` and `_sturges_formula` to `numeric_utils` and `get_coords` to `utils` (#1142)
 * Rank plot: rename `axes` argument to `ax` (#1144)
 * Added a warning specifying log scale is now the default in compare/loo/waic functions ([#1150](https://github.com/arviz-devs/arviz/pull/1150))
+* Fixed bug in `plot_posterior` with rcParam "plot.matplotlib.show" = True (#1151)
 
 ### Deprecation
 
@@ -32,7 +33,7 @@
 * Add classifier to `setup.py` including Matplotlib framework (#1133)
 * Image thumbs generation updated to be Bokeh 2 compatible (#1116)
 * Add new examples for `plot_pair` (#1110)
-* Add examples for `psislw` and `r2_score` (#1129) 
+* Add examples for `psislw` and `r2_score` (#1129)
 
 ## v0.7.0 (2020 Mar 2)
 

--- a/arviz/plots/backends/matplotlib/posteriorplot.py
+++ b/arviz/plots/backends/matplotlib/posteriorplot.py
@@ -253,6 +253,7 @@ def _plot_posterior_op(
             plot_kwargs=kwargs,
             ax=ax,
             rug=False,
+            show=False,
         )
     else:
         if bins is None:


### PR DESCRIPTION
## Description
Fix bug in `plot_posterior` when show rcParam is set to true.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/master/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
