### PR TITLE
fixes to matplotlib subplot handling

### DIFF
--- a/arviz/plots/backends/matplotlib/pairplot.py
+++ b/arviz/plots/backends/matplotlib/pairplot.py
@@ -226,18 +226,13 @@ def plot_pair(
         point_estimate_marker_kwargs.setdefault("s", markersize + 50)
 
         if ax is None:
-            fig, ax = plt.subplots(
-                vars_to_plot,
-                vars_to_plot,
-                figsize=figsize,
-                **backend_kwargs,
-            )
+            fig, ax = plt.subplots(vars_to_plot, vars_to_plot, figsize=figsize, **backend_kwargs,)
         hexbin_values = []
         for i in range(0, vars_to_plot):
             var1 = infdata_group[i]
 
             for j in range(0, vars_to_plot):
-                var2 = infdata_group[j+not_marginals]
+                var2 = infdata_group[j + not_marginals]
                 if i > j:
                     if ax[j, i].get_figure() is not None:
                         ax[j, i].remove()
@@ -294,7 +289,7 @@ def plot_pair(
 
                     if reference_values:
                         x_name = flat_var_names[i]
-                        y_name = flat_var_names[j+not_marginals]
+                        y_name = flat_var_names[j + not_marginals]
                         if x_name and y_name not in difference:
                             ax[j, i].plot(
                                 reference_values_copy[x_name],
@@ -312,7 +307,9 @@ def plot_pair(
                     ax[j, i].axes.get_yaxis().set_major_formatter(NullFormatter())
                 else:
                     ax[j, i].set_ylabel(
-                        "{}".format(flat_var_names[j+not_marginals]), fontsize=ax_labelsize, wrap=True
+                        "{}".format(flat_var_names[j + not_marginals]),
+                        fontsize=ax_labelsize,
+                        wrap=True,
                     )
                 ax[j, i].tick_params(labelsize=xt_labelsize)
 

--- a/arviz/plots/backends/matplotlib/pairplot.py
+++ b/arviz/plots/backends/matplotlib/pairplot.py
@@ -216,7 +216,7 @@ def plot_pair(
                 "{side}x{side} grid".format(max_plots=max_plots, side=cols_to_plot),
                 UserWarning,
             )
-            numvars = cols_to_plot - 1
+            numvars = cols_to_plot - marginals
         vars_to_plot = numvars - not_marginals
 
         (figsize, ax_labelsize, _, xt_labelsize, _, markersize) = _scale_fig_size(

--- a/arviz/plots/backends/matplotlib/pairplot.py
+++ b/arviz/plots/backends/matplotlib/pairplot.py
@@ -206,16 +206,17 @@ def plot_pair(
             if rcParams["plot.max_subplots"] is None
             else rcParams["plot.max_subplots"]
         )
-        cols_to_plot = np.sum(np.arange(num_subplot_cols).cumsum() <= max_plots)
+        cols_to_plot = np.sum(np.arange(1, num_subplot_cols+1).cumsum() <= max_plots)
         if cols_to_plot < num_subplot_cols:
+            vars_to_plot = cols_to_plot
             warnings.warn(
                 "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "
                 "of resulting pair plots with these variables, generating only a "
-                "{side}x{side} grid".format(max_plots=max_plots, side=cols_to_plot),
+                "{side}x{side} grid".format(max_plots=max_plots, side=vars_to_plot),
                 UserWarning,
             )
-            numvars = cols_to_plot - marginals
-        vars_to_plot = numvars - not_marginals
+        else:
+            vars_to_plot = numvars - not_marginals
 
         (figsize, ax_labelsize, _, xt_labelsize, _, markersize) = _scale_fig_size(
             figsize, textsize, vars_to_plot, vars_to_plot

--- a/arviz/plots/backends/matplotlib/pairplot.py
+++ b/arviz/plots/backends/matplotlib/pairplot.py
@@ -207,8 +207,6 @@ def plot_pair(
             else rcParams["plot.max_subplots"]
         )
         cols_to_plot = np.sum(np.arange(num_subplot_cols).cumsum() <= max_plots)
-        print(marginals)
-        print(cols_to_plot)
         if cols_to_plot < num_subplot_cols:
             warnings.warn(
                 "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "

--- a/arviz/plots/backends/matplotlib/pairplot.py
+++ b/arviz/plots/backends/matplotlib/pairplot.py
@@ -206,7 +206,7 @@ def plot_pair(
             if rcParams["plot.max_subplots"] is None
             else rcParams["plot.max_subplots"]
         )
-        cols_to_plot = np.sum(np.arange(1, num_subplot_cols+1).cumsum() <= max_plots)
+        cols_to_plot = np.sum(np.arange(1, num_subplot_cols + 1).cumsum() <= max_plots)
         if cols_to_plot < num_subplot_cols:
             vars_to_plot = cols_to_plot
             warnings.warn(

--- a/arviz/plots/traceplot.py
+++ b/arviz/plots/traceplot.py
@@ -230,7 +230,7 @@ def plot_trace(
 
     plotters = list(xarray_var_iter(data, var_names=var_names, combined=True, skip_dims=skip_dims))
     max_plots = rcParams["plot.max_subplots"]
-    max_plots = len(plotters) if max_plots is None else max_plots
+    max_plots = len(plotters) if max_plots is None else max(max_plots // 2, 1)
     if len(plotters) > max_plots:
         warnings.warn(
             "rcParams['plot.max_subplots'] ({max_plots}) is smaller than the number "

--- a/arviz/tests/base_tests/test_plots_bokeh.py
+++ b/arviz/tests/base_tests/test_plots_bokeh.py
@@ -149,7 +149,7 @@ def test_plot_trace_discrete(discrete_model):
 
 def test_plot_trace_max_subplots_warning(models):
     with pytest.warns(UserWarning):
-        with rc_context(rc={"plot.max_subplots": 1}):
+        with rc_context(rc={"plot.max_subplots": 2}):
             axes = plot_trace(models.model_1, backend="bokeh", show=False)
     assert axes.shape
 

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -479,11 +479,17 @@ def test_plot_pair_overlaid(models, kwargs):
 
 
 @pytest.mark.parametrize("marginals", [True, False])
-def test_plot_pair_shapes(marginals):
+@pytest.mark.parametrize("max_subplots", [True, False])
+def test_plot_pair_shapes(marginals, max_subplots):
     rng = np.random.default_rng()
-    idata = from_dict({"a": rng.standard_normal((4, 500, 3))})
-    ax = plot_pair(idata, marginals=marginals)
-    side = 2 + marginals
+    idata = from_dict({"a": rng.standard_normal((4, 500, 5))})
+    if max_subplots:
+        with rc_context({"plot.max_subplots": 6}):
+            with pytest.warns(UserWarning, match="3x3 grid"):
+                ax = plot_pair(idata, marginals=marginals)
+    else:
+        ax = plot_pair(idata, marginals=marginals)
+    side = 3 if max_subplots else (4 + marginals)
     assert ax.shape == (side, side)
 
 

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -477,6 +477,7 @@ def test_plot_pair_overlaid(models, kwargs):
     assert ax is ax2
     assert ax.shape
 
+
 @pytest.mark.parametrize("marginals", [True, False])
 def test_plot_pair_shapes(marginals):
     rng = np.random.default_rng()

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -188,9 +188,9 @@ def test_plot_trace_discrete(discrete_model):
 
 def test_plot_trace_max_subplots_warning(models):
     with pytest.warns(UserWarning):
-        with rc_context(rc={"plot.max_subplots": 1}):
+        with rc_context(rc={"plot.max_subplots": 6}):
             axes = plot_trace(models.model_1)
-    assert axes.shape
+    assert axes.shape == (3, 2)
 
 
 @pytest.mark.parametrize("kwargs", [{"var_names": ["mu", "tau"], "lines": [("hey", {}, [1])]}])
@@ -476,6 +476,14 @@ def test_plot_pair_overlaid(models, kwargs):
     ax2 = plot_pair(models.model_2, ax=ax, **kwargs)
     assert ax is ax2
     assert ax.shape
+
+@pytest.mark.parametrize("marginals", [True, False])
+def test_plot_pair_shapes(marginals):
+    rng = np.random.default_rng()
+    idata = from_dict({"a": rng.standard_normal((4, 500, 3))})
+    ax = plot_pair(idata, marginals=marginals)
+    side = 2 + marginals
+    assert ax.shape == (side, side)
 
 
 @pytest.mark.parametrize("kind", ["kde", "cumulative", "scatter"])


### PR DESCRIPTION
## Description
Minor changes to matplotlib subplot handling in `plot_trace` and `plot_pair`. 

In `plot_trace` `plot.max_subplots` used to be checked on the number of rows in plot trace, this PR fixes it to check the actual number of subplots. 

I also checked the behaviour in plot_pair to check that it takes into account the actual number of _used_ subplots with or without marginals. I have also modified axes creation to avoid having extra blank spaces at the top and right of with `marginals=False` (see https://arviz-devs.github.io/arviz/examples/matplotlib/mpl_plot_pair.html for example)

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)

