### PR TITLE
Add `filter` feature for `var_names`

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -69,6 +69,7 @@ disable=missing-docstring,
         unnecessary-comprehension,
         unsubscriptable-object,
         cyclic-import,
+        redefined-builtin,
 
         #TODO: Remove this once todos are done
         fixme

--- a/.pylintrc
+++ b/.pylintrc
@@ -69,7 +69,6 @@ disable=missing-docstring,
         unnecessary-comprehension,
         unsubscriptable-object,
         cyclic-import,
-        redefined-builtin,
 
         #TODO: Remove this once todos are done
         fixme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.x.x Unreleased
 
 ### New features
+* Stats and plotting functions that provide `var_names` arg can now filter parameters based on partial naming (`filter="like"`) or regular expressions (`filter="regex"`) (see [#1154](https://github.com/arviz-devs/arviz/pull/1154)).
 * Add `true_values` argument for `plot_pair`. It allows for a scatter plot showing the true values of the variables #1140
 * Integrate jointplot into pairplot, add point-estimate and overlay of plot kinds #1079
 * Add out-of-sample groups (`predictions` and `predictions_constant_data`) and `constant_data` group to pyro translation #1090
@@ -24,7 +25,7 @@
 * Updated benchmarks and moved to asv_benchmarks/benchmarks (#1142)
 * Moved `_fast_kde`, `_fast_kde_2d`, `get_bins` and `_sturges_formula` to `numeric_utils` and `get_coords` to `utils` (#1142)
 * Rank plot: rename `axes` argument to `ax` (#1144)
-* Added a warning specifying log scale is now the default in compare/loo/waic functions ([#1150](https://github.com/arviz-devs/arviz/pull/1150))
+* Added a warning specifying log scale is now the default in compare/loo/waic functions ([#1150](https://github.com/arviz-devs/arviz/pull/1150)).
 
 ### Deprecation
 

--- a/arviz/data/base.py
+++ b/arviz/data/base.py
@@ -189,7 +189,7 @@ def dict_to_dataset(data, *, attrs=None, library=None, coords=None, dims=None):
 
     Examples
     --------
-    dict_to_dataset({'x': np.random.randn(4, 100), 'y', np.random.rand(4, 100)})
+    dict_to_dataset({'x': np.random.randn(4, 100), 'y': np.random.rand(4, 100)})
 
     """
     if dims is None:

--- a/arviz/plots/autocorrplot.py
+++ b/arviz/plots/autocorrplot.py
@@ -14,7 +14,7 @@ from ..utils import _var_names
 def plot_autocorr(
     data,
     var_names=None,
-    filter=None,
+    filter_vars=None,
     max_lag=None,
     combined=False,
     figsize=None,
@@ -38,7 +38,7 @@ def plot_autocorr(
         Variables to be plotted, if None all variable are plotted. Prefix the
         variables by `~` when you want to exclude them from the plot. Vector-value
         stochastics are handled automatically.
-    filter: {None, "like", "regex"}, optional, default=None
+    filter_vars: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
         interpret var_names as substrings of the real variables names. If "regex",
         interpret var_names as regular expressions on the real variables names. A la
@@ -95,7 +95,7 @@ def plot_autocorr(
     .. plot::
         :context: close-figs
 
-        >>> az.plot_autocorr(data, var_names=['~thet'], filter="like", combined=True)
+        >>> az.plot_autocorr(data, var_names=['~thet'], filter_vars="like", combined=True)
 
 
     Specify maximum lag (x axis bound)
@@ -106,7 +106,7 @@ def plot_autocorr(
         >>> az.plot_autocorr(data, var_names=['mu', 'tau'], max_lag=200, combined=True)
     """
     data = convert_to_dataset(data, group="posterior")
-    var_names = _var_names(var_names, data, filter)
+    var_names = _var_names(var_names, data, filter_vars)
 
     # Default max lag to 100 or max length of chain
     if max_lag is None:

--- a/arviz/plots/autocorrplot.py
+++ b/arviz/plots/autocorrplot.py
@@ -14,6 +14,7 @@ from ..utils import _var_names
 def plot_autocorr(
     data,
     var_names=None,
+    filter=None,
     max_lag=None,
     combined=False,
     figsize=None,
@@ -30,18 +31,24 @@ def plot_autocorr(
 
     Parameters
     ----------
-    data : obj
+    data: obj
         Any object that can be converted to an az.InferenceData object
         Refer to documentation of az.convert_to_dataset for details
-    var_names : list of variable names, optional
-        Variables to be plotted, if None all variable are plotted.
-        Vector-value stochastics are handled automatically.
-    max_lag : int, optional
+    var_names: list of variable names, optional
+        Variables to be plotted, if None all variable are plotted. Prefix the
+        variables by `~` when you want to exclude them from the plot. Vector-value
+        stochastics are handled automatically.
+    filter: Union[None, "like", "regex"], optional, default=None
+        If `None` (default), interpret var_names as the real variables names. If "like",
+        interpret var_names as substrings of the real variables names. If "regex",
+        interpret var_names as regular expressions on the real variables names. À la
+        `pandas.filter`.
+    max_lag: int, optional
         Maximum lag to calculate autocorrelation. Defaults to 100 or num draws, whichever is smaller
-    combined : bool
+    combined: bool
         Flag for combining multiple chains into a single chain. If False (default), chains will be
         plotted separately.
-    figsize : tuple
+    figsize: tuple
         Figure size. If None it will be defined automatically.
         Note this is not used if ax is supplied.
     textsize: float
@@ -57,12 +64,12 @@ def plot_autocorr(
     backend_kwargs: dict, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
-    show : bool, optional
+    show: bool, optional
         Call backend show function.
 
     Returns
     -------
-    axes : matplotlib axes or bokeh figures
+    axes: matplotlib axes or bokeh figures
 
     Examples
     --------
@@ -88,7 +95,7 @@ def plot_autocorr(
     .. plot::
         :context: close-figs
 
-        >>> az.plot_autocorr(data, var_names=['mu', 'tau'], combined=True)
+        >>> az.plot_autocorr(data, var_names=['~theta'], filter="like", combined=True)
 
 
     Specify maximum lag (x axis bound)
@@ -99,7 +106,7 @@ def plot_autocorr(
         >>> az.plot_autocorr(data, var_names=['mu', 'tau'], max_lag=200, combined=True)
     """
     data = convert_to_dataset(data, group="posterior")
-    var_names = _var_names(var_names, data)
+    var_names = _var_names(var_names, data, filter)
 
     # Default max lag to 100 or max length of chain
     if max_lag is None:

--- a/arviz/plots/autocorrplot.py
+++ b/arviz/plots/autocorrplot.py
@@ -38,10 +38,10 @@ def plot_autocorr(
         Variables to be plotted, if None all variable are plotted. Prefix the
         variables by `~` when you want to exclude them from the plot. Vector-value
         stochastics are handled automatically.
-    filter: Union[None, "like", "regex"], optional, default=None
+    filter: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
         interpret var_names as substrings of the real variables names. If "regex",
-        interpret var_names as regular expressions on the real variables names. À la
+        interpret var_names as regular expressions on the real variables names. A la
         `pandas.filter`.
     max_lag: int, optional
         Maximum lag to calculate autocorrelation. Defaults to 100 or num draws, whichever is smaller
@@ -90,12 +90,12 @@ def plot_autocorr(
         >>> az.plot_autocorr(data, var_names=['mu', 'tau'] )
 
 
-    Combine chains collapsing by variable
+    Combine chains by variable and select variables by excluding some with partial naming
 
     .. plot::
         :context: close-figs
 
-        >>> az.plot_autocorr(data, var_names=['~theta'], filter="like", combined=True)
+        >>> az.plot_autocorr(data, var_names=['~thet'], filter="like", combined=True)
 
 
     Specify maximum lag (x axis bound)

--- a/arviz/plots/essplot.py
+++ b/arviz/plots/essplot.py
@@ -19,6 +19,7 @@ from ..utils import _var_names, get_coords
 def plot_ess(
     idata,
     var_names=None,
+    filter=None,
     kind="local",
     relative=False,
     coords=None,
@@ -43,60 +44,66 @@ def plot_ess(
 
     Parameters
     ----------
-    idata : obj
+    idata: obj
         Any object that can be converted to an az.InferenceData object
         Refer to documentation of az.convert_to_dataset for details
-    var_names : list of variable names, optional
-        Variables to be plotted.
-    kind : str, optional
+    var_names: list of variable names, optional
+        Variables to be plotted. Prefix the variables by `~` when you want to exclude
+        them from the plot.
+    filter: Union[None, "like", "regex"], optional, default=None
+        If `None` (default), interpret var_names as the real variables names. If "like",
+        interpret var_names as substrings of the real variables names. If "regex",
+        interpret var_names as regular expressions on the real variables names. À la
+        `pandas.filter`.
+    kind: str, optional
         Options: ``local``, ``quantile`` or ``evolution``, specify the kind of plot.
-    relative : bool
+    relative: bool
         Show relative ess in plot ``ress = ess / N``.
-    coords : dict, optional
+    coords: dict, optional
         Coordinates of var_names to be plotted. Passed to `Dataset.sel`
-    figsize : tuple, optional
+    figsize: tuple, optional
         Figure size. If None it will be defined automatically.
     textsize: float, optional
         Text size scaling factor for labels, titles and lines. If None it will be autoscaled based
         on figsize.
-    rug : bool
+    rug: bool
         Plot rug plot of values diverging or that reached the max tree depth.
-    rug_kind : bool
+    rug_kind: bool
         Variable in sample stats to use as rug mask. Must be a boolean variable.
-    n_points : int
+    n_points: int
         Number of points for which to plot their quantile/local ess or number of subsets
         in the evolution plot.
-    extra_methods : bool, optional
+    extra_methods: bool, optional
         Plot mean and sd ESS as horizontal lines. Not taken into account in evolution kind
-    min_ess : int
+    min_ess: int
         Minimum number of ESS desired.
     ax: numpy array-like of matplotlib axes or bokeh figures, optional
         A 2D array of locations into which to plot the densities. If not supplied, Arviz will create
         its own array of plot areas (and return it).
-    extra_kwargs : dict, optional
+    extra_kwargs: dict, optional
         If evolution plot, extra_kwargs is used to plot ess tail and differentiate it
         from ess bulk. Otherwise, passed to extra methods lines.
-    text_kwargs : dict, optional
+    text_kwargs: dict, optional
         Only taken into account when ``extra_methods=True``. kwargs passed to ax.annotate
         for extra methods lines labels. It accepts the additional
         key ``x`` to set ``xy=(text_kwargs["x"], mcse)``
-    hline_kwargs : dict, optional
+    hline_kwargs: dict, optional
         kwargs passed to ax.axhline for the horizontal minimum ESS line.
-    rug_kwargs : dict
+    rug_kwargs: dict
         kwargs passed to rug plot.
     backend: str, optional
         Select plotting backend {"matplotlib","bokeh"}. Default "matplotlib".
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
-    show : bool, optional
+    show: bool, optional
         Call backend show function.
     **kwargs
         Passed as-is to plt.hist() or plt.plot() function depending on the value of `kind`.
 
     Returns
     -------
-    axes : matplotlib axes or bokeh figures
+    axes: matplotlib axes or bokeh figures
 
     References
     ----------
@@ -125,7 +132,7 @@ def plot_ess(
         :context: close-figs
 
         >>> az.plot_ess(
-        ...     idata, kind="quantile", var_names=["mu", "theta"], coords=coords
+        ...     idata, kind="quantile", var_names=['~theta'], filter="like", coords=coords
         ... )
 
     Plot ESS evolution as the number of samples increase. When the model is converging properly,
@@ -172,7 +179,7 @@ def plot_ess(
     extra_methods = False if kind == "evolution" else extra_methods
 
     data = get_coords(convert_to_dataset(idata, group="posterior"), coords)
-    var_names = _var_names(var_names, data)
+    var_names = _var_names(var_names, data, filter)
     n_draws = data.dims["draw"]
     n_samples = n_draws * data.dims["chain"]
 

--- a/arviz/plots/essplot.py
+++ b/arviz/plots/essplot.py
@@ -50,10 +50,10 @@ def plot_ess(
     var_names: list of variable names, optional
         Variables to be plotted. Prefix the variables by `~` when you want to exclude
         them from the plot.
-    filter: Union[None, "like", "regex"], optional, default=None
+    filter: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
         interpret var_names as substrings of the real variables names. If "regex",
-        interpret var_names as regular expressions on the real variables names. À la
+        interpret var_names as regular expressions on the real variables names. A la
         `pandas.filter`.
     kind: str, optional
         Options: ``local``, ``quantile`` or ``evolution``, specify the kind of plot.
@@ -126,13 +126,13 @@ def plot_ess(
         ...     idata, kind="local", var_names=["mu", "theta"], coords=coords
         ... )
 
-    Plot quantile ESS.
+    Plot quantile ESS and exclude variables with partial naming
 
     .. plot::
         :context: close-figs
 
         >>> az.plot_ess(
-        ...     idata, kind="quantile", var_names=['~theta'], filter="like", coords=coords
+        ...     idata, kind="quantile", var_names=['~thet'], filter="like", coords=coords
         ... )
 
     Plot ESS evolution as the number of samples increase. When the model is converging properly,

--- a/arviz/plots/essplot.py
+++ b/arviz/plots/essplot.py
@@ -19,7 +19,7 @@ from ..utils import _var_names, get_coords
 def plot_ess(
     idata,
     var_names=None,
-    filter=None,
+    filter_vars=None,
     kind="local",
     relative=False,
     coords=None,
@@ -50,7 +50,7 @@ def plot_ess(
     var_names: list of variable names, optional
         Variables to be plotted. Prefix the variables by `~` when you want to exclude
         them from the plot.
-    filter: {None, "like", "regex"}, optional, default=None
+    filter_vars: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
         interpret var_names as substrings of the real variables names. If "regex",
         interpret var_names as regular expressions on the real variables names. A la
@@ -132,7 +132,7 @@ def plot_ess(
         :context: close-figs
 
         >>> az.plot_ess(
-        ...     idata, kind="quantile", var_names=['~thet'], filter="like", coords=coords
+        ...     idata, kind="quantile", var_names=['~thet'], filter_vars="like", coords=coords
         ... )
 
     Plot ESS evolution as the number of samples increase. When the model is converging properly,
@@ -179,7 +179,7 @@ def plot_ess(
     extra_methods = False if kind == "evolution" else extra_methods
 
     data = get_coords(convert_to_dataset(idata, group="posterior"), coords)
-    var_names = _var_names(var_names, data, filter)
+    var_names = _var_names(var_names, data, filter_vars)
     n_draws = data.dims["draw"]
     n_samples = n_draws * data.dims["chain"]
 

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -10,7 +10,7 @@ def plot_forest(
     kind="forestplot",
     model_names=None,
     var_names=None,
-    filter=None,
+    filter_vars=None,
     transform=None,
     coords=None,
     combined=False,
@@ -53,7 +53,7 @@ def plot_forest(
         List of variables to plot (defaults to None, which results in all
         variables plotted) Prefix the variables by `~` when you want to exclude them
         from the plot.
-    filter: {None, "like", "regex"}, optional, default=None
+    filter_vars: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
         interpret var_names as substrings of the real variables names. If "regex",
         interpret var_names as regular expressions on the real variables names. A la
@@ -131,7 +131,7 @@ def plot_forest(
         >>> axes = az.plot_forest(non_centered_data,
         >>>                            kind='forestplot',
         >>>                            var_names=["^the"],
-        >>>                            filter="regex",
+        >>>                            filter_vars="regex",
         >>>                            combined=True,
         >>>                            ridgeplot_overlap=3,
         >>>                            figsize=(9, 7))
@@ -164,7 +164,7 @@ def plot_forest(
         datasets, list(reversed(coords)) if isinstance(coords, (list, tuple)) else coords
     )
 
-    var_names = _var_names(var_names, datasets, filter)
+    var_names = _var_names(var_names, datasets, filter_vars)
 
     ncols, width_ratios = 1, [3]
 

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -10,6 +10,7 @@ def plot_forest(
     kind="forestplot",
     model_names=None,
     var_names=None,
+    filter=None,
     transform=None,
     coords=None,
     combined=False,
@@ -40,38 +41,44 @@ def plot_forest(
 
     Parameters
     ----------
-    data : obj or list[obj]
+    data: obj or list[obj]
         Any object that can be converted to an az.InferenceData object
         Refer to documentation of az.convert_to_dataset for details
-    kind : str
+    kind: str
         Choose kind of plot for main axis. Supports "forestplot" or "ridgeplot"
-    model_names : list[str], optional
+    model_names: list[str], optional
         List with names for the models in the list of data. Useful when
         plotting more that one dataset
     var_names: list[str], optional
         List of variables to plot (defaults to None, which results in all
-        variables plotted)
-    transform : callable
+        variables plotted) Prefix the variables by `~` when you want to exclude them
+        from the plot.
+    filter: Union[None, "like", "regex"], optional, default=None
+        If `None` (default), interpret var_names as the real variables names. If "like",
+        interpret var_names as substrings of the real variables names. If "regex",
+        interpret var_names as regular expressions on the real variables names. À la
+        `pandas.filter`.
+    transform: callable
         Function to transform data (defaults to None i.e.the identity function)
-    coords : dict, optional
+    coords: dict, optional
         Coordinates of var_names to be plotted. Passed to `Dataset.sel`
-    combined : bool
+    combined: bool
         Flag for combining multiple chains into a single chain. If False (default),
         chains will be plotted separately.
-    credible_interval : float, optional
+    credible_interval: float, optional
         Credible interval to plot. Defaults to 0.94.
     rope: tuple or dictionary of tuples
         Lower and upper values of the Region Of Practical Equivalence. If a list with one
         interval only is provided, the ROPE will be displayed across the y-axis. If more than one
         interval is provided the length of the list should match the number of variables.
-    quartiles : bool, optional
+    quartiles: bool, optional
         Flag for plotting the interquartile range, in addition to the credible_interval intervals.
         Defaults to True
-    r_hat : bool, optional
+    r_hat: bool, optional
         Flag for plotting Split R-hat statistics. Requires 2 or more chains. Defaults to False
-    ess : bool, optional
+    ess: bool, optional
         Flag for plotting the effective sample size. Defaults to False
-    colors : list or string, optional
+    colors: list or string, optional
         list with valid matplotlib colors, one color per model. Alternative a string can be passed.
         If the string is `cycle`, it will automatically chose a color per model from the
         matplotlibs cycle. If a single color is passed, eg 'k', 'C2', 'red' this color will be used
@@ -79,22 +86,22 @@ def plot_forest(
     textsize: float
         Text size scaling factor for labels, titles and lines. If None it will be autoscaled based
         on figsize.
-    linewidth : int
+    linewidth: int
         Line width throughout. If None it will be autoscaled based on figsize.
-    markersize : int
+    markersize: int
         Markersize throughout. If None it will be autoscaled based on figsize.
-    ridgeplot_alpha : float
+    ridgeplot_alpha: float
         Transparency for ridgeplot fill.  If 0, border is colored by model, otherwise
         a black outline is used.
-    ridgeplot_overlap : float
+    ridgeplot_overlap: float
         Overlap height for ridgeplots.
-    ridgeplot_kind : string
+    ridgeplot_kind: string
         By default ("auto") continuous variables are plotted using KDEs and discrete ones using
         histograms. To override this use "hist" to plot histograms and "density" for KDEs
-    ridgeplot_quantiles : list
+    ridgeplot_quantiles: list
         Quantiles in ascending order used to segment the KDE. Use [.25, .5, .75] for quartiles.
         Defaults to None.
-    figsize : tuple
+    figsize: tuple
         Figure size. If None it will be defined automatically.
     ax: axes, optional
         Matplotlib axes or bokeh figures.
@@ -105,12 +112,12 @@ def plot_forest(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
-    show : bool, optional
+    show: bool, optional
         Call backend show function.
 
     Returns
     -------
-    gridspec : matplotlib GridSpec or bokeh figures
+    gridspec: matplotlib GridSpec or bokeh figures
 
     Examples
     --------
@@ -123,7 +130,8 @@ def plot_forest(
         >>> non_centered_data = az.load_arviz_data('non_centered_eight')
         >>> axes = az.plot_forest(non_centered_data,
         >>>                            kind='forestplot',
-        >>>                            var_names=['theta'],
+        >>>                            var_names=["^the"],
+        >>>                            filter="regex",
         >>>                            combined=True,
         >>>                            ridgeplot_overlap=3,
         >>>                            figsize=(9, 7))
@@ -156,7 +164,7 @@ def plot_forest(
         datasets, list(reversed(coords)) if isinstance(coords, (list, tuple)) else coords
     )
 
-    var_names = _var_names(var_names, datasets)
+    var_names = _var_names(var_names, datasets, filter)
 
     ncols, width_ratios = 1, [3]
 

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -53,10 +53,10 @@ def plot_forest(
         List of variables to plot (defaults to None, which results in all
         variables plotted) Prefix the variables by `~` when you want to exclude them
         from the plot.
-    filter: Union[None, "like", "regex"], optional, default=None
+    filter: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
         interpret var_names as substrings of the real variables names. If "regex",
-        interpret var_names as regular expressions on the real variables names. À la
+        interpret var_names as regular expressions on the real variables names. A la
         `pandas.filter`.
     transform: callable
         Function to transform data (defaults to None i.e.the identity function)

--- a/arviz/plots/jointplot.py
+++ b/arviz/plots/jointplot.py
@@ -16,7 +16,7 @@ def plot_joint(
     data,
     group="posterior",
     var_names=None,
-    filter=None,
+    filter_vars=None,
     transform=None,
     coords=None,
     figsize=None,
@@ -46,7 +46,7 @@ def plot_joint(
         Variables to be plotted. Iterable of two variables or one variable (with subset
         having exactly 2 dimensions) are required. Prefix the variables by `~` when you
         want to exclude them from the plot.
-    filter: {None, "like", "regex"}, optional, default=None
+    filter_vars: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
         interpret var_names as substrings of the real variables names. If "regex",
         interpret var_names as regular expressions on the real variables names. A la
@@ -162,7 +162,7 @@ def plot_joint(
     if coords is None:
         coords = {}
 
-    var_names = _var_names(var_names, data, filter)
+    var_names = _var_names(var_names, data, filter_vars)
 
     plotters = list(xarray_var_iter(get_coords(data, coords), var_names=var_names, combined=True))
 

--- a/arviz/plots/jointplot.py
+++ b/arviz/plots/jointplot.py
@@ -46,10 +46,10 @@ def plot_joint(
         Variables to be plotted. Iterable of two variables or one variable (with subset
         having exactly 2 dimensions) are required. Prefix the variables by `~` when you
         want to exclude them from the plot.
-    filter: Union[None, "like", "regex"], optional, default=None
+    filter: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
         interpret var_names as substrings of the real variables names. If "regex",
-        interpret var_names as regular expressions on the real variables names. À la
+        interpret var_names as regular expressions on the real variables names. A la
         `pandas.filter`.
     transform: callable
         Function to transform data (defaults to None i.e. the identity function)

--- a/arviz/plots/jointplot.py
+++ b/arviz/plots/jointplot.py
@@ -16,6 +16,7 @@ def plot_joint(
     data,
     group="posterior",
     var_names=None,
+    filter=None,
     transform=None,
     coords=None,
     figsize=None,
@@ -36,37 +37,43 @@ def plot_joint(
 
     Parameters
     ----------
-    data : obj
+    data: obj
         Any object that can be converted to an az.InferenceData object
         Refer to documentation of az.convert_to_dataset for details
-    group : str, optional
+    group: str, optional
         Specifies which InferenceData group should be plotted. Defaults to ‘posterior’.
-    var_names : str or iterable of str
-        Variables to be plotted. iter of two variables or one variable (with subset having
-        exactly 2 dimensions) are required.
-    transform : callable
+    var_names: str or iterable of str
+        Variables to be plotted. Iterable of two variables or one variable (with subset
+        having exactly 2 dimensions) are required. Prefix the variables by `~` when you
+        want to exclude them from the plot.
+    filter: Union[None, "like", "regex"], optional, default=None
+        If `None` (default), interpret var_names as the real variables names. If "like",
+        interpret var_names as substrings of the real variables names. If "regex",
+        interpret var_names as regular expressions on the real variables names. À la
+        `pandas.filter`.
+    transform: callable
         Function to transform data (defaults to None i.e. the identity function)
-    coords : mapping, optional
+    coords: mapping, optional
         Coordinates of var_names to be plotted. Passed to `Dataset.sel`
-    figsize : tuple
+    figsize: tuple
         Figure size. If None it will be defined automatically.
     textsize: float
         Text size scaling factor for labels, titles and lines. If None it will be autoscaled based
         on figsize.
-    kind : str
+    kind: str
         Type of plot to display (scatter, kde or hexbin)
-    gridsize : int or (int, int), optional.
+    gridsize: int or (int, int), optional.
         The number of hexagons in the x-direction. Ignored when hexbin is False. See `plt.hexbin`
         for details
-    contour : bool
+    contour: bool
         If True plot the 2D KDE using contours, otherwise plot a smooth 2D KDE. Defaults to True.
-    fill_last : bool
+    fill_last: bool
         If True fill the last contour of the 2D KDE plot. Defaults to True.
-    joint_kwargs : dicts, optional
+    joint_kwargs: dicts, optional
         Additional keywords modifying the join distribution (central subplot)
-    marginal_kwargs : dicts, optional
+    marginal_kwargs: dicts, optional
         Additional keywords modifying the marginals distributions (top and right subplot)
-    ax : tuple of axes, optional
+    ax: tuple of axes, optional
         Tuple containing (ax_joint, ax_hist_x, ax_hist_y). If None, a new figure and axes
         will be created. Matplotlib axes or bokeh figures.
     backend: str, optional
@@ -74,15 +81,15 @@ def plot_joint(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
-    show : bool, optional
+    show: bool, optional
         Call backend show function.
 
     Returns
     -------
-    axes : matplotlib axes or bokeh figures
-        ax_joint : joint (central) distribution
-        ax_hist_x : x (top) distribution
-        ax_hist_y : y (right) distribution
+    axes: matplotlib axes or bokeh figures
+        ax_joint: joint (central) distribution
+        ax_hist_x: x (top) distribution
+        ax_hist_y: y (right) distribution
 
     Examples
     --------
@@ -155,7 +162,7 @@ def plot_joint(
     if coords is None:
         coords = {}
 
-    var_names = _var_names(var_names, data)
+    var_names = _var_names(var_names, data, filter)
 
     plotters = list(xarray_var_iter(get_coords(data, coords), var_names=var_names, combined=True))
 

--- a/arviz/plots/mcseplot.py
+++ b/arviz/plots/mcseplot.py
@@ -47,10 +47,10 @@ def plot_mcse(
     var_names: list of variable names, optional
         Variables to be plotted. Prefix the variables by `~` when you want to exclude
         them from the plot.
-    filter: Union[None, "like", "regex"], optional, default=None
+    filter: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
         interpret var_names as substrings of the real variables names. If "regex",
-        interpret var_names as regular expressions on the real variables names. À la
+        interpret var_names as regular expressions on the real variables names. A la
         `pandas.filter`.
     coords: dict, optional
         Coordinates of var_names to be plotted. Passed to `Dataset.sel`

--- a/arviz/plots/mcseplot.py
+++ b/arviz/plots/mcseplot.py
@@ -19,6 +19,7 @@ from ..utils import _var_names, get_coords
 def plot_mcse(
     idata,
     var_names=None,
+    filter=None,
     coords=None,
     errorbar=False,
     figsize=None,
@@ -40,38 +41,44 @@ def plot_mcse(
 
     Parameters
     ----------
-    idata : obj
+    idata: obj
         Any object that can be converted to an az.InferenceData object
         Refer to documentation of az.convert_to_dataset for details
-    var_names : list of variable names, optional
-        Variables to be plotted.
-    coords : dict, optional
+    var_names: list of variable names, optional
+        Variables to be plotted. Prefix the variables by `~` when you want to exclude
+        them from the plot.
+    filter: Union[None, "like", "regex"], optional, default=None
+        If `None` (default), interpret var_names as the real variables names. If "like",
+        interpret var_names as substrings of the real variables names. If "regex",
+        interpret var_names as regular expressions on the real variables names. À la
+        `pandas.filter`.
+    coords: dict, optional
         Coordinates of var_names to be plotted. Passed to `Dataset.sel`
-    errorbar : bool, optional
+    errorbar: bool, optional
         Plot quantile value +/- mcse instead of plotting mcse.
-    figsize : tuple, optional
+    figsize: tuple, optional
         Figure size. If None it will be defined automatically.
     textsize: float, optional
         Text size scaling factor for labels, titles and lines. If None it will be autoscaled based
         on figsize.
-    extra_methods : bool, optional
+    extra_methods: bool, optional
         Plot mean and sd MCSE as horizontal lines. Only taken into account when
         ``errorbar=False``.
-    rug : bool
+    rug: bool
         Plot rug plot of values diverging or that reached the max tree depth.
-    rug_kind : bool
+    rug_kind: bool
         Variable in sample stats to use as rug mask. Must be a boolean variable.
-    n_points : int
+    n_points: int
         Number of points for which to plot their quantile/local ess or number of subsets
         in the evolution plot.
     ax: numpy array-like of matplotlib axes or bokeh figures, optional
         A 2D array of locations into which to plot the densities. If not supplied, Arviz will create
         its own array of plot areas (and return it).
-    rug_kwargs : dict
+    rug_kwargs: dict
         kwargs passed to rug plot.
-    extra_kwargs : dict, optional
+    extra_kwargs: dict, optional
         kwargs passed to ax.plot for extra methods lines.
-    text_kwargs : dict, optional
+    text_kwargs: dict, optional
         kwargs passed to ax.annotate for extra methods lines labels. It accepts the additional
         key ``x`` to set ``xy=(text_kwargs["x"], mcse)``
     backend: str, optional
@@ -79,14 +86,14 @@ def plot_mcse(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
-    show : bool, optional
+    show: bool, optional
         Call backend show function.
     **kwargs
         Passed as-is to plt.hist() or plt.plot() function depending on the value of `kind`.
 
     Returns
     -------
-    axes : matplotlib axes or bokeh figures
+    axes: matplotlib axes or bokeh figures
 
     References
     ----------
@@ -118,7 +125,7 @@ def plot_mcse(
         raise ValueError("chain and draw are invalid coordinates for this kind of plot")
 
     data = get_coords(convert_to_dataset(idata, group="posterior"), coords)
-    var_names = _var_names(var_names, data)
+    var_names = _var_names(var_names, data, filter)
 
     probs = np.linspace(1 / n_points, 1 - 1 / n_points, n_points)
     mcse_dataset = xr.concat(

--- a/arviz/plots/mcseplot.py
+++ b/arviz/plots/mcseplot.py
@@ -19,7 +19,7 @@ from ..utils import _var_names, get_coords
 def plot_mcse(
     idata,
     var_names=None,
-    filter=None,
+    filter_vars=None,
     coords=None,
     errorbar=False,
     figsize=None,
@@ -47,7 +47,7 @@ def plot_mcse(
     var_names: list of variable names, optional
         Variables to be plotted. Prefix the variables by `~` when you want to exclude
         them from the plot.
-    filter: {None, "like", "regex"}, optional, default=None
+    filter_vars: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
         interpret var_names as substrings of the real variables names. If "regex",
         interpret var_names as regular expressions on the real variables names. A la
@@ -125,7 +125,7 @@ def plot_mcse(
         raise ValueError("chain and draw are invalid coordinates for this kind of plot")
 
     data = get_coords(convert_to_dataset(idata, group="posterior"), coords)
-    var_names = _var_names(var_names, data, filter)
+    var_names = _var_names(var_names, data, filter_vars)
 
     probs = np.linspace(1 / n_points, 1 - 1 / n_points, n_points)
     mcse_dataset = xr.concat(

--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -12,6 +12,7 @@ def plot_pair(
     data,
     group="posterior",
     var_names=None,
+    filter=None,
     coords=None,
     figsize=None,
     textsize=None,
@@ -43,75 +44,81 @@ def plot_pair(
 
     Parameters
     ----------
-    data : obj
+    data: obj
         Any object that can be converted to an az.InferenceData object
         Refer to documentation of az.convert_to_dataset for details
-    group : str, optional
+    group: str, optional
         Specifies which InferenceData group should be plotted.  Defaults to 'posterior'.
-    var_names : list of variable names, optional
-        Variables to be plotted, if ``None`` all variables are plotted
-    coords : mapping, optional
+    var_names: list of variable names, optional
+        Variables to be plotted, if None all variable are plotted. Prefix the
+        variables by `~` when you want to exclude them from the plot.
+    filter: Union[None, "like", "regex"], optional, default=None
+        If `None` (default), interpret var_names as the real variables names. If "like",
+        interpret var_names as substrings of the real variables names. If "regex",
+        interpret var_names as regular expressions on the real variables names. À la
+        `pandas.filter`.
+    coords: mapping, optional
         Coordinates of var_names to be plotted. Passed to `Dataset.sel`
-    figsize : figure size tuple
+    figsize: figure size tuple
         If None, size is (8 + numvars, 8 + numvars)
     textsize: int
         Text size for labels. If None it will be autoscaled based on figsize.
-    kind : str
+    kind: str
         Type of plot to display (scatter, kde and/or hexbin)
-    gridsize : int or (int, int), optional
+    gridsize: int or (int, int), optional
         Only works for kind=hexbin.
         The number of hexagons in the x-direction. The corresponding number of hexagons in the
         y-direction is chosen such that the hexagons are approximately regular.
         Alternatively, gridsize can be a tuple with two elements specifying the number of hexagons
         in the x-direction and the y-direction.
-    contour : bool
+    contour: bool
         If True plot the 2D KDE using contours, otherwise plot a smooth 2D KDE. Defaults to True.
-    fill_last : bool
+    fill_last: bool
         If True fill the last contour of the 2D KDE plot. Defaults to True.
-    divergences : Boolean
+    divergences: Boolean
         If True divergences will be plotted in a different color, only if group is either 'prior'
         or 'posterior'.
-    colorbar : bool
+    colorbar: bool
         If True a colorbar will be included as part of the plot (Defaults to False).
         Only works when kind=hexbin
     ax: axes, optional
         Matplotlib axes or bokeh figures.
-    divergences_kwargs : dicts, optional
+    divergences_kwargs: dicts, optional
         Additional keywords passed to ax.scatter for divergences
     scatter_kwargs:
         Additional keywords passed to ax.plot when using scatter kind
-    kde_kwargs : dict, optional
+    kde_kwargs: dict, optional
         Additional keywords passed to az.plot_kde when using kde kind
-    hexbin_kwargs : dict, optional
+    hexbin_kwargs: dict, optional
         Additional keywords passed to ax.hexbin when using hexbin kind
     backend: str, optional
         Select plotting backend {"matplotlib","bokeh"}. Default "matplotlib".
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
-    diagonal : bool, optional
+    diagonal: bool, optional
         If True pairplot will include marginal distributions for every variable
-    marginal_kwargs : dict, optional
+    marginal_kwargs: dict, optional
         Additional keywords passed to az.plot_dist, modifying the marginal distributions
         plotted in the diagonal.
-    point_estimate : str, optional
+    point_estimate: str, optional
         Select point estimate from 'mean', 'mode' or 'median'. The point estimate will be
         plotted using a scatter marker and vertical/horizontal lines.
-    point_estimate_kwargs : dict, optional
+    point_estimate_kwargs: dict, optional
         Additional keywords passed to ax.vline, ax.hline (matplotlib) or ax.square, Span (bokeh)
     point_estimate_marker_kwargs: dict, optional
         Additional keywords passed to ax.scatter in point estimate plot. Not available in bokeh
-    reference_values : dict, optional
+    reference_values: dict, optional
         Reference values for the plotted variables. The Reference values will be plotted
         using a scatter marker
-    reference_values_kwargs : dict, optional
+    reference_values_kwargs: dict, optional
         Additional keywords passed to ax.plot or ax.circle in reference values plot
-    show : bool, optional
+    show: bool, optional
         Call backend show function.
 
     Returns
     -------
-    axes : matplotlib axes or bokeh figures
+    axes: matplotlib axes or bokeh figures
 
     Examples
     --------
@@ -147,7 +154,8 @@ def plot_pair(
         :context: close-figs
 
         >>> az.plot_pair(centered,
-        ...             var_names=['theta', 'mu', 'tau'],
+        ...             var_names=['^t', 'mu'],
+        ...             filter="regex",
         ...             coords=coords,
         ...             divergences=True,
         ...             textsize=18)
@@ -215,7 +223,7 @@ def plot_pair(
     # Get posterior draws and combine chains
     data = convert_to_inference_data(data)
     grouped_data = convert_to_dataset(data, group=group)
-    var_names = _var_names(var_names, grouped_data)
+    var_names = _var_names(var_names, grouped_data, filter)
     flat_var_names, infdata_group = xarray_to_ndarray(
         get_coords(grouped_data, coords), var_names=var_names, combined=True
     )

--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -13,7 +13,7 @@ def plot_pair(
     data,
     group="posterior",
     var_names: Optional[List[str]] = None,
-    filter=None,
+    filter: Optional[str] = None,
     coords=None,
     figsize=None,
     textsize=None,
@@ -53,10 +53,10 @@ def plot_pair(
     var_names: list of variable names, optional
         Variables to be plotted, if None all variable are plotted. Prefix the
         variables by `~` when you want to exclude them from the plot.
-    filter: Union[None, "like", "regex"], optional, default=None
+    filter: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
         interpret var_names as substrings of the real variables names. If "regex",
-        interpret var_names as regular expressions on the real variables names. À la
+        interpret var_names as regular expressions on the real variables names. A la
         `pandas.filter`.
     coords: mapping, optional
         Coordinates of var_names to be plotted. Passed to `Dataset.sel`
@@ -150,7 +150,7 @@ def plot_pair(
         >>>             textsize=18,
         >>>             kind='hexbin')
 
-    Pair plot showing divergences
+    Pair plot showing divergences and select variables with regular expressions
 
     .. plot::
         :context: close-figs

--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -13,7 +13,7 @@ def plot_pair(
     data,
     group="posterior",
     var_names: Optional[List[str]] = None,
-    filter: Optional[str] = None,
+    filter_vars: Optional[str] = None,
     coords=None,
     figsize=None,
     textsize=None,
@@ -53,7 +53,7 @@ def plot_pair(
     var_names: list of variable names, optional
         Variables to be plotted, if None all variable are plotted. Prefix the
         variables by `~` when you want to exclude them from the plot.
-    filter: {None, "like", "regex"}, optional, default=None
+    filter_vars: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
         interpret var_names as substrings of the real variables names. If "regex",
         interpret var_names as regular expressions on the real variables names. A la
@@ -157,7 +157,7 @@ def plot_pair(
 
         >>> az.plot_pair(centered,
         ...             var_names=['^t', 'mu'],
-        ...             filter="regex",
+        ...             filter_vars="regex",
         ...             coords=coords,
         ...             divergences=True,
         ...             textsize=18)
@@ -225,7 +225,7 @@ def plot_pair(
     # Get posterior draws and combine chains
     data = convert_to_inference_data(data)
     grouped_data = convert_to_dataset(data, group=group)
-    var_names = _var_names(var_names, grouped_data, filter)
+    var_names = _var_names(var_names, grouped_data, filter_vars)
     flat_var_names, infdata_group = xarray_to_ndarray(
         get_coords(grouped_data, coords), var_names=var_names, combined=True
     )

--- a/arviz/plots/parallelplot.py
+++ b/arviz/plots/parallelplot.py
@@ -12,6 +12,7 @@ from ..stats.stats_utils import stats_variance_2d as svar
 def plot_parallel(
     data,
     var_names=None,
+    filter=None,
     coords=None,
     figsize=None,
     textsize=None,
@@ -33,31 +34,37 @@ def plot_parallel(
 
     Parameters
     ----------
-    data : obj
+    data: obj
         Any object that can be converted to an az.InferenceData object
         Refer to documentation of az.convert_to_dataset for details
-    var_names : list of variable names
-        Variables to be plotted, if None all variable are plotted. Can be used to change the order
-        of the plotted variables
-    coords : mapping, optional
+    var_names: list of variable names
+        Variables to be plotted, if `None` all variable are plotted. Can be used to change the order
+        of the plotted variables. Prefix the variables by `~` when you want to exclude
+        them from the plot.
+    filter: Union[None, "like", "regex"], optional, default=None
+        If `None` (default), interpret var_names as the real variables names. If "like",
+        interpret var_names as substrings of the real variables names. If "regex",
+        interpret var_names as regular expressions on the real variables names. À la
+        `pandas.filter`.
+    coords: mapping, optional
         Coordinates of var_names to be plotted. Passed to `Dataset.sel`
-    figsize : tuple
+    figsize: tuple
         Figure size. If None it will be defined automatically.
     textsize: float
         Text size scaling factor for labels, titles and lines. If None it will be autoscaled based
         on figsize.
-    legend : bool
+    legend: bool
         Flag for plotting legend (defaults to True)
-    colornd : valid matplotlib color
+    colornd: valid matplotlib color
         color for non-divergent points. Defaults to 'k'
-    colord : valid matplotlib color
+    colord: valid matplotlib color
         color for divergent points. Defaults to 'C1'
-    shadend : float
+    shadend: float
         Alpha blending value for non-divergent points, between 0 (invisible) and 1 (opaque).
         Defaults to .025
     ax: axes, optional
         Matplotlib axes or bokeh figures.
-    norm_method : str
+    norm_method: str
         Method for normalizing the data. Methods include normal, minmax and rank.
         Defaults to none.
     backend: str, optional
@@ -67,12 +74,12 @@ def plot_parallel(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
-    show : bool, optional
+    show: bool, optional
         Call backend show function.
 
     Returns
     -------
-    axes : matplotlib axes or bokeh figures
+    axes: matplotlib axes or bokeh figures
 
     Examples
     --------
@@ -104,7 +111,7 @@ def plot_parallel(
 
     # Get posterior draws and combine chains
     posterior_data = convert_to_dataset(data, group="posterior")
-    var_names = _var_names(var_names, posterior_data)
+    var_names = _var_names(var_names, posterior_data, filter)
     var_names, _posterior = xarray_to_ndarray(
         get_coords(posterior_data, coords), var_names=var_names, combined=True
     )

--- a/arviz/plots/parallelplot.py
+++ b/arviz/plots/parallelplot.py
@@ -41,10 +41,10 @@ def plot_parallel(
         Variables to be plotted, if `None` all variable are plotted. Can be used to change the order
         of the plotted variables. Prefix the variables by `~` when you want to exclude
         them from the plot.
-    filter: Union[None, "like", "regex"], optional, default=None
+    filter: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
         interpret var_names as substrings of the real variables names. If "regex",
-        interpret var_names as regular expressions on the real variables names. À la
+        interpret var_names as regular expressions on the real variables names. A la
         `pandas.filter`.
     coords: mapping, optional
         Coordinates of var_names to be plotted. Passed to `Dataset.sel`

--- a/arviz/plots/parallelplot.py
+++ b/arviz/plots/parallelplot.py
@@ -12,7 +12,7 @@ from ..stats.stats_utils import stats_variance_2d as svar
 def plot_parallel(
     data,
     var_names=None,
-    filter=None,
+    filter_vars=None,
     coords=None,
     figsize=None,
     textsize=None,
@@ -41,7 +41,7 @@ def plot_parallel(
         Variables to be plotted, if `None` all variable are plotted. Can be used to change the order
         of the plotted variables. Prefix the variables by `~` when you want to exclude
         them from the plot.
-    filter: {None, "like", "regex"}, optional, default=None
+    filter_vars: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
         interpret var_names as substrings of the real variables names. If "regex",
         interpret var_names as regular expressions on the real variables names. A la
@@ -111,7 +111,7 @@ def plot_parallel(
 
     # Get posterior draws and combine chains
     posterior_data = convert_to_dataset(data, group="posterior")
-    var_names = _var_names(var_names, posterior_data, filter)
+    var_names = _var_names(var_names, posterior_data, filter_vars)
     var_names, _posterior = xarray_to_ndarray(
         get_coords(posterior_data, coords), var_names=var_names, combined=True
     )

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -48,10 +48,10 @@ def plot_posterior(
     var_names: list of variable names
         Variables to be plotted, two variables are required. Prefix the variables by `~`
         when you want to exclude them from the plot.
-    filter: Union[None, "like", "regex"], optional, default=None
+    filter: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
         interpret var_names as substrings of the real variables names. If "regex",
-        interpret var_names as regular expressions on the real variables names. À la
+        interpret var_names as regular expressions on the real variables names. A la
         `pandas.filter`.
     transform: callable
         Function to transform data (defaults to None i.e.the identity function)
@@ -127,7 +127,7 @@ def plot_posterior(
 
         >>> az.plot_posterior(data, var_names=['mu'])
 
-    Plot Region of Practical Equivalence (rope) for all distributions
+    Plot Region of Practical Equivalence (rope) and select variables with regular expressions
 
     .. plot::
         :context: close-figs

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -17,7 +17,7 @@ from ..rcparams import rcParams
 def plot_posterior(
     data,
     var_names=None,
-    filter=None,
+    filter_vars=None,
     transform=None,
     coords=None,
     figsize=None,
@@ -48,7 +48,7 @@ def plot_posterior(
     var_names: list of variable names
         Variables to be plotted, two variables are required. Prefix the variables by `~`
         when you want to exclude them from the plot.
-    filter: {None, "like", "regex"}, optional, default=None
+    filter_vars: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
         interpret var_names as substrings of the real variables names. If "regex",
         interpret var_names as regular expressions on the real variables names. A la
@@ -132,7 +132,7 @@ def plot_posterior(
     .. plot::
         :context: close-figs
 
-        >>> az.plot_posterior(data, var_names=['mu', '^the'], filter="regex", rope=(-1, 1))
+        >>> az.plot_posterior(data, var_names=['mu', '^the'], filter_vars="regex", rope=(-1, 1))
 
     Plot Region of Practical Equivalence for selected distributions
 
@@ -190,7 +190,7 @@ def plot_posterior(
     data = convert_to_dataset(data, group=group)
     if transform is not None:
         data = transform(data)
-    var_names = _var_names(var_names, data, filter)
+    var_names = _var_names(var_names, data, filter_vars)
 
     if coords is None:
         coords = {}

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -17,6 +17,7 @@ from ..rcparams import rcParams
 def plot_posterior(
     data,
     var_names=None,
+    filter=None,
     transform=None,
     coords=None,
     figsize=None,
@@ -41,31 +42,37 @@ def plot_posterior(
 
     Parameters
     ----------
-    data : obj
+    data: obj
         Any object that can be converted to an az.InferenceData object
         Refer to documentation of az.convert_to_dataset for details
-    var_names : list of variable names
-        Variables to be plotted, two variables are required.
-    transform : callable
+    var_names: list of variable names
+        Variables to be plotted, two variables are required. Prefix the variables by `~`
+        when you want to exclude them from the plot.
+    filter: Union[None, "like", "regex"], optional, default=None
+        If `None` (default), interpret var_names as the real variables names. If "like",
+        interpret var_names as substrings of the real variables names. If "regex",
+        interpret var_names as regular expressions on the real variables names. À la
+        `pandas.filter`.
+    transform: callable
         Function to transform data (defaults to None i.e.the identity function)
-    coords : mapping, optional
+    coords: mapping, optional
         Coordinates of var_names to be plotted. Passed to `Dataset.sel`
-    figsize : tuple
+    figsize: tuple
         Figure size. If None it will be defined automatically.
     textsize: float
         Text size scaling factor for labels, titles and lines. If None it will be autoscaled based
         on figsize.
-    credible_interval : float, optional
+    credible_interval: float, optional
         Credible intervals. Defaults to 0.94. Use None to hide the credible interval
-    multimodal : bool
+    multimodal: bool
         If true (default) it may compute more than one credible interval if the distribution is
         multimodal and the modes are well separated.
-    round_to : int, optional
+    round_to: int, optional
         Controls formatting of floats. Defaults to 2 or the integer part, whichever is bigger.
-    point_estimate : Optional[str]
+    point_estimate: Optional[str]
         Plot point estimate per variable. Values should be 'mean', 'median', 'mode' or None.
         Defaults to 'auto' i.e. it falls back to default set in rcParams.
-    group : str, optional
+    group: str, optional
         Specifies which InferenceData group should be plotted. Defaults to ‘posterior’.
     rope: tuple or dictionary of tuples
         Lower and upper values of the Region Of Practical Equivalence. If a list is provided, its
@@ -77,11 +84,11 @@ def plot_posterior(
     kind: str
         Type of plot to display (kde or hist) For discrete variables this argument is ignored and
         a histogram is always used.
-    bw : float
+    bw: float
         Bandwidth scaling factor for the KDE. Should be larger than 0. The higher this number the
         smoother the KDE will be. Defaults to 4.5 which is essentially the same as the Scott's rule
         of thumb (the default rule used by SciPy). Only works if `kind == kde`.
-    bins : integer or sequence or 'auto', optional
+    bins: integer or sequence or 'auto', optional
         Controls the number of bins, accepts the same keywords `matplotlib.hist()` does. Only works
         if `kind == hist`. If None (default) it will use `auto` for continuous variables and
         `range(xmin, xmax + 1)` for discrete variables.
@@ -93,14 +100,14 @@ def plot_posterior(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
-    show : bool, optional
+    show: bool, optional
         Call backend show function.
     **kwargs
         Passed as-is to plt.hist() or plt.plot() function depending on the value of `kind`.
 
     Returns
     -------
-    axes : matplotlib axes or bokeh figures
+    axes: matplotlib axes or bokeh figures
 
     Examples
     --------
@@ -125,7 +132,7 @@ def plot_posterior(
     .. plot::
         :context: close-figs
 
-        >>> az.plot_posterior(data, var_names=['mu', 'theta'], rope=(-1, 1))
+        >>> az.plot_posterior(data, var_names=['mu', '^the'], filter="regex", rope=(-1, 1))
 
     Plot Region of Practical Equivalence for selected distributions
 
@@ -183,7 +190,7 @@ def plot_posterior(
     data = convert_to_dataset(data, group=group)
     if transform is not None:
         data = transform(data)
-    var_names = _var_names(var_names, data)
+    var_names = _var_names(var_names, data, filter)
 
     if coords is None:
         coords = {}

--- a/arviz/plots/ppcplot.py
+++ b/arviz/plots/ppcplot.py
@@ -26,7 +26,7 @@ def plot_ppc(
     textsize=None,
     data_pairs=None,
     var_names=None,
-    filter=None,
+    filter_vars=None,
     coords=None,
     flatten=None,
     flatten_pp=None,
@@ -74,7 +74,7 @@ def plot_ppc(
     var_names: list of variable names
         Variables to be plotted, if `None` all variable are plotted. Prefix the
         variables by `~` when you want to exclude them from the plot.
-    filter: {None, "like", "regex"}, optional, default=None
+    filter_vars: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
         interpret var_names as substrings of the real variables names. If "regex",
         interpret var_names as regular expressions on the real variables names. A la
@@ -224,9 +224,9 @@ def plot_ppc(
 
     if var_names is None:
         var_names = list(observed.data_vars)
-    var_names = _var_names(var_names, observed, filter)
+    var_names = _var_names(var_names, observed, filter_vars)
     pp_var_names = [data_pairs.get(var, var) for var in var_names]
-    pp_var_names = _var_names(pp_var_names, predictive_dataset, filter)
+    pp_var_names = _var_names(pp_var_names, predictive_dataset, filter_vars)
 
     if flatten_pp is None and flatten is None:
         flatten_pp = list(predictive_dataset.dims.keys())

--- a/arviz/plots/ppcplot.py
+++ b/arviz/plots/ppcplot.py
@@ -74,10 +74,10 @@ def plot_ppc(
     var_names: list of variable names
         Variables to be plotted, if `None` all variable are plotted. Prefix the
         variables by `~` when you want to exclude them from the plot.
-    filter: Union[None, "like", "regex"], optional, default=None
+    filter: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
         interpret var_names as substrings of the real variables names. If "regex",
-        interpret var_names as regular expressions on the real variables names. À la
+        interpret var_names as regular expressions on the real variables names. A la
         `pandas.filter`.
     coords: dict
         Dictionary mapping dimensions to selected coordinates to be plotted.

--- a/arviz/plots/ppcplot.py
+++ b/arviz/plots/ppcplot.py
@@ -26,6 +26,7 @@ def plot_ppc(
     textsize=None,
     data_pairs=None,
     var_names=None,
+    filter=None,
     coords=None,
     flatten=None,
     flatten_pp=None,
@@ -46,21 +47,21 @@ def plot_ppc(
 
     Parameters
     ----------
-    data : az.InferenceData object
+    data: az.InferenceData object
         InferenceData object containing the observed and posterior/prior predictive data.
-    kind : str
+    kind: str
         Type of plot to display (kde, cumulative, or scatter). Defaults to kde.
-    alpha : float
+    alpha: float
         Opacity of posterior/prior predictive density curves.
         Defaults to 0.2 for kind = kde and cumulative, for scatter defaults to 0.7
-    mean : bool
+    mean: bool
         Whether or not to plot the mean posterior/prior predictive distribution. Defaults to True
-    figsize : tuple
+    figsize: tuple
         Figure size. If None it will be defined automatically.
     textsize: float
         Text size scaling factor for labels, titles and lines. If None it will be
         autoscaled based on figsize.
-    data_pairs : dict
+    data_pairs: dict
         Dictionary containing relations between observed data and posterior/prior predictive data.
         Dictionary structure:
 
@@ -70,39 +71,44 @@ def plot_ppc(
         For example, `data_pairs = {'y' : 'y_hat'}`
         If None, it will assume that the observed data and the posterior/prior
         predictive data have the same variable name.
-    var_names : list
-        List of variables to be plotted. Defaults to all observed variables in the
-        model if None.
-    coords : dict
+    var_names: list of variable names
+        Variables to be plotted, if `None` all variable are plotted. Prefix the
+        variables by `~` when you want to exclude them from the plot.
+    filter: Union[None, "like", "regex"], optional, default=None
+        If `None` (default), interpret var_names as the real variables names. If "like",
+        interpret var_names as substrings of the real variables names. If "regex",
+        interpret var_names as regular expressions on the real variables names. À la
+        `pandas.filter`.
+    coords: dict
         Dictionary mapping dimensions to selected coordinates to be plotted.
         Dimensions without a mapping specified will include all coordinates for
         that dimension. Defaults to including all coordinates for all
         dimensions if None.
-    flatten : list
+    flatten: list
         List of dimensions to flatten in observed_data. Only flattens across the coordinates
         specified in the coords argument. Defaults to flattening all of the dimensions.
-    flatten_pp : list
+    flatten_pp: list
         List of dimensions to flatten in posterior_predictive/prior_predictive. Only flattens
         across the coordinates specified in the coords argument. Defaults to flattening all
         of the dimensions. Dimensions should match flatten excluding dimensions for data_pairs
         parameters. If flatten is defined and flatten_pp is None, then `flatten_pp=flatten`.
-    num_pp_samples : int
+    num_pp_samples: int
         The number of posterior/prior predictive samples to plot. For `kind` = 'scatter' and
         `animation = False` if defaults to a maximum of 5 samples and will set jitter to 0.7
         unless defined otherwise. Otherwise it defaults to all provided samples.
-    random_seed : int
+    random_seed: int
         Random number generator seed passed to numpy.random.seed to allow
         reproducibility of the plot. By default, no seed will be provided
         and the plot will change each call if a random sample is specified
         by `num_pp_samples`.
-    jitter : float
+    jitter: float
         If kind is "scatter", jitter will add random uniform noise to the height
         of the ppc samples and observed data. By default 0.
-    animated : bool
+    animated: bool
         Create an animation of one posterior/prior predictive sample per frame. Defaults to False.
-    animation_kwargs : dict
+    animation_kwargs: dict
         Keywords passed to `animation.FuncAnimation`.
-    legend : bool
+    legend: bool
         Add legend to figure. By default True.
     ax: numpy array-like of matplotlib axes or bokeh figures, optional
         A 2D array of locations into which to plot the densities. If not supplied, Arviz will create
@@ -112,15 +118,15 @@ def plot_ppc(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
-    group : {"prior", "posterior"}, optional
+    group: {"prior", "posterior"}, optional
         Specifies which InferenceData group should be plotted. Defaults to 'posterior'.
         Other value can be 'prior'.
-    show : bool, optional
+    show: bool, optional
         Call backend show function.
 
     Returns
     -------
-    axes : matplotlib axes or bokeh figures
+    axes: matplotlib axes or bokeh figures
 
     Examples
     --------
@@ -131,8 +137,8 @@ def plot_ppc(
 
         >>> import arviz as az
         >>> data = az.load_arviz_data('radon')
-        >>> az.plot_ppc(data,data_pairs={"obs":"obs"})
-        >>> #az.plot_ppc(data,data_pairs={"obs":"obs_hat"})
+        >>> az.plot_ppc(data, data_pairs={"obs":"obs"})
+        >>> #az.plot_ppc(data, data_pairs={"obs":"obs_hat"})
 
     Plot the overlay with empirical CDFs.
 
@@ -218,9 +224,9 @@ def plot_ppc(
 
     if var_names is None:
         var_names = list(observed.data_vars)
-    var_names = _var_names(var_names, observed)
+    var_names = _var_names(var_names, observed, filter)
     pp_var_names = [data_pairs.get(var, var) for var in var_names]
-    pp_var_names = _var_names(pp_var_names, predictive_dataset)
+    pp_var_names = _var_names(pp_var_names, predictive_dataset, filter)
 
     if flatten_pp is None and flatten is None:
         flatten_pp = list(predictive_dataset.dims.keys())

--- a/arviz/plots/rankplot.py
+++ b/arviz/plots/rankplot.py
@@ -18,6 +18,7 @@ from ..numeric_utils import _sturges_formula
 def plot_rank(
     data,
     var_names=None,
+    filter=None,
     transform=None,
     coords=None,
     bins=None,
@@ -47,31 +48,37 @@ def plot_rank(
 
     Parameters
     ----------
-    data : obj
+    data: obj
         Any object that can be converted to an az.InferenceData object. Refer to documentation of
         az.convert_to_dataset for details
-    var_names : string or list of variable names
-        Variables to be plotted
-    transform : callable
+    var_names: string or list of variable names
+        Variables to be plotted. Prefix the variables by `~` when you want to exclude
+        them from the plot.
+    filter: Union[None, "like", "regex"], optional, default=None
+        If `None` (default), interpret var_names as the real variables names. If "like",
+        interpret var_names as substrings of the real variables names. If "regex",
+        interpret var_names as regular expressions on the real variables names. À la
+        `pandas.filter`.
+    transform: callable
         Function to transform data (defaults to None i.e.the identity function)
-    coords : mapping, optional
+    coords: mapping, optional
         Coordinates of var_names to be plotted. Passed to `Dataset.sel`
-    bins : None or passed to np.histogram
+    bins: None or passed to np.histogram
         Binning strategy used for histogram. By default uses twice the result of Sturges' formula.
         See `np.histogram` documenation for, other available arguments.
-    kind : string
+    kind: string
         If bars (defaults), ranks are represented as stacked histograms (one per chain). If vlines
         ranks are represented as vertical lines above or below `ref_line`.
-    colors : string or list of strings
+    colors: string or list of strings
         List with valid matplotlib colors, one color per model. Alternative a string can be passed.
         If the string is `cycle`, it will automatically choose a color per model from matplotlib's
         cycle. If a single color is passed, e.g. 'k', 'C2' or 'red' this color will be used for all
         models. Defaults to `cycle`.
-    ref_line : boolean
+    ref_line: boolean
         Whether to include a dashed line showing where a uniform distribution would lie
-    labels : bool
+    labels: bool
         wheter to plot or not the x and y labels, defaults to True
-    figsize : tuple
+    figsize: tuple
         Figure size. If None it will be defined automatically.
     ax: numpy array-like of matplotlib axes or bokeh figures, optional
         A 2D array of locations into which to plot the densities. If not supplied, Arviz will create
@@ -81,12 +88,12 @@ def plot_rank(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
-    show : bool, optional
+    show: bool, optional
         Call backend show function.
 
     Returns
     -------
-    axes : matplotlib axes or bokeh figures
+    axes: matplotlib axes or bokeh figures
 
     Examples
     --------
@@ -126,7 +133,7 @@ def plot_rank(
     posterior_data = convert_to_dataset(data, group="posterior")
     if coords is not None:
         posterior_data = posterior_data.sel(**coords)
-    var_names = _var_names(var_names, posterior_data)
+    var_names = _var_names(var_names, posterior_data, filter)
     plotters = filter_plotters_list(
         list(xarray_var_iter(posterior_data, var_names=var_names, combined=True)), "plot_rank"
     )

--- a/arviz/plots/rankplot.py
+++ b/arviz/plots/rankplot.py
@@ -18,7 +18,7 @@ from ..numeric_utils import _sturges_formula
 def plot_rank(
     data,
     var_names=None,
-    filter=None,
+    filter_vars=None,
     transform=None,
     coords=None,
     bins=None,
@@ -54,7 +54,7 @@ def plot_rank(
     var_names: string or list of variable names
         Variables to be plotted. Prefix the variables by `~` when you want to exclude
         them from the plot.
-    filter: {None, "like", "regex"}, optional, default=None
+    filter_vars: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
         interpret var_names as substrings of the real variables names. If "regex",
         interpret var_names as regular expressions on the real variables names. A la
@@ -133,7 +133,7 @@ def plot_rank(
     posterior_data = convert_to_dataset(data, group="posterior")
     if coords is not None:
         posterior_data = posterior_data.sel(**coords)
-    var_names = _var_names(var_names, posterior_data, filter)
+    var_names = _var_names(var_names, posterior_data, filter_vars)
     plotters = filter_plotters_list(
         list(xarray_var_iter(posterior_data, var_names=var_names, combined=True)), "plot_rank"
     )

--- a/arviz/plots/rankplot.py
+++ b/arviz/plots/rankplot.py
@@ -54,10 +54,10 @@ def plot_rank(
     var_names: string or list of variable names
         Variables to be plotted. Prefix the variables by `~` when you want to exclude
         them from the plot.
-    filter: Union[None, "like", "regex"], optional, default=None
+    filter: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
         interpret var_names as substrings of the real variables names. If "regex",
-        interpret var_names as regular expressions on the real variables names. À la
+        interpret var_names as regular expressions on the real variables names. A la
         `pandas.filter`.
     transform: callable
         Function to transform data (defaults to None i.e.the identity function)

--- a/arviz/plots/traceplot.py
+++ b/arviz/plots/traceplot.py
@@ -57,10 +57,10 @@ def plot_trace(
     var_names: str or list of str, optional
         One or more variables to be plotted. Prefix the variables by `~` when you want
         to exclude them from the plot.
-    filter: Union[None, "like", "regex"], optional, default=None
+    filter: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
         interpret var_names as substrings of the real variables names. If "regex",
-        interpret var_names as regular expressions on the real variables names. À la
+        interpret var_names as regular expressions on the real variables names. A la
         `pandas.filter`.
     coords: dict of {str: slice or array_like}, optional
         Coordinates of var_names to be plotted. Passed to `Dataset.sel`
@@ -110,7 +110,7 @@ def plot_trace(
 
     Examples
     --------
-    Plot a subset variables
+    Plot a subset variables and select them with partial naming
 
     .. plot::
         :context: close-figs
@@ -134,7 +134,7 @@ def plot_trace(
 
         >>> az.plot_trace(data, var_names=["mu", "tau"], kind="rank_bars")
 
-    Combine all chains into one distribution
+    Combine all chains into one distribution and select variables with regular expressions
 
     .. plot::
         :context: close-figs

--- a/arviz/plots/traceplot.py
+++ b/arviz/plots/traceplot.py
@@ -139,7 +139,9 @@ def plot_trace(
     .. plot::
         :context: close-figs
 
-        >>> az.plot_trace(data, var_names=('^theta'), filter_vars="regex", coords=coords, combined=True)
+        >>> az.plot_trace(
+        >>>     data, var_names=('^theta'), filter_vars="regex", coords=coords, combined=True
+        >>>> )
 
 
     Plot reference lines against distribution and trace

--- a/arviz/plots/traceplot.py
+++ b/arviz/plots/traceplot.py
@@ -19,7 +19,7 @@ from ..rcparams import rcParams
 def plot_trace(
     data: InferenceData,
     var_names: Optional[List[str]] = None,
-    filter: Optional[str] = None,
+    filter_vars: Optional[str] = None,
     transform: Optional[Callable] = None,
     coords: Optional[CoordSpec] = None,
     divergences: Optional[str] = "bottom",
@@ -57,7 +57,7 @@ def plot_trace(
     var_names: str or list of str, optional
         One or more variables to be plotted. Prefix the variables by `~` when you want
         to exclude them from the plot.
-    filter: {None, "like", "regex"}, optional, default=None
+    filter_vars: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
         interpret var_names as substrings of the real variables names. If "regex",
         interpret var_names as regular expressions on the real variables names. A la
@@ -118,7 +118,7 @@ def plot_trace(
         >>> import arviz as az
         >>> data = az.load_arviz_data('non_centered_eight')
         >>> coords = {'school': ['Choate', 'Lawrenceville']}
-        >>> az.plot_trace(data, var_names=('theta'), filter="like", coords=coords)
+        >>> az.plot_trace(data, var_names=('theta'), filter_vars="like", coords=coords)
 
     Show all dimensions of multidimensional variables in the same plot
 
@@ -139,7 +139,7 @@ def plot_trace(
     .. plot::
         :context: close-figs
 
-        >>> az.plot_trace(data, var_names=('^theta'), filter="regex", coords=coords, combined=True)
+        >>> az.plot_trace(data, var_names=('^theta'), filter_vars="regex", coords=coords, combined=True)
 
 
     Plot reference lines against distribution and trace
@@ -175,7 +175,7 @@ def plot_trace(
     if transform is not None:
         data = transform(data)
 
-    var_names = _var_names(var_names, data, filter)
+    var_names = _var_names(var_names, data, filter_vars)
 
     if lines is None:
         lines = ()

--- a/arviz/plots/traceplot.py
+++ b/arviz/plots/traceplot.py
@@ -19,6 +19,7 @@ from ..rcparams import rcParams
 def plot_trace(
     data: InferenceData,
     var_names: Optional[List[str]] = None,
+    filter: Optional[str] = None,
     transform: Optional[Callable] = None,
     coords: Optional[CoordSpec] = None,
     divergences: Optional[str] = "bottom",
@@ -50,57 +51,62 @@ def plot_trace(
 
     Parameters
     ----------
-    data : obj
+    data: obj
         Any object that can be converted to an az.InferenceData object
         Refer to documentation of az.convert_to_dataset for details
-    var_names : str or list of str, optional
-        One or more variables to be plotted.
-    coords : dict of {str: slice or array_like}, optional
+    var_names: str or list of str, optional
+        One or more variables to be plotted. Prefix the variables by `~` when you want
+        to exclude them from the plot.
+    filter: Union[None, "like", "regex"], optional, default=None
+        If `None` (default), interpret var_names as the real variables names. If "like",
+        interpret var_names as substrings of the real variables names. If "regex",
+        interpret var_names as regular expressions on the real variables names. À la
+        `pandas.filter`.
+    coords: dict of {str: slice or array_like}, optional
         Coordinates of var_names to be plotted. Passed to `Dataset.sel`
-    divergences : {"bottom", "top", None}, optional
+    divergences: {"bottom", "top", None}, optional
         Plot location of divergences on the traceplots.
-    kind : {"trace", "rank_bar", "rank_vlines"}, optional
+    kind: {"trace", "rank_bar", "rank_vlines"}, optional
         Choose between plotting sampled values per iteration and rank plots.
-    transform : callable, optional
+    transform: callable, optional
         Function to transform data (defaults to None i.e.the identity function)
-    figsize : tuple of (float, float), optional
+    figsize: tuple of (float, float), optional
         If None, size is (12, variables * 2)
-    rug : bool, optional
+    rug: bool, optional
         If True adds a rugplot. Defaults to False. Ignored for 2D KDE.
         Only affects continuous variables.
-    lines : list of tuple of (str, dict, array_like), optional
+    lines: list of tuple of (str, dict, array_like), optional
         List of (var_name, {'coord': selection}, [line, positions]) to be overplotted as
         vertical lines on the density and horizontal lines on the trace.
-    compact : bool, optional
+    compact: bool, optional
         Plot multidimensional variables in a single plot.
-    compact_prop : tuple of (str, array_like), optional
+    compact_prop: tuple of (str, array_like), optional
         Tuple containing the property name and the property values to distinguish diferent
         dimensions with compact=True
-    combined : bool, optional
+    combined: bool, optional
         Flag for combining multiple chains into a single line. If False (default), chains will be
         plotted separately.
-    chain_prop : tuple of (str, array_like), optional
+    chain_prop: tuple of (str, array_like), optional
         Tuple containing the property name and the property values to distinguish diferent chains
-    legend : bool, optional
+    legend: bool, optional
         Add a legend to the figure with the chain color code.
-    plot_kwargs, fill_kwargs, rug_kwargs, hist_kwargs : dict, optional
+    plot_kwargs, fill_kwargs, rug_kwargs, hist_kwargs: dict, optional
         Extra keyword arguments passed to `arviz.plot_dist`. Only affects continuous variables.
-    trace_kwargs : dict, optional
+    trace_kwargs: dict, optional
         Extra keyword arguments passed to `plt.plot`
-    backend : {"matplotlib", "bokeh"}, optional
+    backend: {"matplotlib", "bokeh"}, optional
         Select plotting backend.
-    backend_config : dict, optional
+    backend_config: dict, optional
         Currently specifies the bounds to use for bokeh axes. Defaults to value set in rcParams.
-    backend_kwargs : dict, optional
+    backend_kwargs: dict, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
-    show : bool, optional
+    show: bool, optional
         Call backend show function.
 
     Returns
     -------
-    axes : matplotlib axes or bokeh figures
-
+    axes: matplotlib axes or bokeh figures
 
     Examples
     --------
@@ -112,7 +118,7 @@ def plot_trace(
         >>> import arviz as az
         >>> data = az.load_arviz_data('non_centered_eight')
         >>> coords = {'school': ['Choate', 'Lawrenceville']}
-        >>> az.plot_trace(data, var_names=('theta_t', 'theta'), coords=coords)
+        >>> az.plot_trace(data, var_names=('theta'), filter="like", coords=coords)
 
     Show all dimensions of multidimensional variables in the same plot
 
@@ -133,7 +139,7 @@ def plot_trace(
     .. plot::
         :context: close-figs
 
-        >>> az.plot_trace(data, var_names=('theta_t', 'theta'), coords=coords, combined=True)
+        >>> az.plot_trace(data, var_names=('^theta'), filter="regex", coords=coords, combined=True)
 
 
     Plot reference lines against distribution and trace
@@ -169,7 +175,7 @@ def plot_trace(
     if transform is not None:
         data = transform(data)
 
-    var_names = _var_names(var_names, data)
+    var_names = _var_names(var_names, data, filter)
 
     if lines is None:
         lines = ()

--- a/arviz/plots/violinplot.py
+++ b/arviz/plots/violinplot.py
@@ -15,7 +15,7 @@ from ..rcparams import rcParams
 def plot_violin(
     data,
     var_names=None,
-    filter=None,
+    filter_vars=None,
     transform=None,
     quartiles=True,
     rug=False,
@@ -47,7 +47,7 @@ def plot_violin(
     var_names: list of variable names, optional
         Variables to be plotted, if None all variable are plotted. Prefix the
         variables by `~` when you want to exclude them from the plot.
-    filter: {None, "like", "regex"}, optional, default=None
+    filter_vars: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
         interpret var_names as substrings of the real variables names. If "regex",
         interpret var_names as regular expressions on the real variables names. A la
@@ -119,7 +119,7 @@ def plot_violin(
     data = convert_to_dataset(data, group="posterior")
     if transform is not None:
         data = transform(data)
-    var_names = _var_names(var_names, data, filter)
+    var_names = _var_names(var_names, data, filter_vars)
 
     plotters = filter_plotters_list(
         list(xarray_var_iter(data, var_names=var_names, combined=True)), "plot_violin"

--- a/arviz/plots/violinplot.py
+++ b/arviz/plots/violinplot.py
@@ -47,10 +47,10 @@ def plot_violin(
     var_names: list of variable names, optional
         Variables to be plotted, if None all variable are plotted. Prefix the
         variables by `~` when you want to exclude them from the plot.
-    filter: Union[None, "like", "regex"], optional, default=None
+    filter: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
         interpret var_names as substrings of the real variables names. If "regex",
-        interpret var_names as regular expressions on the real variables names. À la
+        interpret var_names as regular expressions on the real variables names. A la
         `pandas.filter`.
     transform: callable
         Function to transform data (defaults to None i.e. the identity function)

--- a/arviz/plots/violinplot.py
+++ b/arviz/plots/violinplot.py
@@ -15,6 +15,7 @@ from ..rcparams import rcParams
 def plot_violin(
     data,
     var_names=None,
+    filter=None,
     transform=None,
     quartiles=True,
     rug=False,
@@ -40,42 +41,48 @@ def plot_violin(
 
     Parameters
     ----------
-    data : obj
+    data: obj
         Any object that can be converted to an az.InferenceData object
         Refer to documentation of az.convert_to_dataset for details
-    var_names: list, optional
-        List of variables to plot (defaults to None, which results in all variables plotted)
-    transform : callable
+    var_names: list of variable names, optional
+        Variables to be plotted, if None all variable are plotted. Prefix the
+        variables by `~` when you want to exclude them from the plot.
+    filter: Union[None, "like", "regex"], optional, default=None
+        If `None` (default), interpret var_names as the real variables names. If "like",
+        interpret var_names as substrings of the real variables names. If "regex",
+        interpret var_names as regular expressions on the real variables names. À la
+        `pandas.filter`.
+    transform: callable
         Function to transform data (defaults to None i.e. the identity function)
-    quartiles : bool, optional
+    quartiles: bool, optional
         Flag for plotting the interquartile range, in addition to the credible_interval*100%
         intervals. Defaults to True
-    rug : bool
+    rug: bool
         If True adds a jittered rugplot. Defaults to False.
-    credible_interval : float, optional
+    credible_interval: float, optional
         Credible intervals. Defaults to 0.94.
-    shade : float
+    shade: float
         Alpha blending value for the shaded area under the curve, between 0
         (no shade) and 1 (opaque). Defaults to 0
-    bw : float
+    bw: float
         Bandwidth scaling factor. Should be larger than 0. The higher this number the smoother the
         KDE will be. Defaults to 4.5 which is essentially the same as the Scott's rule of thumb
         (the default rule used by SciPy).
-    figsize : tuple
+    figsize: tuple
         Figure size. If None it will be defined automatically.
     textsize: int
         Text size of the point_estimates, axis ticks, and HPD. If None it will be autoscaled
         based on figsize.
-    sharex : bool
+    sharex: bool
         Defaults to True, violinplots share a common x-axis scale.
-    sharey : bool
+    sharey: bool
         Defaults to True, violinplots share a common y-axis scale.
     ax: numpy array-like of matplotlib axes or bokeh figures, optional
         A 2D array of locations into which to plot the densities. If not supplied, Arviz will create
         its own array of plot areas (and return it).
-    shade_kwargs : dicts, optional
+    shade_kwargs: dicts, optional
         Additional keywords passed to `fill_between`, or `barh` to control the shade.
-    rug_kwargs : dict
+    rug_kwargs: dict
         Keywords passed to the rug plot. If true only the righ half side of the violin will be
         plotted.
     backend: str, optional
@@ -83,12 +90,12 @@ def plot_violin(
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used. For additional documentation
         check the plotting method of the backend.
-    show : bool, optional
+    show: bool, optional
         Call backend show function.
 
     Returns
     -------
-    axes : matplotlib axes or bokeh figures
+    axes: matplotlib axes or bokeh figures
 
     Examples
     --------
@@ -112,7 +119,7 @@ def plot_violin(
     data = convert_to_dataset(data, group="posterior")
     if transform is not None:
         data = transform(data)
-    var_names = _var_names(var_names, data)
+    var_names = _var_names(var_names, data, filter)
 
     plotters = filter_plotters_list(
         list(xarray_var_iter(data, var_names=var_names, combined=True)), "plot_violin"

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -321,6 +321,7 @@ def hpd(
     skipna=False,
     group="posterior",
     var_names=None,
+    filter=None,
     coords=None,
     max_modes=10,
     **kwargs,
@@ -351,7 +352,14 @@ def hpd(
          Specifies which InferenceData group should be used to calculate hpd.
          Defaults to 'posterior'
     var_names: list, optional
-        Names of variables to include in the hpd report
+        Names of variables to include in the hpd report. Prefix the variables by `~`
+        when you want to exclude them from the report: `["~beta"]` instead of `["beta"]`
+        (see `az.summary` for more details).
+    filter: Union[None, "like", "regex"], optional, default=None
+        If `None` (default), interpret var_names as the real variables names. If "like",
+         interpret var_names as substrings of the real variables names. If "regex",
+         interpret var_names as regular expressions on the real variables names. À la
+        `pandas.filter`.
     coords: mapping, optional
         Specifies the subset over to calculate hpd.
     max_modes: int, optional
@@ -435,7 +443,7 @@ def hpd(
     ary = convert_to_dataset(ary, group=group)
     if coords is not None:
         ary = get_coords(ary, coords)
-    var_names = _var_names(var_names, ary)
+    var_names = _var_names(var_names, ary, filter)
     ary = ary[var_names] if var_names else ary
 
     hpd_data = _wrap_xarray_ufunc(func, ary, func_kwargs=func_kwargs, **kwargs)
@@ -952,7 +960,7 @@ def summary(
         Names of variables to include in summary. Prefix the variables by `~` when you
         want to exclude them from the summary: `["~beta"]` instead of `["beta"]` (see
         examples below).
-    filter: Union[None, "like", "regex"], default=None
+    filter: Union[None, "like", "regex"], optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
          interpret var_names as substrings of the real variables names. If "regex",
          interpret var_names as regular expressions on the real variables names. À la
@@ -1019,8 +1027,8 @@ def summary(
         In [1]: az.summary(data, var_names=["the"], filter="like")
 
     Use `filter="regex"` to select based on regular expressions, and prefix the variables
-    you want to exclude by `~`. Here, we exlude from the summary all the variables that
-    start with the letter t:
+    you want to exclude by `~`. Here, we exclude from the summary all the variables
+    starting with the letter t:
 
     .. ipython::
 

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -321,7 +321,7 @@ def hpd(
     skipna=False,
     group="posterior",
     var_names=None,
-    filter=None,
+    filter_vars=None,
     coords=None,
     max_modes=10,
     **kwargs,
@@ -355,7 +355,7 @@ def hpd(
         Names of variables to include in the hpd report. Prefix the variables by `~`
         when you want to exclude them from the report: `["~beta"]` instead of `["beta"]`
         (see `az.summary` for more details).
-    filter: {None, "like", "regex"}, optional, default=None
+    filter_vars: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
          interpret var_names as substrings of the real variables names. If "regex",
          interpret var_names as regular expressions on the real variables names. A la
@@ -443,7 +443,7 @@ def hpd(
     ary = convert_to_dataset(ary, group=group)
     if coords is not None:
         ary = get_coords(ary, coords)
-    var_names = _var_names(var_names, ary, filter)
+    var_names = _var_names(var_names, ary, filter_vars)
     ary = ary[var_names] if var_names else ary
 
     hpd_data = _wrap_xarray_ufunc(func, ary, func_kwargs=func_kwargs, **kwargs)
@@ -935,7 +935,7 @@ def r2_score(y_true, y_pred):
 def summary(
     data,
     var_names: Optional[List[str]] = None,
-    filter=None,
+    filter_vars=None,
     fmt: str = "wide",
     kind: str = "all",
     round_to=None,
@@ -960,7 +960,7 @@ def summary(
         Names of variables to include in summary. Prefix the variables by `~` when you
         want to exclude them from the summary: `["~beta"]` instead of `["beta"]` (see
         examples below).
-    filter: {None, "like", "regex"}, optional, default=None
+    filter_vars: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
          interpret var_names as substrings of the real variables names. If "regex",
          interpret var_names as regular expressions on the real variables names. A la
@@ -1019,20 +1019,20 @@ def summary(
            ...: data = az.load_arviz_data("centered_eight")
            ...: az.summary(data, var_names=["mu", "tau"])
 
-    You can use `filter` to select variables without having to specify all the exact
-    names. Use `filter="like"` to select based on partial naming:
+    You can use `filter_vars` to select variables without having to specify all the exact
+    names. Use `filter_vars="like"` to select based on partial naming:
 
     .. ipython::
 
-        In [1]: az.summary(data, var_names=["the"], filter="like")
+        In [1]: az.summary(data, var_names=["the"], filter_vars="like")
 
-    Use `filter="regex"` to select based on regular expressions, and prefix the variables
+    Use `filter_vars="regex"` to select based on regular expressions, and prefix the variables
     you want to exclude by `~`. Here, we exclude from the summary all the variables
     starting with the letter t:
 
     .. ipython::
 
-        In [1]: az.summary(data, var_names=["~^t"], filter="regex")
+        In [1]: az.summary(data, var_names=["~^t"], filter_vars="regex")
 
     Other statistics can be calculated by passing a list of functions
     or a dictionary with key, function pairs.
@@ -1073,7 +1073,7 @@ def summary(
         if not 1 >= credible_interval > 0:
             raise ValueError("The value of credible_interval should be in the interval (0, 1]")
     posterior = convert_to_dataset(data, group="posterior", **extra_args)
-    var_names = _var_names(var_names, posterior, filter)
+    var_names = _var_names(var_names, posterior, filter_vars)
     posterior = posterior if var_names is None else posterior[var_names]
 
     fmt_group = ("wide", "long", "xarray")

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -355,15 +355,15 @@ def hpd(
         Names of variables to include in the hpd report. Prefix the variables by `~`
         when you want to exclude them from the report: `["~beta"]` instead of `["beta"]`
         (see `az.summary` for more details).
-    filter: Union[None, "like", "regex"], optional, default=None
+    filter: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
          interpret var_names as substrings of the real variables names. If "regex",
-         interpret var_names as regular expressions on the real variables names. À la
+         interpret var_names as regular expressions on the real variables names. A la
         `pandas.filter`.
     coords: mapping, optional
         Specifies the subset over to calculate hpd.
     max_modes: int, optional
-        Specifies the maximume number of modes for multimodal case.
+        Specifies the maximum number of modes for multimodal case.
     kwargs: dict, optional
         Additional keywords passed to `wrap_xarray_ufunc`.
         See the docstring of :obj:`wrap_xarray_ufunc method </.stats_utils.wrap_xarray_ufunc>`.
@@ -960,10 +960,10 @@ def summary(
         Names of variables to include in summary. Prefix the variables by `~` when you
         want to exclude them from the summary: `["~beta"]` instead of `["beta"]` (see
         examples below).
-    filter: Union[None, "like", "regex"], optional, default=None
+    filter: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
          interpret var_names as substrings of the real variables names. If "regex",
-         interpret var_names as regular expressions on the real variables names. À la
+         interpret var_names as regular expressions on the real variables names. A la
         `pandas.filter`.
     fmt: {'wide', 'long', 'xarray'}
         Return format is either pandas.DataFrame {'wide', 'long'} or xarray.Dataset {'xarray'}.

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -949,7 +949,9 @@ def summary(
         Any object that can be converted to an az.InferenceData object
         Refer to documentation of az.convert_to_dataset for details
     var_names: list
-        Names of variables to include in summary
+        Names of variables to include in summary. Prefix the variables by `~` when you
+        want to exclude them from the summary: `["~beta"]` instead of `["beta"]` (see
+        examples below).
     filter: Union[None, "like", "regex"], default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
          interpret var_names as substrings of the real variables names. If "regex",
@@ -1008,6 +1010,21 @@ def summary(
         In [1]: import arviz as az
            ...: data = az.load_arviz_data("centered_eight")
            ...: az.summary(data, var_names=["mu", "tau"])
+
+    You can use `filter` to select variables without having to specify all the exact
+    names. Use `filter="like"` to select based on partial naming:
+
+    .. ipython::
+
+        In [1]: az.summary(data, var_names=["the"], filter="like")
+
+    Use `filter="regex"` to select based on regular expressions, and prefix the variables
+    you want to exclude by `~`. Here, we exlude from the summary all the variables that
+    start with the letter t:
+
+    .. ipython::
+
+        In [1]: az.summary(data, var_names=["~^t"], filter="regex")
 
     Other statistics can be calculated by passing a list of functions
     or a dictionary with key, function pairs.

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -927,7 +927,7 @@ def r2_score(y_true, y_pred):
 def summary(
     data,
     var_names: Optional[List[str]] = None,
-    filter_like=False,
+    filter=None,
     fmt: str = "wide",
     kind: str = "all",
     round_to=None,
@@ -950,9 +950,11 @@ def summary(
         Refer to documentation of az.convert_to_dataset for details
     var_names: list
         Names of variables to include in summary
-    filter_like: bool, default=False
-        Whether to interpret var_names as substrings of the real variables names. À la
-        `pandas.filter("like")`.
+    filter: Union[None, "like", "regex"], default=None
+        If `None` (default), interpret var_names as the real variables names. If "like",
+         interpret var_names as substrings of the real variables names. If "regex",
+         interpret var_names as regular expressions on the real variables names. À la
+        `pandas.filter`.
     fmt: {'wide', 'long', 'xarray'}
         Return format is either pandas.DataFrame {'wide', 'long'} or xarray.Dataset {'xarray'}.
     kind: {'all', 'stats', 'diagnostics'}
@@ -1046,7 +1048,7 @@ def summary(
         if not 1 >= credible_interval > 0:
             raise ValueError("The value of credible_interval should be in the interval (0, 1]")
     posterior = convert_to_dataset(data, group="posterior", **extra_args)
-    var_names = _var_names(var_names, posterior, filter_like)
+    var_names = _var_names(var_names, posterior, filter)
     posterior = posterior if var_names is None else posterior[var_names]
 
     fmt_group = ("wide", "long", "xarray")

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -927,6 +927,7 @@ def r2_score(y_true, y_pred):
 def summary(
     data,
     var_names: Optional[List[str]] = None,
+    filter_like=False,
     fmt: str = "wide",
     kind: str = "all",
     round_to=None,
@@ -949,6 +950,9 @@ def summary(
         Refer to documentation of az.convert_to_dataset for details
     var_names: list
         Names of variables to include in summary
+    filter_like: bool, default=False
+        Whether to interpret var_names as substrings of the real variables names. À la
+        `pandas.filter("like")`.
     fmt: {'wide', 'long', 'xarray'}
         Return format is either pandas.DataFrame {'wide', 'long'} or xarray.Dataset {'xarray'}.
     kind: {'all', 'stats', 'diagnostics'}
@@ -1042,7 +1046,7 @@ def summary(
         if not 1 >= credible_interval > 0:
             raise ValueError("The value of credible_interval should be in the interval (0, 1]")
     posterior = convert_to_dataset(data, group="posterior", **extra_args)
-    var_names = _var_names(var_names, posterior)
+    var_names = _var_names(var_names, posterior, filter_like)
     posterior = posterior if var_names is None else posterior[var_names]
 
     fmt_group = ("wide", "long", "xarray")

--- a/arviz/tests/base_tests/test_utils.py
+++ b/arviz/tests/base_tests/test_utils.py
@@ -62,26 +62,31 @@ def test_var_names_key_error(data):
     "var_args",
     [
         (["alpha", "beta"], ["alpha", "beta1", "beta2"], "like"),
-        (["~beta"], ["alpha", "p1", "p2", "phi"], "like"),
+        (["~beta"], ["alpha", "p1", "p2", "phi", "theta", "theta_t"], "like"),
+        (["theta"], ["theta", "theta_t"], "like"),
+        (["~theta"], ["alpha", "beta1", "beta2", "p1", "p2", "phi"], "like"),
         (["p"], ["alpha", "p1", "p2", "phi"], "like"),
-        (["~p"], ["beta1", "beta2"], "like"),
+        (["~p"], ["beta1", "beta2", "theta", "theta_t"], "like"),
         (["^bet"], ["beta1", "beta2"], "regex"),
         (["^p"], ["p1", "p2", "phi"], "regex"),
-        (["~^p"], ["alpha", "beta1", "beta2"], "regex"),
+        (["~^p"], ["alpha", "beta1", "beta2", "theta", "theta_t"], "regex"),
         (["p[0-9]+"], ["p1", "p2"], "regex"),
-        (["~p[0-9]+"], ["alpha", "beta1", "beta2", "phi"], "regex"),
+        (["~p[0-9]+"], ["alpha", "beta1", "beta2", "phi", "theta", "theta_t"], "regex"),
     ],
 )
 def test_var_names_filter(var_args):
     """Test var_names filter with partial naming or regular expressions."""
+    samples = np.random.randn(10)
     data = dict_to_dataset(
         {
-            "alpha": np.random.randn(10),
-            "beta1": np.random.randn(10),
-            "beta2": np.random.randn(10),
-            "p1": np.random.randn(10),
-            "p2": np.random.randn(10),
-            "phi": np.random.randn(10),
+            "alpha": samples,
+            "beta1": samples,
+            "beta2": samples,
+            "p1": samples,
+            "p2": samples,
+            "phi": samples,
+            "theta": samples,
+            "theta_t": samples,
         }
     )
     var_names, expected, filter = var_args

--- a/arviz/tests/base_tests/test_utils.py
+++ b/arviz/tests/base_tests/test_utils.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 import numpy as np
 import pytest
 
+from arviz.data.base import dict_to_dataset
 from ...utils import _var_names, _stack, one_de, two_de, expand_dims, flatten_inference_data_to_dict
 from ...data import load_arviz_data, from_dict
 
@@ -58,7 +59,7 @@ def test_var_names_key_error(data):
 
 
 @pytest.mark.parametrize(
-    "var_names_expected",
+    "var_args",
     [
         (["alpha", "beta"], ["alpha", "beta1", "beta2"], "like"),
         (["~beta"], ["alpha", "p1", "p2", "phi"], "like"),
@@ -71,10 +72,10 @@ def test_var_names_key_error(data):
         (["~p[0-9]+"], ["alpha", "beta1", "beta2", "phi"], "regex"),
     ],
 )
-def test_var_names_filter(var_names_expected):
-    """Test var_name filter with partial naming or regular expressions."""
-    data = from_dict(
-        posterior={
+def test_var_names_filter(var_args):
+    """Test var_names filter with partial naming or regular expressions."""
+    data = dict_to_dataset(
+        {
             "alpha": np.random.randn(10),
             "beta1": np.random.randn(10),
             "beta2": np.random.randn(10),
@@ -82,8 +83,8 @@ def test_var_names_filter(var_names_expected):
             "p2": np.random.randn(10),
             "phi": np.random.randn(10),
         }
-    ).posterior
-    var_names, expected, filter = var_names_expected
+    )
+    var_names, expected, filter = var_args
     assert _var_names(var_names, data, filter) == expected
 
 

--- a/arviz/tests/base_tests/test_utils.py
+++ b/arviz/tests/base_tests/test_utils.py
@@ -89,8 +89,8 @@ def test_var_names_filter(var_args):
             "theta_t": samples,
         }
     )
-    var_names, expected, filter = var_args
-    assert _var_names(var_names, data, filter) == expected
+    var_names, expected, filter_vars = var_args
+    assert _var_names(var_names, data, filter_vars) == expected
 
 
 @pytest.fixture(scope="function")

--- a/arviz/tests/base_tests/test_utils.py
+++ b/arviz/tests/base_tests/test_utils.py
@@ -6,14 +6,7 @@ from unittest.mock import Mock
 import numpy as np
 import pytest
 
-from ...utils import (
-    _var_names,
-    _stack,
-    one_de,
-    two_de,
-    expand_dims,
-    flatten_inference_data_to_dict,
-)
+from ...utils import _var_names, _stack, one_de, two_de, expand_dims, flatten_inference_data_to_dict
 from ...data import load_arviz_data, from_dict
 
 
@@ -92,6 +85,7 @@ def test_var_names_filter(var_names_expected):
     ).posterior
     var_names, expected, filter = var_names_expected
     assert _var_names(var_names, data, filter) == expected
+
 
 @pytest.fixture(scope="function")
 def utils_with_numba_import_fail(monkeypatch):

--- a/arviz/tests/base_tests/test_utils.py
+++ b/arviz/tests/base_tests/test_utils.py
@@ -64,6 +64,35 @@ def test_var_names_key_error(data):
         _var_names(("theta", "tau", "bad_var_name"), data)
 
 
+@pytest.mark.parametrize(
+    "var_names_expected",
+    [
+        (["alpha", "beta"], ["alpha", "beta1", "beta2"], "like"),
+        (["~beta"], ["alpha", "p1", "p2", "phi"], "like"),
+        (["p"], ["alpha", "p1", "p2", "phi"], "like"),
+        (["~p"], ["beta1", "beta2"], "like"),
+        (["^bet"], ["beta1", "beta2"], "regex"),
+        (["^p"], ["p1", "p2", "phi"], "regex"),
+        (["~^p"], ["alpha", "beta1", "beta2"], "regex"),
+        (["p[0-9]+"], ["p1", "p2"], "regex"),
+        (["~p[0-9]+"], ["alpha", "beta1", "beta2", "phi"], "regex"),
+    ],
+)
+def test_var_names_filter(var_names_expected):
+    """Test var_name filter with partial naming or regular expressions."""
+    data = from_dict(
+        posterior={
+            "alpha": np.random.randn(10),
+            "beta1": np.random.randn(10),
+            "beta2": np.random.randn(10),
+            "p1": np.random.randn(10),
+            "p2": np.random.randn(10),
+            "phi": np.random.randn(10),
+        }
+    ).posterior
+    var_names, expected, filter = var_names_expected
+    assert _var_names(var_names, data, filter) == expected
+
 @pytest.fixture(scope="function")
 def utils_with_numba_import_fail(monkeypatch):
     """Patch numba in utils so when its imported it raises ImportError"""

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -10,7 +10,7 @@ import matplotlib.pyplot as plt
 from .rcparams import rcParams
 
 
-def _var_names(var_names, data, filter=False):
+def _var_names(var_names, data, filter_like=False):
     """Handle var_names input across arviz.
 
     Parameters
@@ -18,6 +18,9 @@ def _var_names(var_names, data, filter=False):
     var_names: str, list, or None
     data : xarray.Dataset
         Posterior data in an xarray
+    filter_like: bool, default=False
+        Whether to interpret var_names as substrings of the real variables names. À la
+        `pandas.filter("like")`.
     Returns
     -------
     var_name: list or None
@@ -51,17 +54,15 @@ def _var_names(var_names, data, filter=False):
             var[1:] for var in var_names if var.startswith("~") and var not in all_vars
         ]
         if excluded_vars:
-            if filter:
+            if filter_like:
                 for var in excluded_vars:
                     if var not in all_vars:
-                        real_vars = [
-                            real_var for real_var in all_vars if var in real_var
-                        ]
+                        real_vars = [real_var for real_var in all_vars if var in real_var]
                         excluded_vars.extend(real_vars)
                         excluded_vars.remove(var)
             var_names = [var for var in all_vars if var not in excluded_vars]
 
-        if filter:
+        if filter_like:
             var_names = [var for var in all_vars for name in var_names if name in var]
 
         existing_vars = np.isin(var_names, all_vars)

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -19,9 +19,11 @@ def _var_names(var_names, data, filter=None):
     var_names: str, list, or None
     data : xarray.Dataset
         Posterior data in an xarray
-    filter_like: bool, default=False
-        Whether to interpret var_names as substrings of the real variables names. À la
-        `pandas.filter("like")`.
+    filter: Union[None, "like", "regex"], default=None
+        If `None` (default), interpret var_names as the real variables names. If "like",
+         interpret var_names as substrings of the real variables names. If "regex",
+         interpret var_names as regular expressions on the real variables names. À la
+        `pandas.filter`.
 
     Returns
     -------

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -12,7 +12,7 @@ from numpy import newaxis
 from .rcparams import rcParams
 
 
-def _var_names(var_names, data, filter=None):
+def _var_names(var_names, data, filter_vars=None):
     """Handle var_names input across arviz.
 
     Parameters
@@ -20,7 +20,7 @@ def _var_names(var_names, data, filter=None):
     var_names: str, list, or None
     data : xarray.Dataset
         Posterior data in an xarray
-    filter: {None, "like", "regex"}, optional, default=None
+    filter_vars: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
          interpret var_names as substrings of the real variables names. If "regex",
          interpret var_names as regular expressions on the real variables names. A la
@@ -58,16 +58,16 @@ def _var_names(var_names, data, filter=None):
         excluded_vars = [
             var[1:] for var in var_names if var.startswith("~") and var not in all_vars
         ]
-        filter = str(filter).lower()
+        filter_vars = str(filter_vars).lower()
 
         if excluded_vars:
-            if filter in ("like", "regex"):
+            if filter_vars in ("like", "regex"):
                 for pattern in excluded_vars[:]:
                     excluded_vars.remove(pattern)
-                    if filter == "like":
+                    if filter_vars == "like":
                         real_vars = [real_var for real_var in all_vars if pattern in real_var]
                     else:
-                        # i.e filter == "regex"
+                        # i.e filter_vars == "regex"
                         real_vars = [
                             real_var for real_var in all_vars if re.search(pattern, real_var)
                         ]
@@ -75,9 +75,9 @@ def _var_names(var_names, data, filter=None):
             var_names = [var for var in all_vars if var not in excluded_vars]
 
         else:
-            if filter == "like":
+            if filter_vars == "like":
                 var_names = [var for var in all_vars for name in var_names if name in var]
-            elif filter == "regex":
+            elif filter_vars == "regex":
                 var_names = [var for var in all_vars for name in var_names if re.search(name, var)]
 
         existing_vars = np.isin(var_names, all_vars)

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -21,6 +21,7 @@ def _var_names(var_names, data, filter_like=False):
     filter_like: bool, default=False
         Whether to interpret var_names as substrings of the real variables names. À la
         `pandas.filter("like")`.
+
     Returns
     -------
     var_name: list or None


### PR DESCRIPTION
## Description
- Currently, users can select variables entering `az.summary` and other plotting/diagnostics functions with the `var_names` kwarg. 
This selection must however be exact, meaning that if you have variables with similar names in your trace, you have to specify them all: `az.summary(idata, var_names=["alpha", "beta1", "beta2", "beta3"])`, which can be cumbersome for big models.

- This PR introduces the `filter_like` kwarg to allow users to select _all_ variables containing the given word. For instance, `az.summary(idata, var_names=["alpha", "beta"], filter_like=True)` would give the same result as above. This also works to _exclude_ variables with similar names: `az.summary(idata, var_names=["~beta"], filter_like=True)`

- `filter_like` defaults to `False` to ensure backwards-compatibility.

Before adding these changes to the changelog, I had pending questions:
1. Should we add `filter_like` to the other functionalities that use `var_names`, and not only to `summary`?
2. Should we include new tests for this feature?
- Bonus points: the new code may be too convoluted at times, so please tell me if you see a simpler, more pythonic way to do things.

I'm of course available for any changes, and thanks a lot in advances for your reviews 🖖 