### PR TITLE
Deal with PyMC3 traces that do not contain n_draws information in the sampler report

### DIFF
--- a/arviz/__init__.py
+++ b/arviz/__init__.py
@@ -1,6 +1,6 @@
 # pylint: disable=wildcard-import,invalid-name,wrong-import-position
 """ArviZ is a library for exploratory analysis of Bayesian models."""
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 
 import os
 import logging

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -98,7 +98,7 @@ class PyMC3Converter:  # pylint: disable=too-many-instance-attributes
                     0
                 ].model
             self.nchains = trace.nchains if hasattr(trace, "nchains") else 1
-            if hasattr(trace.report, "n_tune"):
+            if hasattr(trace.report, "n_draws") and trace.report.n_draws is not None:
                 self.ndraws = trace.report.n_draws
                 self.attrs = {
                     "sampling_time": trace.report.t_sampling,
@@ -109,7 +109,8 @@ class PyMC3Converter:  # pylint: disable=too-many-instance-attributes
                 if self.save_warmup:
                     warnings.warn(
                         "Warmup samples will be stored in posterior group and will not be"
-                        " excluded from stats and diagnostics. Please consider using PyMC3>=3.9",
+                        " excluded from stats and diagnostics."
+                        " Please consider using PyMC3>=3.9 and do not slice the trace manually.",
                         UserWarning,
                     )
         else:

--- a/arviz/tests/external_tests/test_data_pymc.py
+++ b/arviz/tests/external_tests/test_data_pymc.py
@@ -1,7 +1,6 @@
 # pylint: disable=no-member, invalid-name, redefined-outer-name
 from sys import version_info
 from typing import Dict, Tuple
-import packaging
 
 import numpy as np
 import pytest
@@ -399,6 +398,8 @@ class TestDataPyMC3:
         fails = check_multiple_attrs(test_dict, inference_data)
         assert not fails
 
+
+class TestPyMC3WarmupHandling:
     @pytest.mark.skipif(
         not hasattr(pm.backends.base.SamplerReport, 'n_draws'),
         reason="requires pymc3 3.9 or higher",

--- a/arviz/tests/external_tests/test_data_pymc.py
+++ b/arviz/tests/external_tests/test_data_pymc.py
@@ -456,7 +456,7 @@ class TestPyMC3WarmupHandling:
 
             # <=3.8 did not track n_draws in the sampler report,
             # making from_pymc3 fall back to len(trace) and triggering a warning
-            with pytest.warns(UserWarning):
+            with pytest.warns(UserWarning, match="Warmup samples"):
                 idata = from_pymc3(trace, save_warmup=True)
             assert idata.posterior.dims["draw"] == 300
             assert idata.posterior.dims["chain"] == 2
@@ -486,7 +486,7 @@ class TestPyMC3WarmupHandling:
             assert idata.posterior.dims["draw"] == 200
 
             # manually sliced trace triggers the same warning as <=3.8
-            with pytest.warns(UserWarning):
+            with pytest.warns(UserWarning, match="Warmup samples"):
                 idata = from_pymc3(trace[-30:], save_warmup=True)
             assert idata.posterior.dims["chain"] == 2
             assert idata.posterior.dims["draw"] == 30

--- a/arviz/tests/external_tests/test_data_pymc.py
+++ b/arviz/tests/external_tests/test_data_pymc.py
@@ -401,7 +401,7 @@ class TestDataPyMC3:
 
 class TestPyMC3WarmupHandling:
     @pytest.mark.skipif(
-        not hasattr(pm.backends.base.SamplerReport, 'n_draws'),
+        not hasattr(pm.backends.base.SamplerReport, "n_draws"),
         reason="requires pymc3 3.9 or higher",
     )
     @pytest.mark.parametrize("save_warmup", [False, True])
@@ -437,8 +437,7 @@ class TestPyMC3WarmupHandling:
             assert idata.warmup_posterior.dims["draw"] == 100
 
     @pytest.mark.skipif(
-        hasattr(pm.backends.base.SamplerReport, 'n_draws'),
-        reason="requires pymc3 3.8 or lower",
+        hasattr(pm.backends.base.SamplerReport, "n_draws"), reason="requires pymc3 3.8 or lower",
     )
     def test_save_warmup_issue_1208_before_3_9(self):
         with pm.Model():
@@ -463,7 +462,7 @@ class TestPyMC3WarmupHandling:
             assert idata.posterior.dims["chain"] == 2
 
     @pytest.mark.skipif(
-        not hasattr(pm.backends.base.SamplerReport, 'n_draws'),
+        not hasattr(pm.backends.base.SamplerReport, "n_draws"),
         reason="requires pymc3 3.9 or higher",
     )
     def test_save_warmup_issue_1208_after_3_9(self):


### PR DESCRIPTION
## Description
This is a hotfix for #1208 

In short: When traces are sliced manually, the `n_draws` information is lost. With the latest arviz version, this breaks some PyMC3 tests and potentially user workflows.

These changes modify how `n_draws` is checked such that it falls back to the previous behavior when `n_draws` is unavailable.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)