### PR TITLE
Support pymc3 traces with no draws or no tuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@
 
 ### Documentation
 
+## v0.8.3 (2020 May 28)
+### Maintenance and fixes
+* Restructured internals of `from_pymc3` to handle old pymc3 releases and
+  sliced traces and to provide useful warnings (#1211)
+
+## v0.8.2 (2020 May 25)
+### Maintenance and fixes
+* Fixed bug in `from_pymc3` for sliced `pymc3.MultiTrace` input (#1209)
+
 ## v0.8.1 (2020 May 24)
 
 ### Maintenance and fixes

--- a/arviz/__init__.py
+++ b/arviz/__init__.py
@@ -1,6 +1,6 @@
 # pylint: disable=wildcard-import,invalid-name,wrong-import-position
 """ArviZ is a library for exploratory analysis of Bayesian models."""
-__version__ = "0.8.2"
+__version__ = "0.8.3"
 
 import os
 import logging

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -211,10 +211,10 @@ class PyMC3Converter:  # pylint: disable=too-many-instance-attributes
             n_tune = len(self.trace) - self.ndraws
             if self.save_warmup:
                 data_warmup[var_name] = np.array(
-                    self.trace[: n_tune].get_values(var_name, combine=False, squeeze=False)
+                    self.trace[:n_tune].get_values(var_name, combine=False, squeeze=False)
                 )
             data[var_name] = np.array(
-                self.trace[n_tune :].get_values(var_name, combine=False, squeeze=False)
+                self.trace[n_tune:].get_values(var_name, combine=False, squeeze=False)
             )
         return (
             dict_to_dataset(

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -1,7 +1,7 @@
 """PyMC3-specific conversion code."""
 import logging
 import warnings
-from typing import Dict, List, Any, Optional, Iterable, Union, TYPE_CHECKING
+from typing import Dict, List, Any, Optional, Iterable, Union, TYPE_CHECKING, Tuple
 from types import ModuleType
 
 import numpy as np
@@ -114,6 +114,7 @@ class PyMC3Converter:  # pylint: disable=too-many-instance-attributes
                         UserWarning,
                     )
             self.ntune = len(self.trace) - self.ndraws
+            self.posterior_trace, self.warmup_trace = self.split_trace()
         else:
             self.nchains = self.ndraws = 0
 
@@ -160,6 +161,26 @@ class PyMC3Converter:  # pylint: disable=too-many-instance-attributes
             assert self.model is not None
             return {obs.name: obs.observations for obs in self.model.observed_RVs}
         return None
+
+    def split_trace(self) -> Tuple[Union[None, MultiTrace], Union[None, MultiTrace]]:
+        """Split MultiTrace object into posterior and warmup.
+
+        Returns
+        -------
+        trace_posterior: pymc3.MultiTrace or None
+            The slice of the trace corresponding to the posterior. If the posterior
+            trace is empty, None would is returned
+        trace_warmup: pymc3.MultiTrace or None
+            The slice of the trace corresponding to the warmup. If the warmup trace is
+            empty or ``save_warmup=False``, None would is returned
+        """
+        trace_posterior = None
+        trace_warmup = None
+        if self.save_warmup and self.ntune > 0:
+            trace_warmup = self.trace[: self.ntune]
+        if self.ndraws > 0:
+            trace_posterior = self.trace[self.ntune :]
+        return trace_posterior, trace_warmup
 
     def log_likelihood_vals_point(self, point, var, log_like_fun):
         """Compute log likelihood for each observed point."""
@@ -209,13 +230,14 @@ class PyMC3Converter:  # pylint: disable=too-many-instance-attributes
         data = {}
         data_warmup = {}
         for var_name in var_names:
-            if self.save_warmup:
+            if self.warmup_trace:
                 data_warmup[var_name] = np.array(
-                    self.trace[: self.ntune].get_values(var_name, combine=False, squeeze=False)
+                    self.warmup_trace.get_values(var_name, combine=False, squeeze=False)
                 )
-            data[var_name] = np.array(
-                self.trace[self.ntune :].get_values(var_name, combine=False, squeeze=False)
-            )
+            if self.posterior_trace:
+                data[var_name] = np.array(
+                    self.posterior_trace.get_values(var_name, combine=False, squeeze=False)
+                )
         return (
             dict_to_dataset(
                 data, library=self.pymc3, coords=self.coords, dims=self.dims, attrs=self.attrs
@@ -240,11 +262,12 @@ class PyMC3Converter:  # pylint: disable=too-many-instance-attributes
             name = rename_key.get(stat, stat)
             if name == "tune":
                 continue
-            if self.save_warmup:
+            if self.warmup_trace:
                 data_warmup[name] = np.array(
-                    self.trace[: self.ntune].get_sampler_stats(stat, combine=False)
+                    self.warmup_trace.get_sampler_stats(stat, combine=False)
                 )
-            data[name] = np.array(self.trace[self.ntune :].get_sampler_stats(stat, combine=False))
+            if self.posterior_trace:
+                data[name] = np.array(self.posterior_trace.get_sampler_stats(stat, combine=False))
 
         return (
             dict_to_dataset(
@@ -261,17 +284,22 @@ class PyMC3Converter:  # pylint: disable=too-many-instance-attributes
         """Extract log likelihood and log_p data from PyMC3 trace."""
         if self.predictions or not self.log_likelihood:
             return None
-        try:
-            data = self._extract_log_likelihood(self.trace[self.ntune :])
-        except TypeError:
-            warnings.warn(
-                """Could not compute log_likelihood, it will be omitted.
-                Check your model object or set log_likelihood=False"""
-            )
-            return None
         data_warmup = {}
-        if self.save_warmup:
-            data_warmup = self._extract_log_likelihood(self.trace[self.ntune:])
+        data = {}
+        warn_msg = (
+            "Could not compute log_likelihood, it will be omitted. "
+            "Check your model object or set log_likelihood=False"
+        )
+        if self.posterior_trace:
+            try:
+                data = self._extract_log_likelihood(self.posterior_trace)
+            except TypeError:
+                warnings.warn(warn_msg)
+        if self.warmup_trace:
+            try:
+                data_warmup = self._extract_log_likelihood(self.warmup_trace)
+            except TypeError:
+                warnings.warn(warn_msg)
         return (
             dict_to_dataset(data, library=self.pymc3, dims=self.dims, coords=self.coords),
             dict_to_dataset(data_warmup, library=self.pymc3, dims=self.dims, coords=self.coords),

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -169,10 +169,10 @@ class PyMC3Converter:  # pylint: disable=too-many-instance-attributes
         -------
         trace_posterior: pymc3.MultiTrace or None
             The slice of the trace corresponding to the posterior. If the posterior
-            trace is empty, None would is returned
+            trace is empty, None is returned
         trace_warmup: pymc3.MultiTrace or None
             The slice of the trace corresponding to the warmup. If the warmup trace is
-            empty or ``save_warmup=False``, None would is returned
+            empty or ``save_warmup=False``, None is returned
         """
         trace_posterior = None
         trace_warmup = None

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -208,12 +208,13 @@ class PyMC3Converter:  # pylint: disable=too-many-instance-attributes
         data = {}
         data_warmup = {}
         for var_name in var_names:
+            n_tune = len(self.trace) - self.ndraws
             if self.save_warmup:
                 data_warmup[var_name] = np.array(
-                    self.trace[: -self.ndraws].get_values(var_name, combine=False, squeeze=False)
+                    self.trace[: n_tune].get_values(var_name, combine=False, squeeze=False)
                 )
             data[var_name] = np.array(
-                self.trace[-self.ndraws :].get_values(var_name, combine=False, squeeze=False)
+                self.trace[n_tune :].get_values(var_name, combine=False, squeeze=False)
             )
         return (
             dict_to_dataset(

--- a/arviz/tests/external_tests/test_data_pymc.py
+++ b/arviz/tests/external_tests/test_data_pymc.py
@@ -1,4 +1,4 @@
-# pylint: disable=no-member, invalid-name, redefined-outer-name
+# pylint: disable=no-member, invalid-name, redefined-outer-name, protected-access
 from sys import version_info
 from typing import Dict, Tuple
 

--- a/arviz/tests/external_tests/test_data_pymc.py
+++ b/arviz/tests/external_tests/test_data_pymc.py
@@ -422,7 +422,7 @@ class TestPyMC3WarmupHandling:
             assert isinstance(trace, pm.backends.base.MultiTrace)
             idata = from_pymc3(trace, save_warmup=save_warmup)
         warmup_prefix = "" if save_warmup and (tune > 0) else "~"
-        post_prefix = "" if draws > 0 and (tune > 0) else "~"
+        post_prefix = "" if draws > 0 else "~"
         test_dict = {
             f"{post_prefix}posterior": ["u1", "n1"],
             f"{post_prefix}sample_stats": ["~tune", "accept"],

--- a/arviz/tests/external_tests/test_data_pymc.py
+++ b/arviz/tests/external_tests/test_data_pymc.py
@@ -406,7 +406,7 @@ class TestPyMC3WarmupHandling:
     )
     @pytest.mark.parametrize("save_warmup", [False, True])
     @pytest.mark.parametrize("chains", [1, 2])
-    @pytest.mark.parametrize("tune,draws", [(0, 200), (100, 200), (100, 0)])
+    @pytest.mark.parametrize("tune,draws", [(0, 50), (10, 40), (30, 0)])
     def test_save_warmup(self, save_warmup, chains, tune, draws):
         with pm.Model():
             pm.Uniform("u1")


### PR DESCRIPTION
## Description
Slicing the trace from the end caused #1210.

This PR improves the test to detect the issue and implements the fix.

I feel bad for having to bump the version number again..

## Checklist
- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)