### PR TITLE
add viridis as default cmap

### DIFF
--- a/arviz/plots/styles/arviz-darkgrid.mplstyle
+++ b/arviz/plots/styles/arviz-darkgrid.mplstyle
@@ -29,6 +29,7 @@ axes.facecolor: eeeeee
 axes.edgecolor: white
 axes.linewidth: 0
 grid.color: white
+image.cmap: viridis
 xtick.major.size: 0
 ytick.major.size: 0
 xtick.minor.size: 0

--- a/arviz/plots/styles/arviz-white.mplstyle
+++ b/arviz/plots/styles/arviz-white.mplstyle
@@ -29,6 +29,7 @@ axes.edgecolor: 0
 axes.linewidth: 1
 axes.spines.top: False
 axes.spines.right: False
+image.cmap: viridis
 xtick.major.size: 0
 ytick.major.size: 0
 xtick.minor.size: 0

--- a/arviz/plots/styles/arviz-whitegrid.mplstyle
+++ b/arviz/plots/styles/arviz-whitegrid.mplstyle
@@ -29,6 +29,7 @@ axes.facecolor: white
 axes.edgecolor: .8
 axes.linewidth: 1
 grid.color: .8
+image.cmap: viridis
 xtick.major.size: 0
 ytick.major.size: 0
 xtick.minor.size: 0


### PR DESCRIPTION
Following discussion #1159 this adds viridis as the default cmap, except for `arviz-colors.mplstyle` that intentionally only modifies the color cycle.