### PR TITLE
updates for numpy 1.19 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Skip tests on matplotlib animations if ffmpeg is not installed (#1227)
 * Fix hpd bug where arguments were being ignored (#1236)
 * Change the default `zorder` of scatter points from `0` to `0.6` in `plot_pair` (#1246)
+* Update `get_bins` for numpy 1.19 compatibility (#1256)
 
 ### Deprecation
 * Using `from_pymc3` without a model context available now raises a

--- a/arviz/numeric_utils.py
+++ b/arviz/numeric_utils.py
@@ -188,7 +188,7 @@ def get_bins(values):
     iqr = np.subtract(*np.percentile(values, [75, 25]))  # pylint: disable=assignment-from-no-return
     bins_fd = 2 * iqr * values.size ** (-1 / 3)
 
-    width = round(np.max([1, bins_sturges, bins_fd])).astype(int)
+    width = np.round(np.max([1, bins_sturges, bins_fd])).astype(int)
 
     return np.arange(x_min, x_max + width + 1, width)
 


### PR DESCRIPTION
## Description
Test failed in #1255 due to numpy latest version, 1.19, this should fix the issue.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/master/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
