### PR TITLE
fix bug in io_pymc3 and add warning for PyMC3<3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 ### Maintenance and fixes
+* fix bug in `from_pymc3` when used with PyMC3<3.9 (#1203)
 
 ### Deprecation
 

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -105,7 +105,13 @@ class PyMC3Converter:  # pylint: disable=too-many-instance-attributes
                     "tuning_steps": trace.report.n_tune,
                 }
             else:
-                self.nchains = len(trace)
+                self.ndraws = len(trace)
+                if self.save_warmup:
+                    warnings.warn(
+                        "Warmup samples will be stored in posterior group and will not be"
+                        " excluded from stats and diagnostics. Please consider using PyMC3>=3.9",
+                        UserWarning,
+                    )
         else:
             self.nchains = self.ndraws = 0
 


### PR DESCRIPTION
## Description
bugfix for io_pymc3, there was one self.nchains that should have been self.ndraws. Fixes #1202 

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/master/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
