### PR TITLE
fix io_pymc3 bug when model not passed explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * loo-pit plot. The kde is computed over the data interval (this could be shorter than [0, 1]). The hdi is computed analitically (#1215)
 * Added `html_repr` of InferenceData objects for jupyter notebooks. (#1217)
 * Added support for PyJAGS via the function `from_pyjags` in the module arviz.data.io_pyjags. (#1219)
+* `from_pymc3` can now retrieve `coords` and `dims` from model context (#1228
+  and #1240)
 
 ### Maintenance and fixes
 * Include data from `MultiObservedRV` to `observed_data` when using

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -148,12 +148,12 @@ class PyMC3Converter:  # pylint: disable=too-many-instance-attributes
             self.ndraws = aelem.shape[0]
 
         self.coords = coords
-        if coords is None and hasattr(model, "coords"):
-            self.coords = model.coords
+        if coords is None and hasattr(self.model, "coords"):
+            self.coords = self.model.coords
 
         self.dims = dims
-        if dims is None and hasattr(model, "RV_dims"):
-            self.dims = {k: list(v) for k, v in model.RV_dims.items()}
+        if dims is None and hasattr(self.model, "RV_dims"):
+            self.dims = {k: list(v) for k, v in self.model.RV_dims.items()}
 
         self.observations, self.multi_observations = self.find_observations()
 


### PR DESCRIPTION
## Description
if model is not passed explicitly, it is retrieved from the context and stored in self.model, however, currently we check coords/dims in model instead.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/master/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
