### PR TITLE
Capitalized HDI everywhere it is used in text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.x.x Unreleased
 
 ### New features
-* loo-pit plot. The kde is computed over the data interval (this could be shorter than [0, 1]). The hdi is computed analitically (#1215)
+* loo-pit plot. The kde is computed over the data interval (this could be shorter than [0, 1]). The HDI is computed analitically (#1215)
 * Added `html_repr` of InferenceData objects for jupyter notebooks. (#1217)
 * Added support for PyJAGS via the function `from_pyjags` in the module arviz.data.io_pyjags. (#1219)
 

--- a/arviz/plots/backends/bokeh/forestplot.py
+++ b/arviz/plots/backends/bokeh/forestplot.py
@@ -417,7 +417,7 @@ class PlotHandler:
                     x=values[mid], y=y, size=markersize * 0.75, fill_color=color,
                 )
         _title = Title()
-        _title.text = "{:.1%} hdi".format(hdi_prob)
+        _title.text = "{:.1%} HDI".format(hdi_prob)
         ax.title = _title
 
         return ax

--- a/arviz/plots/backends/bokeh/hdiplot.py
+++ b/arviz/plots/backends/bokeh/hdiplot.py
@@ -10,7 +10,7 @@ from .. import show_layout
 
 
 def plot_hdi(ax, x_data, y_data, plot_kwargs, fill_kwargs, backend_kwargs, show):
-    """Bokeh hdi plot."""
+    """Bokeh HDI plot."""
     if backend_kwargs is None:
         backend_kwargs = {}
 

--- a/arviz/plots/backends/matplotlib/forestplot.py
+++ b/arviz/plots/backends/matplotlib/forestplot.py
@@ -341,7 +341,7 @@ class PlotHandler:
                     color=color,
                 )
         ax.tick_params(labelsize=xt_labelsize)
-        ax.set_title("{:.1%} hdi".format(hdi_prob), fontsize=titlesize, wrap=True)
+        ax.set_title("{:.1%} HDI".format(hdi_prob), fontsize=titlesize, wrap=True)
         if rope is None or isinstance(rope, dict):
             return
         elif len(rope) == 2:

--- a/arviz/plots/backends/matplotlib/hdiplot.py
+++ b/arviz/plots/backends/matplotlib/hdiplot.py
@@ -6,7 +6,7 @@ from . import backend_show
 
 
 def plot_hdi(ax, x_data, y_data, plot_kwargs, fill_kwargs, backend_kwargs, show):
-    """Matplotlib hdi plot."""
+    """Matplotlib HDI plot."""
     if backend_kwargs is not None:
         warnings.warn(
             (

--- a/arviz/plots/essplot.py
+++ b/arviz/plots/essplot.py
@@ -113,7 +113,7 @@ def plot_ess(
     --------
     Plot local ESS. This plot, together with the quantile ESS plot, is recommended to check
     that there are enough samples for all the explored regions of parameter space. Checking
-    local and quantile ESS is particularly relevant when working with hdi intervals as
+    local and quantile ESS is particularly relevant when working with HDI intervals as
     opposed to ESS bulk, which is relevant for point estimates.
 
     .. plot::

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -227,4 +227,3 @@ def plot_forest(
     plot = get_plotting_function("plot_forest", "forestplot", backend)
     axes = plot(**plot_forest_kwargs)
     return axes
-``

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -36,9 +36,9 @@ def plot_forest(
     show=None,
     credible_interval=None,
 ):
-    """Forest plot to compare hdi intervals from a number of distributions.
+    """Forest plot to compare HDI intervals from a number of distributions.
 
-    Generates a forest plot of 100*(hdi_prob)% hdi intervals from
+    Generates a forest plot of 100*(hdi_prob)% HDI intervals from
     a trace or list of traces.
 
     Parameters
@@ -227,3 +227,4 @@ def plot_forest(
     plot = get_plotting_function("plot_forest", "forestplot", backend)
     axes = plot(**plot_forest_kwargs)
     return axes
+``

--- a/arviz/plots/hdiplot.py
+++ b/arviz/plots/hdiplot.py
@@ -28,20 +28,20 @@ def plot_hdi(
     credible_interval=None,
 ):
     r"""
-    Plot hdi intervals for regression data.
+    Plot HDI intervals for regression data.
 
     Parameters
     ----------
     x : array-like
         Values to plot.
     y : array-like
-        Values from which to compute the hdi. Assumed shape (chain, draw, \*shape).
+        Values from which to compute the HDI. Assumed shape (chain, draw, \*shape).
     hdi_prob : float, optional
         Probability for the highest density interval. Defaults to 0.94.
     color : str
-        Color used for the limits of the hdi and fill. Should be a valid matplotlib color.
+        Color used for the limits of the HDI and fill. Should be a valid matplotlib color.
     circular : bool, optional
-        Whether to compute the hdi taking into account `x` is a circular variable
+        Whether to compute the HDI taking into account `x` is a circular variable
         (in the range [-np.pi, np.pi]) or not. Defaults to False (i.e non-circular variables).
     smooth : boolean
         If True the result will be smoothed by first computing a linear interpolation of the data
@@ -53,7 +53,7 @@ def plot_hdi(
     fill_kwargs : dict
         Keywords passed to `fill_between` (use fill_kwargs={'alpha': 0} to disable fill).
     plot_kwargs : dict
-        Keywords passed to hdi limits.
+        Keywords passed to HDI limits.
     ax: axes, optional
         Matplotlib axes or bokeh figures.
     backend: str, optional

--- a/arviz/plots/loopitplot.py
+++ b/arviz/plots/loopitplot.py
@@ -218,7 +218,7 @@ def plot_loo_pit(
                 hdi_kwargs = {}
             hdi_kwargs.setdefault("color", to_hex(hsv_to_rgb(light_color)))
             hdi_kwargs.setdefault("alpha", 0.35)
-            hdi_kwargs.setdefault("label", "Uniform hdi")
+            hdi_kwargs.setdefault("label", "Uniform HDI")
 
     loo_pit_kwargs = dict(
         ax=ax,

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -413,7 +413,7 @@ def hdi(
 
     Examples
     --------
-    Calculate the hdi of a Normal random variable:
+    Calculate the HDI of a Normal random variable:
 
     .. ipython::
 
@@ -422,7 +422,7 @@ def hdi(
            ...: data = np.random.normal(size=2000)
            ...: az.hdi(data, hdi_prob=.68)
 
-    Calculate the hdi of a dataset:
+    Calculate the HDI of a dataset:
 
     .. ipython::
 
@@ -430,13 +430,13 @@ def hdi(
            ...: data = az.load_arviz_data('centered_eight')
            ...: az.hdi(data)
 
-    We can also calculate the hdi of some of the variables of dataset:
+    We can also calculate the HDI of some of the variables of dataset:
 
     .. ipython::
 
         In [1]: az.hdi(data, var_names=["mu", "theta"])
 
-    If we want to calculate the hdi over specified dimension of dataset,
+    If we want to calculate the HDI over specified dimension of dataset,
     we can pass `input_core_dims` by kwargs:
 
     .. ipython::
@@ -527,7 +527,7 @@ def _hdi(ary, hdi_prob, circular, skipna):
 
 
 def _hdi_multimodal(ary, hdi_prob, skipna, max_modes):
-    """Compute hdi if the distribution is multimodal."""
+    """Compute HDI if the distribution is multimodal."""
     ary = ary.flatten()
     if skipna:
         ary = ary[~np.isnan(ary)]
@@ -1029,7 +1029,7 @@ def summary(
         If True, use the statistics returned by ``stat_funcs`` in addition to, rather than in place
         of, the default statistics. This is only meaningful when ``stat_funcs`` is not None.
     hdi_prob: float, optional
-        hdi interval to compute. Defaults to 0.94. This is only meaningful when ``stat_funcs`` is
+        HDI interval to compute. Defaults to 0.94. This is only meaningful when ``stat_funcs`` is
         None.
     order: {"C", "F"}
         If fmt is "wide", use either C or F unpacking order. Defaults to C.


### PR DESCRIPTION
HDI is an acronym, so it should be capitalized. Currently, it is "HDI" in some places and "hdi" in others (e.g. `plot_forest`):

<img width="137" alt="Screenshot 2020-06-15 11 33 35" src="https://user-images.githubusercontent.com/81476/84684032-b2538b80-aefd-11ea-96c9-1013a2965e03.png">

This PR makes capitalization consistent.