### PR TITLE
Use constrained layout in all styles

### DIFF
--- a/arviz/plots/styles/arviz-darkgrid.mplstyle
+++ b/arviz/plots/styles/arviz-darkgrid.mplstyle
@@ -5,6 +5,7 @@
 figure.figsize: 7.2, 4.8
 figure.dpi: 100.0
 figure.facecolor: white
+figure.constrained_layout.use: True
 text.color: .15
 axes.labelcolor: .15
 legend.frameon: False

--- a/arviz/plots/styles/arviz-grayscale.mplstyle
+++ b/arviz/plots/styles/arviz-grayscale.mplstyle
@@ -5,6 +5,7 @@
 figure.figsize: 7.2, 4.8
 figure.dpi: 100.0
 figure.facecolor: white
+figure.constrained_layout.use: True
 text.color: .15
 axes.labelcolor: .15
 legend.frameon: False

--- a/arviz/plots/styles/arviz-white.mplstyle
+++ b/arviz/plots/styles/arviz-white.mplstyle
@@ -5,6 +5,7 @@
 figure.figsize: 7.2, 4.8
 figure.dpi: 100.0
 figure.facecolor: white
+figure.constrained_layout.use: True
 text.color: .15
 axes.labelcolor: .15
 legend.frameon: False

--- a/arviz/plots/styles/arviz-whitegrid.mplstyle
+++ b/arviz/plots/styles/arviz-whitegrid.mplstyle
@@ -5,6 +5,7 @@
 figure.figsize: 7.2, 4.8
 figure.dpi: 100.0
 figure.facecolor: white
+figure.constrained_layout.use: True
 text.color: .15
 axes.labelcolor: .15
 legend.frameon: False


### PR DESCRIPTION
This adds `constrained_layout=True` to all arviz styles. This was experimental as of matplotlib 2.2, we use >3.0. I've been using this for my plots for a few years with no problem.  I've included an example below. Notice the text boxes do not overlap with the subplots. 

Running 

```python
import matplotlib.pyplot as plt
import arviz as az

az.style.use("arviz-darkgrid")

centered = az.load_arviz_data("centered_eight")
az.plot_trace(centered, var_names=["theta", "mu", "tau"], divergences=True);
```

Here is before the change:
![image](https://user-images.githubusercontent.com/2295568/84849794-1f614100-b024-11ea-9f77-791f03008dbf.png)

Here is after the change:

![image](https://user-images.githubusercontent.com/2295568/84849867-4d468580-b024-11ea-8041-12b046bf26e2.png)
