### PR TITLE
Add finances section

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -93,7 +93,7 @@ Council Members will have the responsibility of
 * Make decisions when regular community discussion doesn’t produce consensus on an issue in a reasonable time frame.
 * Make decisions about strategic collaborations with other organizations or individuals.
 * Make decisions about the overall scope, vision and direction of the project.
-* Developing finding sources or spending money
+* Developing funding sources or spending money.
 
 The council may choose to delegate these responsibilities to sub committees. If so they must update this document to make the delegation clear.
 
@@ -205,4 +205,3 @@ can make the determination for acceptance with a process of their choosing.
 #### Core Contributor Responsibilities
 * Enforce code of conduct
 * Maintain a check against Council
-

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -93,11 +93,12 @@ Council Members will have the responsibility of
 * Make decisions when regular community discussion doesn’t produce consensus on an issue in a reasonable time frame.
 * Make decisions about strategic collaborations with other organizations or individuals.
 * Make decisions about the overall scope, vision and direction of the project.
-* Developing funding sources or spending money.
+* Developing funding sources
+* Deciding how to disburse funds
 
 The council may choose to delegate these responsibilities to sub-committees. If so, Council members must update this document to make the delegation clear.
 
-Note that each individual council member does not have the power to unilaterally wield these responsibilities, but the council as a whole must jointly make these decisions. In other words, Council Members are first and foremost Core Contributors, but only when needed they can collectively make decisions for the health of the project.
+Note that individual council member does not have the power to unilaterally wield these responsibilities, but the council as a whole must jointly make these decisions. In other words, Council Members are first and foremost Core Contributors, but only when needed they can collectively make decisions for the health of the project.
 
 ArviZ will be holding its first election to determine its initial council in the coming weeks and this document will be updated.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -95,7 +95,7 @@ Council Members will have the responsibility of
 * Make decisions about the overall scope, vision and direction of the project.
 * Developing funding sources or spending money.
 
-The council may choose to delegate these responsibilities to sub committees. If so they must update this document to make the delegation clear.
+The council may choose to delegate these responsibilities to sub-committees. If so, Council members must update this document to make the delegation clear.
 
 Note that each individual council member does not have the power to unilaterally wield these responsibilities, but the council as a whole must jointly make these decisions. In other words, Council Members are first and foremost Core Contributors, but only when needed they can collectively make decisions for the health of the project.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -93,6 +93,9 @@ Council Members will have the responsibility of
 * Make decisions when regular community discussion doesn’t produce consensus on an issue in a reasonable time frame.
 * Make decisions about strategic collaborations with other organizations or individuals.
 * Make decisions about the overall scope, vision and direction of the project.
+* Developing finding sources or spending money
+
+The council may choose to delegate these responsibilities to sub committees. If so they must update this document to make the delegation clear.
 
 Note that each individual council member does not have the power to unilaterally wield these responsibilities, but the council as a whole must jointly make these decisions. In other words, Council Members are first and foremost Core Contributors, but only when needed they can collectively make decisions for the health of the project.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -94,7 +94,7 @@ Council Members will have the responsibility of
 * Make decisions about strategic collaborations with other organizations or individuals.
 * Make decisions about the overall scope, vision and direction of the project.
 * Developing funding sources
-* Deciding how to disburse funds
+* Deciding how to disburse funds with consultation from Core Contributors
 
 The council may choose to delegate these responsibilities to sub-committees. If so, Council members must update this document to make the delegation clear.
 


### PR DESCRIPTION
Added a very basic generic stub. Looked at other projects but most don't really have this section filled out. @fonnesbeck gave me some tips, and I looked at matplotlibs and it says to refer to a section that doesn't exist :)

https://github.com/matplotlib/governance/blob/master/governance.md

In general though I think there's two broad paths. We let the council decide how they want to do this, or we try and make strict now so the process is consistent across councils. Please share opinions if you have any.

The outcome of this is that we need to have a general process as well as responsibility holder, It doesnt need to happen before this PR is merged, but it does need to be communicated when we apply for financial sponsorship