### PR TITLE
Change the default scatter_kwargs in pairplot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Added `log_likelihood` argument to `from_pyro` and a warning if log likelihood cannot be obtained (#1227)
 * Skip tests on matplotlib animations if ffmpeg is not installed (#1227)
 * Fix hpd bug where arguments were being ignored (#1236)
+* Change the default `zorder` of scatter points from `0` to `0.6` in `plot_pair` (#1246)
 
 ### Deprecation
 * Using `from_pymc3` without a model context available now raises a

--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -194,7 +194,7 @@ def plot_pair(
 
     scatter_kwargs.setdefault("marker", ".")
     scatter_kwargs.setdefault("lw", 0)
-    scatter_kwargs.setdefault("zorder", 0)
+    scatter_kwargs.setdefault("zorder", 1)
 
     if kde_kwargs is None:
         kde_kwargs = {}

--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -194,7 +194,8 @@ def plot_pair(
 
     scatter_kwargs.setdefault("marker", ".")
     scatter_kwargs.setdefault("lw", 0)
-    scatter_kwargs.setdefault("zorder", 1)
+    # Sets the default zorder higher than zorder of grid, which is 0.5
+    scatter_kwargs.setdefault("zorder", 0.6)
 
     if kde_kwargs is None:
         kde_kwargs = {}


### PR DESCRIPTION
Fix the issue: the grid is overwriting points in pair plot. For example, in [the gallery example](https://arviz-devs.github.io/arviz/examples/matplotlib/mpl_plot_pair.html), blue points are separated into two pieces at grid lines.