### PR TITLE
Fix keyword ignores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   objects. (#1218)
 * Added `log_likelihood` argument to `from_pyro` and a warning if log likelihood cannot be obtained (#1227)
 * Skip tests on matplotlib animations if ffmpeg is not installed (#1227)
+* Fix hpd bug where arguments were being ignored (#1236)
 
 ### Deprecation
 * Using `from_pymc3` without a model context available now raises a

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -338,15 +338,15 @@ def hpd(
     warnings.warn(("hpd will be deprecated " "Please replace hdi"),)
     return hdi(
         ary,
-        hdi_prob=None,
-        circular=False,
-        multimodal=False,
-        skipna=False,
-        group="posterior",
-        var_names=None,
-        filter_vars=None,
-        coords=None,
-        max_modes=10,
+        hdi_prob,
+        circular,
+        multimodal,
+        skipna,
+        group,
+        var_names,
+        filter_vars,
+        coords,
+        max_modes,
         **kwargs,
     )
 


### PR DESCRIPTION
## Description
hpd forwarding to hdi has a bug where it ignores user arguments

Here's a small example
```
def function_1(value="a", **kwargs):
    function_2(value="TheWrongVal", **kwargs)

def function_2(value=None, **kwargs):
    print(value)


function_1("a")
function_1("test_val")
```
## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Includes new or updated tests to cover the new feature
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)

