### PR TITLE
Metagroups and InferenceData.map

### DIFF
--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -272,7 +272,7 @@ class InferenceData:
                ...: print(idata_subset.observed_data.coords)
 
         """
-        #TODO: use wrap_xarray_method
+        # TODO: use wrap_xarray_method
         if chain_prior is not None:
             warnings.warn(
                 "chain_prior has been deprecated. Use groups argument and "
@@ -285,7 +285,7 @@ class InferenceData:
             warnings.warn(
                 "warmup has been deprecated. Use groups argument and "
                 "rcParams['data.metagroups'] instead.",
-                DeprecationWarning
+                DeprecationWarning,
             )
         if groups is None:
             groups = self._groups.copy()
@@ -308,7 +308,6 @@ class InferenceData:
             return None
         else:
             return out
-
 
     def map(self, fun, groups=None, inplace=False, **kwargs):
         """Apply a function to multiple groups.
@@ -364,7 +363,6 @@ class InferenceData:
             return None
         else:
             return out
-
 
     def _wrap_xarray_method(self, method, groups=None, inplace=False, **kwargs):
         """Extend and xarray.Dataset method to InferenceData object.

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -217,7 +217,7 @@ class InferenceData:
         """Concatenate two InferenceData objects."""
         return concat(self, other, copy=True, inplace=False)
 
-    def sel(self, groups=None, inplace=False, chain_prior=None, warmup=None, **kwargs):
+    def sel(self, groups=None, filter_groups=None, inplace=False, chain_prior=None, warmup=None, **kwargs):
         """Perform an xarray selection on all groups.
 
         Loops groups to perform Dataset.sel(key=item)
@@ -273,7 +273,6 @@ class InferenceData:
                ...: print(idata_subset.observed_data.coords)
 
         """
-        # TODO: use wrap_xarray_method
         if chain_prior is not None:
             warnings.warn(
                 "chain_prior has been deprecated. Use groups argument and "
@@ -288,6 +287,7 @@ class InferenceData:
                 "rcParams['data.metagroups'] instead.",
                 DeprecationWarning,
             )
+        #TODO: use self._group_names after deprecating warmup and chain_prior
         if groups is None:
             groups = self._groups.copy()
         if warmup:

--- a/arviz/rcparams.py
+++ b/arviz/rcparams.py
@@ -482,9 +482,11 @@ def read_rcfile(fname):
         return config
 
 
-def rc_params():
+def rc_params(ignore_files=False):
     """Read and validate arvizrc file."""
-    fname = get_arviz_rcfile()
+    fname = None
+    if not ignore_files:
+        fname = get_arviz_rcfile()
     defaults = RcParams([(key, default) for key, (default, _) in defaultParams.items()])
     if fname is not None:
         file_defaults = read_rcfile(fname)

--- a/arviz/rcparams.py
+++ b/arviz/rcparams.py
@@ -165,6 +165,7 @@ def _validate_bokeh_marker(value):
         raise ValueError("{} is not one of {}".format(value, all_markers))
     return value
 
+
 def _validate_dict_of_lists(values):
     if isinstance(values, dict):
         return {key: tuple(item) for key, item in values.items()}
@@ -175,8 +176,8 @@ def _validate_dict_of_lists(values):
             if len(tup) != 2:
                 raise ValueError(f"Could not interpret '{value}' as key: list or str")
             key, vals = tup
-            key = key.strip(" \"")
-            vals = [val.strip(" \"") for val in vals.strip(" [],").split(",")]
+            key = key.strip(' "')
+            vals = [val.strip(' "') for val in vals.strip(" [],").split(",")]
             if key in validated_dict:
                 warnings.warn(f"Repeated key {key} when validating dict of lists")
             validated_dict[key] = tuple(vals)
@@ -211,10 +212,13 @@ _validate_bokeh_bounds = make_iterable_validator(  # pylint: disable=invalid-nam
 METAGROUPS = {
     "posterior_groups": ["posterior", "posterior_predictive", "sample_stats"],
     "prior_groups": ["prior", "prior_predictive", "sample_stats_prior"],
-    "posterior_groups_warmup":
-        ["_warmup_posterior", "_warmup_posterior_predictive", "_warmup_sample_stats"],
+    "posterior_groups_warmup": [
+        "_warmup_posterior",
+        "_warmup_posterior_predictive",
+        "_warmup_sample_stats",
+    ],
     "latent_vars_groups": ["posterior", "prior"],
-    "observed__vars_groups": ["posterior_predictive", "obseved_data", "prior_predictive"]
+    "observed__vars_groups": ["posterior_predictive", "obseved_data", "prior_predictive"],
 }
 
 defaultParams = {  # pylint: disable=invalid-name

--- a/arviz/rcparams.py
+++ b/arviz/rcparams.py
@@ -210,15 +210,15 @@ _validate_bokeh_bounds = make_iterable_validator(  # pylint: disable=invalid-nam
 )
 
 METAGROUPS = {
-    "posterior_groups": ["posterior", "posterior_predictive", "sample_stats"],
+    "posterior_groups": ["posterior", "posterior_predictive", "sample_stats", "log_likelihood"],
     "prior_groups": ["prior", "prior_predictive", "sample_stats_prior"],
     "posterior_groups_warmup": [
         "_warmup_posterior",
         "_warmup_posterior_predictive",
         "_warmup_sample_stats",
     ],
-    "latent_vars_groups": ["posterior", "prior"],
-    "observed__vars_groups": ["posterior_predictive", "obseved_data", "prior_predictive"],
+    "latent_vars": ["posterior", "prior"],
+    "observed_vars": ["posterior_predictive", "observed_data", "prior_predictive"],
 }
 
 defaultParams = {  # pylint: disable=invalid-name

--- a/arviz/tests/base_tests/test_rcparams.py
+++ b/arviz/tests/base_tests/test_rcparams.py
@@ -8,6 +8,7 @@ from xarray.core.indexing import MemoryCachedArray
 from ...data import load_arviz_data, datasets
 from ...stats import compare
 from ...rcparams import (
+    rc_params,
     rcParams,
     rc_context,
     _make_validate_choice,
@@ -18,6 +19,7 @@ from ...rcparams import (
     _validate_probability,
     read_rcfile,
 )
+
 
 from ..helpers import models  # pylint: disable=unused-import
 
@@ -108,8 +110,13 @@ def test_rcparams_repr_str():
 def test_rctemplate_updated():
     fname = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../../arvizrc.template")
     rc_pars_template = read_rcfile(fname)
-    assert all([key in rc_pars_template.keys() for key in rcParams.keys()])
-    assert all([value == rc_pars_template[key] for key, value in rcParams.items()])
+    rc_defaults = rc_params(ignore_files=True)
+    assert all([key in rc_pars_template.keys() for key in rc_defaults.keys()]), [
+        key for key in rc_defaults.keys() if key not in rc_pars_template
+    ]
+    assert all([value == rc_pars_template[key] for key, value in rc_defaults.items()]), [
+        key for key, value in rc_defaults.items() if value != rc_pars_template[key]
+    ]
 
 
 ### Test validation functions ###

--- a/arviz/tests/base_tests/test_utils.py
+++ b/arviz/tests/base_tests/test_utils.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 from arviz.data.base import dict_to_dataset
-from ...utils import _var_names, _stack, one_de, two_de, expand_dims, flatten_inference_data_to_dict
+from ...utils import _var_names, _stack, one_de, two_de, expand_dims, flatten_inference_data_to_dict, _subset_list
 from ...data import load_arviz_data, from_dict
 
 
@@ -91,6 +91,13 @@ def test_var_names_filter(var_args):
     )
     var_names, expected, filter_vars = var_args
     assert _var_names(var_names, data, filter_vars) == expected
+
+
+def test_subset_list_negation_not_found():
+    """Check there is a warning if negation pattern is ignored"""
+    names = ["mu", "theta"]
+    with pytest.warns(UserWarning, match=".+not.+found.+"):
+        assert _subset_list("~tau", names) == names
 
 
 @pytest.fixture(scope="function")

--- a/arviz/tests/base_tests/test_utils.py
+++ b/arviz/tests/base_tests/test_utils.py
@@ -7,7 +7,15 @@ import numpy as np
 import pytest
 
 from arviz.data.base import dict_to_dataset
-from ...utils import _var_names, _stack, one_de, two_de, expand_dims, flatten_inference_data_to_dict, _subset_list
+from ...utils import (
+    _var_names,
+    _stack,
+    one_de,
+    two_de,
+    expand_dims,
+    flatten_inference_data_to_dict,
+    _subset_list,
+)
 from ...data import load_arviz_data, from_dict
 
 

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -18,7 +18,7 @@ def _var_names(var_names, data, filter_vars=None):
     Parameters
     ----------
     var_names: str, list, or None
-    data: xarray.Dataset
+    data : xarray.Dataset
         Posterior data in an xarray
     filter_vars: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
@@ -64,11 +64,11 @@ def _subset_list(subset, whole_list, filter_items=None, warn=True):
 
     Parameters
     ----------
-    subset: str, list, or None
-    whole_list: list
+    subset : str, list, or None
+    whole_list : list
         List from which to select a subset according to subset elements and
         filter_items value.
-    filter_items: {None, "like", "regex"}, optional
+    filter_items : {None, "like", "regex"}, optional
         If `None` (default), interpret `subset` as the exact elements in `whole_list`
         names. If "like", interpret `subset` as substrings of the elements in
         `whole_list`. If "regex", interpret `subset` as regular expressions to match
@@ -76,7 +76,9 @@ def _subset_list(subset, whole_list, filter_items=None, warn=True):
 
     Returns
     -------
-    subset: list or None
+    list or None
+        A subset of ``whole_list`` fulfilling the requests imposed by ``subset``
+        and ``filter_items``.
     """
     if subset is not None:
 

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -99,6 +99,7 @@ def _subset_list(subset, whole_list, filter_items=None, warn=True):
             item[1:] for item in subset if item.startswith("~") and item not in whole_list
         ]
         filter_items = str(filter_items).lower()
+        not_found = []
 
         if excluded_items:
             if filter_items in ("like", "regex"):
@@ -111,7 +112,14 @@ def _subset_list(subset, whole_list, filter_items=None, warn=True):
                         real_items = [
                             real_item for real_item in whole_list if re.search(pattern, real_item)
                         ]
+                    if not real_items:
+                        not_found.append(pattern)
                     excluded_items.extend(real_items)
+            not_found.extend([item for item in excluded_items if item not in whole_list])
+            if not_found:
+                warnings.warn(
+                    f"Items starting with ~: {not_found} have not been found and will be ignored"
+                )
             subset = [item for item in whole_list if item not in excluded_items]
 
         else:

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -18,7 +18,7 @@ def _var_names(var_names, data, filter_vars=None):
     Parameters
     ----------
     var_names: str, list, or None
-    data : xarray.Dataset
+    data: xarray.Dataset
         Posterior data in an xarray
     filter_vars: {None, "like", "regex"}, optional, default=None
         If `None` (default), interpret var_names as the real variables names. If "like",
@@ -31,10 +31,6 @@ def _var_names(var_names, data, filter_vars=None):
     var_name: list or None
     """
     if var_names is not None:
-
-        if isinstance(var_names, str):
-            var_names = [var_names]
-
         if isinstance(data, (list, tuple)):
             all_vars = []
             for dataset in data:
@@ -55,40 +51,78 @@ def _var_names(var_names, data, filter_vars=None):
                 )
             )
 
-        excluded_vars = [
-            var[1:] for var in var_names if var.startswith("~") and var not in all_vars
-        ]
-        filter_vars = str(filter_vars).lower()
+        try:
+            var_names = _subset_list(var_names, all_vars, filter_items=filter_vars, warn=False)
+        except KeyError as err:
+            msg = " ".join(("var names:", f"{err}", "in dataset"))
+            raise KeyError(msg)
+    return var_names
 
-        if excluded_vars:
-            if filter_vars in ("like", "regex"):
-                for pattern in excluded_vars[:]:
-                    excluded_vars.remove(pattern)
-                    if filter_vars == "like":
-                        real_vars = [real_var for real_var in all_vars if pattern in real_var]
-                    else:
-                        # i.e filter_vars == "regex"
-                        real_vars = [
-                            real_var for real_var in all_vars if re.search(pattern, real_var)
-                        ]
-                    excluded_vars.extend(real_vars)
-            var_names = [var for var in all_vars if var not in excluded_vars]
 
-        else:
-            if filter_vars == "like":
-                var_names = [var for var in all_vars for name in var_names if name in var]
-            elif filter_vars == "regex":
-                var_names = [var for var in all_vars for name in var_names if re.search(name, var)]
+def _subset_list(subset, whole_list, filter_items=None, warn=True):
+    """Handle list subsetting (var_names, groups...) across arviz.
 
-        existing_vars = np.isin(var_names, all_vars)
-        if not np.all(existing_vars):
-            raise KeyError(
-                "{} var names are not present in dataset".format(
-                    np.array(var_names)[~existing_vars]
+    Parameters
+    ----------
+    subset: str, list, or None
+    whole_list: list
+        List from which to select a subset according to subset elements and
+        filter_items value.
+    filter_items: {None, "like", "regex"}, optional
+        If `None` (default), interpret `subset` as the exact elements in `whole_list`
+        names. If "like", interpret `subset` as substrings of the elements in
+        `whole_list`. If "regex", interpret `subset` as regular expressions to match
+        elements in `whole_list`. A la `pandas.filter`.
+
+    Returns
+    -------
+    subset: list or None
+    """
+    if subset is not None:
+
+        if isinstance(subset, str):
+            subset = [subset]
+
+        whole_list_tilde = [item for item in whole_list if item.startswith("~")]
+        if whole_list_tilde and warn:
+            warnings.warn(
+                "ArviZ treats '~' as a negation character for selection. There are "
+                "elements in `whole_list` starting with '~', {0}. Please double check"
+                "your results to ensure all elements are included".format(
+                    ", ".join(whole_list_tilde)
                 )
             )
 
-    return var_names
+        excluded_items = [
+            item[1:] for item in subset if item.startswith("~") and item not in whole_list
+        ]
+        filter_items = str(filter_items).lower()
+
+        if excluded_items:
+            if filter_items in ("like", "regex"):
+                for pattern in excluded_items[:]:
+                    excluded_items.remove(pattern)
+                    if filter_items == "like":
+                        real_items = [real_item for real_item in whole_list if pattern in real_item]
+                    else:
+                        # i.e filter_items == "regex"
+                        real_items = [
+                            real_item for real_item in whole_list if re.search(pattern, real_item)
+                        ]
+                    excluded_items.extend(real_items)
+            subset = [item for item in whole_list if item not in excluded_items]
+
+        else:
+            if filter_items == "like":
+                subset = [item for item in whole_list for name in subset if name in item]
+            elif filter_items == "regex":
+                subset = [item for item in whole_list for name in subset if re.search(name, item)]
+
+        existing_items = np.isin(subset, whole_list)
+        if not np.all(existing_items):
+            raise KeyError("{} are not present".format(np.array(subset)[~existing_items]))
+
+    return subset
 
 
 class lazy_property:  # pylint: disable=invalid-name

--- a/arvizrc.template
+++ b/arvizrc.template
@@ -7,6 +7,13 @@ data.index_origin            : 0     # index origin, must be either 0 or 1
 data.load                    : lazy  # Sets the default data loading mode.
                                      # "lazy" stands for xarray lazy loading,
                                      # "eager" loads all datasets into memory
+data.metagroups              : {
+    "posterior_groups": ["posterior", "posterior_predictive", "sample_stats"],
+    "prior_groups": ["prior", "prior_predictive", "sample_stats_prior"],
+    "posterior_groups_warmup": ["_warmup_posterior", "_warmup_posterior_predictive", "_warmup_sample_stats"],
+    "latent_vars_groups": ["posterior", "prior"],
+    "observed__vars_groups": ["posterior_predictive", "obseved_data", "prior_predictive"]
+}
 data.save_warmup             : false # save warmup iterations, one of "true", "false"
 
 ### PLOT  ###

--- a/arvizrc.template
+++ b/arvizrc.template
@@ -8,11 +8,11 @@ data.load                    : lazy  # Sets the default data loading mode.
                                      # "lazy" stands for xarray lazy loading,
                                      # "eager" loads all datasets into memory
 data.metagroups              : {
-    posterior_groups: posterior, posterior_predictive, sample_stats
+    posterior_groups: posterior, posterior_predictive, sample_stats, log_likelihood
     prior_groups: prior, prior_predictive, sample_stats_prior
     posterior_groups_warmup: _warmup_posterior, _warmup_posterior_predictive, _warmup_sample_stats
-    latent_vars_groups: posterior, prior
-    observed_vars_groups: posterior_predictive, observed_data, prior_predictive
+    latent_vars: posterior, prior
+    observed_vars: posterior_predictive, observed_data, prior_predictive
 }
 data.save_warmup             : false # save warmup iterations, one of "true", "false"
 

--- a/arvizrc.template
+++ b/arvizrc.template
@@ -8,11 +8,11 @@ data.load                    : lazy  # Sets the default data loading mode.
                                      # "lazy" stands for xarray lazy loading,
                                      # "eager" loads all datasets into memory
 data.metagroups              : {
-    "posterior_groups": ["posterior", "posterior_predictive", "sample_stats"],
-    "prior_groups": ["prior", "prior_predictive", "sample_stats_prior"],
-    "posterior_groups_warmup": ["_warmup_posterior", "_warmup_posterior_predictive", "_warmup_sample_stats"],
-    "latent_vars_groups": ["posterior", "prior"],
-    "observed__vars_groups": ["posterior_predictive", "obseved_data", "prior_predictive"]
+    posterior_groups: posterior, posterior_predictive, sample_stats
+    prior_groups: prior, prior_predictive, sample_stats_prior
+    posterior_groups_warmup: _warmup_posterior, _warmup_posterior_predictive, _warmup_sample_stats
+    latent_vars_groups: posterior, prior
+    observed__vars_groups: posterior_predictive, obseved_data, prior_predictive
 }
 data.save_warmup             : false # save warmup iterations, one of "true", "false"
 

--- a/arvizrc.template
+++ b/arvizrc.template
@@ -12,7 +12,7 @@ data.metagroups              : {
     prior_groups: prior, prior_predictive, sample_stats_prior
     posterior_groups_warmup: _warmup_posterior, _warmup_posterior_predictive, _warmup_sample_stats
     latent_vars_groups: posterior, prior
-    observed_vars_groups: posterior_predictive, obseved_data, prior_predictive
+    observed_vars_groups: posterior_predictive, observed_data, prior_predictive
 }
 data.save_warmup             : false # save warmup iterations, one of "true", "false"
 

--- a/arvizrc.template
+++ b/arvizrc.template
@@ -12,7 +12,7 @@ data.metagroups              : {
     prior_groups: prior, prior_predictive, sample_stats_prior
     posterior_groups_warmup: _warmup_posterior, _warmup_posterior_predictive, _warmup_sample_stats
     latent_vars_groups: posterior, prior
-    observed__vars_groups: posterior_predictive, obseved_data, prior_predictive
+    observed_vars_groups: posterior_predictive, obseved_data, prior_predictive
 }
 data.save_warmup             : false # save warmup iterations, one of "true", "false"
 


### PR DESCRIPTION
## Description
Add metagroups rcParam (very open to better names!). The idea is to have a dictionary storing customizable aliases for lists of groups. This does not have many uses right now, but I think it will be really helpful to have once we start adding more methods to inference data objects. 

Unless there are some objections, I plan to update `InferenceData.sel()` and `to_cds` to use these metagroups.

Related to #1066 

# PR description
This PR proposes some new features, all of them trying to make inferencedata objects more usable and closely related. 

## `InferenceData.map()`
Applies any function to multiple groups in the inference data object.

## `InferenceData._wrap_xarray_method()`
Applies an `xarray.Dataset` method to multiple groups in the inference data. This had the long term idea in mind to define methods like `load` or `mean` directly as attributes of inferencedata objects. I think we should carefully think which methods to add. I think that `map` is much more flexible, and having some methods like `assign` as inferencedata methods directly may end up being frustrating for new users. To put one example using assign for instance, you may want to define a new variable in several groups, based on other variables in the group (i.e. you forgot to define a Deterministic in pymc3), this cannot be achieved with `idata.assign` but can easily be done with `idata.map(lambda ds: ds.assign(new_var=ds.var1+3*ds.var2))`. 

## Metagroups
Metagroups allow users to define custom aliases for combinations of groups (to_cds uses aliases to refer to combinations of groups already). 

_Disclaimer:_ right now I have added several combinations as rcParams to make sure the new validator and so on worked, some metagroups (like the ones used in to_cds) should probably be fixed so users cannot remove them and break functions like `to_cds`.

## Examples using the rugby dataset
To showcase the new capabilities, I have played around with the rugby dataset, setting as fake goal making posterior predictive plots for "Wales" matches only. The first step is to cast results to int, not sure why but they are floats originally, then split the match info into home and away team and finally plot using `map` to select with a condition.

<details><summary>See example</summary>

```
import arviz as az
import numpy as np
az.style.use("arviz-darkgrid")

idata = az.load_arviz_data("rugby")._wrap_xarray_method(
    "astype",
    groups="observed_vars",
    args=[int]
)

home_team, away_team = np.array([m.split() for m in idata.observed_data.match.values]).T
idata = idata._wrap_xarray_method(
    "assign_coords",
    groups="observed_vars",  # metagroup
    home_team=("match", home_team),
    away_team=("match", away_team),
)
idata.observed_data
```

Output

```
<xarray.Dataset>
Dimensions:      (match: 60)
Coordinates:
  * match        (match) object 'Wales Italy' ... 'Ireland England'
    home_team    (match) <U8 'Wales' 'France' 'Ireland' ... 'France' 'Ireland'
    away_team    (match) <U8 'Italy' 'England' 'Scotland' ... 'Wales' 'England'
Data variables:
    home_points  (match) int64 23 26 28 26 0 30 27 20 ... 36 22 18 61 29 20 13
    away_points  (match) int64 15 24 6 3 20 10 6 21 10 ... 9 15 9 40 21 0 18 9

```

Plots

```
az.plot_ppc(
    idata.map(
        lambda ds: ds.where(
            (ds.home_team == "Wales") | (ds.away_team == "Wales"), drop=True
        ).astype(int),
        groups="observed_vars",
    ),
    show=True,
)
```

The weird "Wales" subset defined looks like:

![image](https://user-images.githubusercontent.com/23738400/80977205-b1223f80-8e24-11ea-9638-a1faa68d53ee.png)

As opposed to the `plot_ppc` with all matches.

```
az.plot_ppc(idata, show=True)
```

![image](https://user-images.githubusercontent.com/23738400/80977348-e4fd6500-8e24-11ea-9152-635cd7e4a364.png)


</details>

## Example on radon dataset
Rename coordinate names and variables after inferencedata creation.

<details><summary>See example</summary>

```
import arviz as az

idata = az.load_arviz_data("radon")
idata = idata.map(
    lambda ds: ds.rename({"gamma_dim_0": "uranium_coefs"}).assign(
        uranium_coefs=["intercept", "u_slope", "xbar_slope"]
    ),
    groups=["posterior", "prior"]
)
idata.posterior
```

Output

```
<xarray.Dataset>
Dimensions:          (chain: 4, county: 85, draw: 500, observed_county: 919, uranium_coefs: 3)
Coordinates:
  * chain            (chain) int64 0 1 2 3
  * draw             (draw) int64 0 1 2 3 4 5 6 ... 493 494 495 496 497 498 499
  * uranium_coefs    (uranium_coefs) <U10 'intercept' 'u_slope' 'xbar_slope'
  * county           (county) object 'AITKIN' 'ANOKA' ... 'YELLOW MEDICINE'
  * observed_county  (observed_county) object 'AITKIN' ... 'YELLOW MEDICINE'
Data variables:
    gamma            (chain, draw, uranium_coefs) float64 ...
    eps_a            (chain, draw, county) float64 ...
    b                (chain, draw) float64 ...
    sigma_a          (chain, draw) float64 ...
    mu_a             (chain, draw, observed_county) float64 ...
    a                (chain, draw, observed_county) float64 ...
    sigma_y          (chain, draw) float64 ...
Attributes:
    created_at:                 2018-10-05T15:29:14.514378
    inference_library:          pymc3
    inference_library_version:  3.5

```

</details>


## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] New features are properly documented (with an example if appropriate)?
- [ ] Includes new or updated tests to cover the new feature
- [ ] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/master/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
