### PR TITLE
Add circular histogram and KDE plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.x.x Unreleased
 ### New features
-* Added InferenceData dataset containing circular variables (#1266)
+* Added InferenceData dataset containing circular variables (#1265)
 * Added `is_circular` argument to `plot_dist` and `plot_kde` allowing for a circular histogram (Matplotlib, Bokeh) or 1D KDE plot (Matplotlib). (#1266)
 ### Maintenance and fixes
 * plot_posterior: fix overlap of hdi and rope (#1263)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## v0.x.x Unreleased
 ### New features
-* Added InferenceData dataset containing circular variables (#1265)
-
+* Added InferenceData dataset containing circular variables (#1266)
 * Added `is_circular` argument to `plot_dist` allowing for a circular histogram (Matplotlib, Bokeh) or KDE plot (Matplotlib). (#1266)
 ### Maintenance and fixes
 * plot_posterior: fix overlap of hdi and rope (#1263)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.x.x Unreleased
 ### New features
 * Added InferenceData dataset containing circular variables (#1266)
-* Added `is_circular` argument to `plot_dist` allowing for a circular histogram (Matplotlib, Bokeh) or KDE plot (Matplotlib). (#1266)
+* Added `is_circular` argument to `plot_dist` and `plot_kde` allowing for a circular histogram (Matplotlib, Bokeh) or 1D KDE plot (Matplotlib). (#1266)
 ### Maintenance and fixes
 * plot_posterior: fix overlap of hdi and rope (#1263)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### New features
 * Added InferenceData dataset containing circular variables (#1265)
 
+* Added `is_circular` argument to `plot_dist` allowing for a circular histogram (Matplotlib, Bokeh) or KDE plot (Matplotlib). (#1266)
 ### Maintenance and fixes
 * plot_posterior: fix overlap of hdi and rope (#1263)
 
@@ -73,7 +74,7 @@
 
 ### New features
 * Stats and plotting functions that provide `var_names` arg can now filter parameters based on partial naming (`filter="like"`) or regular expressions (`filter="regex"`) (see [#1154](https://github.com/arviz-devs/arviz/pull/1154)).
-* Add `true_values` argument for `plot_pair`. It allows for a scatter plot showing the true values of the variables #1140
+* Add `true_values` argument for `plot_pair`. It allows for a scatter plot showing the true values of the variables (#1140)
 * Allow xarray.Dataarray input for plots.(#1120)
 * Revamped the `hpd` function to make it work with mutidimensional arrays, InferenceData and xarray objects (#1117)
 * Skip test for optional/extra dependencies when not installed (#1113)

--- a/arviz/plots/backends/bokeh/distplot.py
+++ b/arviz/plots/backends/bokeh/distplot.py
@@ -131,6 +131,9 @@ def _histplot_bokeh_op(values, values2, rotated, ax, hist_kwargs, is_circular):
 
     if is_circular:
 
+        if is_circular == "degrees":
+            edges = np.deg2rad(edges)
+
         start_angle = edges
         outer_radius = hist
 
@@ -152,16 +155,16 @@ def _histplot_bokeh_op(values, values2, rotated, ax, hist_kwargs, is_circular):
             outer_radius=np.max(outer_radius) * 1.1,
             start_angle=ticks[:-1],
             end_angle=ticks[:-1] + 0.002,
-            **hist_kwargs,
+            line_color="grey",
         )
 
         radii_circles = np.linspace(0, np.max(outer_radius) * 1.1, 4)
-        ax.circle(0, 0, radius=radii_circles, fill_color=None, **hist_kwargs)
+        ax.circle(0, 0, radius=radii_circles, fill_color=None, line_color="grey")
 
-        if is_circular == 'degrees':
+        if is_circular == "degrees":
             labels = ["0°", "45°", "90°", "135°", "180°", "225°", "270°", "315°"]
         else:
-            
+
             labels = [
                 r"0",
                 r"π/4",

--- a/arviz/plots/backends/bokeh/distplot.py
+++ b/arviz/plots/backends/bokeh/distplot.py
@@ -6,6 +6,7 @@ import matplotlib.pyplot as plt
 from . import backend_kwarg_defaults
 from .. import show_layout
 from ...kdeplot import plot_kde
+from ...plot_utils import set_bokeh_circular_ticks_labels
 from ....numeric_utils import get_bins
 
 
@@ -161,48 +162,7 @@ def _histplot_bokeh_op(values, values2, rotated, ax, hist_kwargs, is_circular):
             **hist_kwargs,
         )
 
-        ticks = np.linspace(-np.pi, np.pi, len(labels), endpoint=False)
-        ax.annular_wedge(
-            x=0,
-            y=0,
-            inner_radius=0,
-            outer_radius=np.max(hist) * 1.1,
-            start_angle=ticks,
-            end_angle=ticks,
-            line_color="grey",
-        )
-
-        radii_circles = np.linspace(0, np.max(hist) * 1.1, 4)
-        ax.circle(0, 0, radius=radii_circles, fill_color=None, line_color="grey")
-
-        offset = np.max(hist * 1.05) * 0.15
-        ticks_labels_pos_1 = np.max(hist * 1.05)
-        ticks_labels_pos_2 = ticks_labels_pos_1 * np.sqrt(2) / 2
-
-        ax.text(
-            [
-                ticks_labels_pos_1 + offset,
-                ticks_labels_pos_2 + offset,
-                0,
-                -ticks_labels_pos_2 - offset,
-                -ticks_labels_pos_1 - offset,
-                -ticks_labels_pos_2 - offset,
-                0,
-                ticks_labels_pos_2 + offset,
-            ],
-            [
-                0,
-                ticks_labels_pos_2 + offset / 2,
-                ticks_labels_pos_1 + offset,
-                ticks_labels_pos_2 + offset / 2,
-                0,
-                -ticks_labels_pos_2 - offset,
-                -ticks_labels_pos_1 - offset,
-                -ticks_labels_pos_2 - offset,
-            ],
-            text=labels,
-            text_align="center",
-        )
+        ax = set_bokeh_circular_ticks_labels(ax, hist, labels)
 
     else:
 

--- a/arviz/plots/backends/bokeh/distplot.py
+++ b/arviz/plots/backends/bokeh/distplot.py
@@ -87,6 +87,7 @@ def plot_dist(
             contour_kwargs=contour_kwargs,
             contourf_kwargs=contourf_kwargs,
             pcolormesh_kwargs=pcolormesh_kwargs,
+            is_circular=is_circular,
             ax=ax,
             backend="bokeh",
             backend_kwargs={},
@@ -133,35 +134,6 @@ def _histplot_bokeh_op(values, values2, rotated, ax, hist_kwargs, is_circular):
 
         if is_circular == "degrees":
             edges = np.deg2rad(edges)
-
-        start_angle = edges
-        outer_radius = hist
-
-        ax.annular_wedge(
-            x=0,
-            y=0,
-            inner_radius=0,
-            outer_radius=outer_radius,
-            start_angle=start_angle,
-            end_angle=start_angle + 0.8,
-            **hist_kwargs,
-        )
-
-        ticks = np.linspace(-np.pi, np.pi, 9)
-        ax.annular_wedge(
-            x=0,
-            y=0,
-            inner_radius=0,
-            outer_radius=np.max(outer_radius) * 1.1,
-            start_angle=ticks[:-1],
-            end_angle=ticks[:-1] + 0.002,
-            line_color="grey",
-        )
-
-        radii_circles = np.linspace(0, np.max(outer_radius) * 1.1, 4)
-        ax.circle(0, 0, radius=radii_circles, fill_color=None, line_color="grey")
-
-        if is_circular == "degrees":
             labels = ["0°", "45°", "90°", "135°", "180°", "225°", "270°", "315°"]
         else:
 
@@ -176,29 +148,54 @@ def _histplot_bokeh_op(values, values2, rotated, ax, hist_kwargs, is_circular):
                 r"7π/4",
             ]
 
-        offset = np.max(outer_radius * 1.05) * 0.15
-        ticks_labels_pos = np.max(outer_radius * 1.05)
+        ax.annular_wedge(
+            x=0,
+            y=0,
+            inner_radius=0,
+            outer_radius=hist,
+            start_angle=edges[:-1],
+            end_angle=edges[1:],
+            **hist_kwargs,
+        )
+
+        ticks = np.linspace(-np.pi, np.pi, len(labels), endpoint=False)
+        ax.annular_wedge(
+            x=0,
+            y=0,
+            inner_radius=0,
+            outer_radius=np.max(hist) * 1.1,
+            start_angle=ticks,
+            end_angle=ticks,
+            line_color="grey",
+        )
+
+        radii_circles = np.linspace(0, np.max(hist) * 1.1, 4)
+        ax.circle(0, 0, radius=radii_circles, fill_color=None, line_color="grey")
+
+        offset = np.max(hist * 1.05) * 0.15
+        ticks_labels_pos_1 = np.max(hist * 1.05)
+        ticks_labels_pos_2 = ticks_labels_pos_1 * np.sqrt(2) / 2
 
         ax.text(
             [
-                ticks_labels_pos + offset,
-                ticks_labels_pos * np.sqrt(2) / 2 + offset,
+                ticks_labels_pos_1 + offset,
+                ticks_labels_pos_2 + offset,
                 0,
-                -ticks_labels_pos * np.sqrt(2) / 2 - offset,
-                -ticks_labels_pos - offset,
-                -ticks_labels_pos * np.sqrt(2) / 2 - offset,
+                -ticks_labels_pos_2 - offset,
+                -ticks_labels_pos_1 - offset,
+                -ticks_labels_pos_2 - offset,
                 0,
-                ticks_labels_pos * np.sqrt(2) / 2 + offset,
+                ticks_labels_pos_2 + offset,
             ],
             [
                 0,
-                ticks_labels_pos * np.sqrt(2) / 2 + offset / 2,
-                ticks_labels_pos + offset,
-                ticks_labels_pos * np.sqrt(2) / 2 + offset / 2,
+                ticks_labels_pos_2 + offset / 2,
+                ticks_labels_pos_1 + offset,
+                ticks_labels_pos_2 + offset / 2,
                 0,
-                -ticks_labels_pos * np.sqrt(2) / 2 - offset,
-                -ticks_labels_pos - offset,
-                -ticks_labels_pos * np.sqrt(2) / 2 - offset,
+                -ticks_labels_pos_2 - offset,
+                -ticks_labels_pos_1 - offset,
+                -ticks_labels_pos_2 - offset,
             ],
             text=labels,
             text_align="center",

--- a/arviz/plots/backends/bokeh/distplot.py
+++ b/arviz/plots/backends/bokeh/distplot.py
@@ -150,13 +150,16 @@ def _histplot_bokeh_op(values, values2, rotated, ax, hist_kwargs, is_circular):
                 r"7π/4",
             ]
 
+        delta = np.mean(np.diff(edges) / 2)
+
         ax.annular_wedge(
             x=0,
             y=0,
             inner_radius=0,
             outer_radius=hist,
-            start_angle=edges[:-1],
-            end_angle=edges[1:],
+            start_angle=edges[1:] - delta,
+            end_angle=edges[:-1] - delta,
+            direction="clock",
             **hist_kwargs,
         )
 

--- a/arviz/plots/backends/bokeh/distplot.py
+++ b/arviz/plots/backends/bokeh/distplot.py
@@ -115,9 +115,7 @@ def _histplot_bokeh_op(values, values2, rotated, ax, hist_kwargs, is_circular):
         hist_kwargs["fill_color"] = color
         hist_kwargs["line_color"] = color
 
-    line_alpha = hist_kwargs.pop("line_alpha", False)
-    if not line_alpha:
-        hist_kwargs.setdefault("line_alpha", 0)
+    hist_kwargs.setdefault("line_alpha", 0)
 
     # remove defaults for mpl
     hist_kwargs.pop("rwidth", None)

--- a/arviz/plots/backends/bokeh/distplot.py
+++ b/arviz/plots/backends/bokeh/distplot.py
@@ -45,7 +45,7 @@ def plot_dist(
     }
     if ax is None:
         if is_circular:
-            ax = bkp.figure(x_axis_type=None, y_axis_type=None, **backend_kwargs)
+            ax = bkp.figure(x_axis_type=None, y_axis_type=None)
         else:
             ax = bkp.figure(**backend_kwargs)
 
@@ -116,7 +116,7 @@ def _histplot_bokeh_op(values, values2, rotated, ax, hist_kwargs, is_circular):
 
     line_alpha = hist_kwargs.pop("line_alpha", False)
     if not line_alpha:
-        hist_kwargs["line_alpha"] = 0
+        hist_kwargs.setdefault("line_alpha", 0)
 
     # remove defaults for mpl
     hist_kwargs.pop("rwidth", None)

--- a/arviz/plots/backends/bokeh/distplot.py
+++ b/arviz/plots/backends/bokeh/distplot.py
@@ -45,7 +45,7 @@ def plot_dist(
     }
     if ax is None:
         if is_circular:
-            ax = bkp.figure(x_axis_type=None, y_axis_type=None,)
+            ax = bkp.figure(x_axis_type=None, y_axis_type=None, **backend_kwargs)
         else:
             ax = bkp.figure(**backend_kwargs)
 

--- a/arviz/plots/backends/bokeh/distplot.py
+++ b/arviz/plots/backends/bokeh/distplot.py
@@ -87,7 +87,6 @@ def plot_dist(
             contour_kwargs=contour_kwargs,
             contourf_kwargs=contourf_kwargs,
             pcolormesh_kwargs=pcolormesh_kwargs,
-            is_circular=is_circular,
             ax=ax,
             backend="bokeh",
             backend_kwargs={},
@@ -114,6 +113,10 @@ def _histplot_bokeh_op(values, values2, rotated, ax, hist_kwargs, is_circular):
     if color:
         hist_kwargs["fill_color"] = color
         hist_kwargs["line_color"] = color
+
+    line_alpha = hist_kwargs.pop("line_alpha", False)
+    if not line_alpha:
+        hist_kwargs["line_alpha"] = 0
 
     # remove defaults for mpl
     hist_kwargs.pop("rwidth", None)

--- a/arviz/plots/backends/bokeh/energyplot.py
+++ b/arviz/plots/backends/bokeh/energyplot.py
@@ -72,7 +72,12 @@ def plot_energy(
             hist_kwargs["line_color"] = None
             hist_kwargs["line_alpha"] = alpha
             _histplot_bokeh_op(
-                value.flatten(), values2=None, rotated=False, ax=ax, hist_kwargs=hist_kwargs
+                value.flatten(),
+                values2=None,
+                rotated=False,
+                ax=ax,
+                hist_kwargs=hist_kwargs,
+                is_circular=None,
             )
 
     else:

--- a/arviz/plots/backends/bokeh/energyplot.py
+++ b/arviz/plots/backends/bokeh/energyplot.py
@@ -77,7 +77,7 @@ def plot_energy(
                 rotated=False,
                 ax=ax,
                 hist_kwargs=hist_kwargs,
-                is_circular=None,
+                is_circular=False,
             )
 
     else:

--- a/arviz/plots/backends/matplotlib/distplot.py
+++ b/arviz/plots/backends/matplotlib/distplot.py
@@ -129,6 +129,8 @@ def _histplot_mpl_op(values, values2, rotated, ax, hist_kwargs, is_circular):
 
     if rotated:
         ax.set_yticks(bins[:-1])
+    elif not is_circular:
+        ax.set_xticks(bins[:-1])
 
     if is_circular:
         ax.set_ylim(0, 1.5 * n.max())

--- a/arviz/plots/backends/matplotlib/distplot.py
+++ b/arviz/plots/backends/matplotlib/distplot.py
@@ -133,7 +133,7 @@ def _histplot_mpl_op(values, values2, rotated, ax, hist_kwargs, is_circular):
         ax.set_xticks(bins[:-1])
 
     if is_circular:
-        ax.set_ylim(0, n.max() + 0.5 * n.max())
+        ax.set_ylim(0, 1.5 * n.max())
 
     if hist_kwargs.get("label") is not None:
         ax.legend()

--- a/arviz/plots/backends/matplotlib/distplot.py
+++ b/arviz/plots/backends/matplotlib/distplot.py
@@ -100,24 +100,24 @@ def _histplot_mpl_op(values, values2, rotated, ax, hist_kwargs, is_circular):
 
     if is_circular:
 
-        if values.min() < np.pi and values.max() > np.pi:
+        if is_circular == "degrees":
             if bins is None:
                 bins = get_bins(values)
             values = np.deg2rad(values)
             bins = np.deg2rad(bins)
         else:
-            label = [
-                r"$0$",
-                r"$\pi/4$",
-                r"$\pi/2$",
-                r"$3\pi/4$",
-                r"$\pi$",
-                r"$5\pi/4$",
-                r"$3\pi/2$",
-                r"$7\pi/4$",
+            labels = [
+                r"0",
+                r"π/4",
+                r"π/2",
+                r"3π/4",
+                r"π",
+                r"5π/4",
+                r"3π/2",
+                r"7π/4",
             ]
 
-            ax.set_xticklabels(label)
+            ax.set_xticklabels(labels)
         ax.set_yticklabels([])
 
     if values2 is not None:

--- a/arviz/plots/backends/matplotlib/distplot.py
+++ b/arviz/plots/backends/matplotlib/distplot.py
@@ -127,10 +127,8 @@ def _histplot_mpl_op(values, values2, rotated, ax, hist_kwargs, is_circular):
 
     n, _, _ = ax.hist(np.asarray(values).flatten(), bins=bins, **hist_kwargs)
 
-    if rotated or is_circular:
+    if rotated:
         ax.set_yticks(bins[:-1])
-    else:
-        ax.set_xticks(bins[:-1])
 
     if is_circular:
         ax.set_ylim(0, 1.5 * n.max())

--- a/arviz/plots/backends/matplotlib/distplot.py
+++ b/arviz/plots/backends/matplotlib/distplot.py
@@ -95,7 +95,6 @@ def plot_dist(
 
 def _histplot_mpl_op(values, values2, rotated, ax, hist_kwargs, is_circular):
     """Add a histogram for the data to the axes."""
-
     bins = hist_kwargs.pop("bins")
 
     if is_circular == "degrees":

--- a/arviz/plots/backends/matplotlib/distplot.py
+++ b/arviz/plots/backends/matplotlib/distplot.py
@@ -102,7 +102,6 @@ def _histplot_mpl_op(values, values2, rotated, ax, hist_kwargs, is_circular):
             bins = get_bins(values)
         values = np.deg2rad(values)
         bins = np.deg2rad(bins)
-        ax.set_yticklabels([])
 
     elif is_circular:
         labels = [
@@ -117,7 +116,6 @@ def _histplot_mpl_op(values, values2, rotated, ax, hist_kwargs, is_circular):
         ]
 
         ax.set_xticklabels(labels)
-        ax.set_yticklabels([])
 
     if values2 is not None:
         raise NotImplementedError("Insert hexbin plot here")
@@ -134,6 +132,7 @@ def _histplot_mpl_op(values, values2, rotated, ax, hist_kwargs, is_circular):
 
     if is_circular:
         ax.set_ylim(0, 1.5 * n.max())
+        ax.set_yticklabels([])
 
     if hist_kwargs.get("label") is not None:
         ax.legend()

--- a/arviz/plots/backends/matplotlib/distplot.py
+++ b/arviz/plots/backends/matplotlib/distplot.py
@@ -98,26 +98,26 @@ def _histplot_mpl_op(values, values2, rotated, ax, hist_kwargs, is_circular):
 
     bins = hist_kwargs.pop("bins")
 
-    if is_circular:
+    if is_circular == "degrees":
+        if bins is None:
+            bins = get_bins(values)
+        values = np.deg2rad(values)
+        bins = np.deg2rad(bins)
+        ax.set_yticklabels([])
 
-        if is_circular == "degrees":
-            if bins is None:
-                bins = get_bins(values)
-            values = np.deg2rad(values)
-            bins = np.deg2rad(bins)
-        else:
-            labels = [
-                r"0",
-                r"π/4",
-                r"π/2",
-                r"3π/4",
-                r"π",
-                r"5π/4",
-                r"3π/2",
-                r"7π/4",
-            ]
+    elif is_circular == "radians":
+        labels = [
+            r"0",
+            r"π/4",
+            r"π/2",
+            r"3π/4",
+            r"π",
+            r"5π/4",
+            r"3π/2",
+            r"7π/4",
+        ]
 
-            ax.set_xticklabels(labels)
+        ax.set_xticklabels(labels)
         ax.set_yticklabels([])
 
     if values2 is not None:

--- a/arviz/plots/backends/matplotlib/distplot.py
+++ b/arviz/plots/backends/matplotlib/distplot.py
@@ -95,7 +95,7 @@ def plot_dist(
 
 def _histplot_mpl_op(values, values2, rotated, ax, hist_kwargs, is_circular):
     """Add a histogram for the data to the axes."""
-    bins = hist_kwargs.pop("bins")
+    bins = hist_kwargs.pop("bins", None)
 
     if is_circular == "degrees":
         if bins is None:
@@ -104,7 +104,7 @@ def _histplot_mpl_op(values, values2, rotated, ax, hist_kwargs, is_circular):
         bins = np.deg2rad(bins)
         ax.set_yticklabels([])
 
-    elif is_circular == "radians":
+    elif is_circular:
         labels = [
             r"0",
             r"π/4",

--- a/arviz/plots/backends/matplotlib/kdeplot.py
+++ b/arviz/plots/backends/matplotlib/kdeplot.py
@@ -32,6 +32,7 @@ def plot_kde(
     contour_kwargs,
     contourf_kwargs,
     pcolormesh_kwargs,
+    is_circular,
     ax,
     legend,
     backend_kwargs,
@@ -76,7 +77,27 @@ def plot_kde(
 
         rug_space = max(density) * rug_kwargs.pop("space")
 
-        x = np.linspace(lower, upper, len(density))
+        if is_circular:
+
+            if values.min() >= -np.pi and values.max() <= np.pi:
+                label = [
+                    r"$0$",
+                    r"$\pi/4$",
+                    r"$\pi/2$",
+                    r"$3\pi/4$",
+                    r"$\pi$",
+                    r"$5\pi/4$",
+                    r"$3\pi/2$",
+                    r"$7\pi/4$",
+                ]
+
+                ax.set_xticklabels(label)
+
+            x = np.linspace(-np.pi, np.pi, len(density))
+            ax.set_yticklabels([])
+
+        else:
+            x = np.linspace(lower, upper, len(density))
 
         fill_func = ax.fill_between
         fill_x, fill_y = x, density

--- a/arviz/plots/backends/matplotlib/kdeplot.py
+++ b/arviz/plots/backends/matplotlib/kdeplot.py
@@ -79,19 +79,19 @@ def plot_kde(
 
         if is_circular:
 
-            if values.min() >= -np.pi and values.max() <= np.pi:
-                label = [
-                    r"$0$",
-                    r"$\pi/4$",
-                    r"$\pi/2$",
-                    r"$3\pi/4$",
-                    r"$\pi$",
-                    r"$5\pi/4$",
-                    r"$3\pi/2$",
-                    r"$7\pi/4$",
+            if is_circular == "radians":
+                labels = [
+                    r"0",
+                    r"π/4",
+                    r"π/2",
+                    r"3π/4",
+                    r"π",
+                    r"5π/4",
+                    r"3π/2",
+                    r"7π/4",
                 ]
 
-                ax.set_xticklabels(label)
+                ax.set_xticklabels(labels)
 
             x = np.linspace(-np.pi, np.pi, len(density))
             ax.set_yticklabels([])

--- a/arviz/plots/distplot.py
+++ b/arviz/plots/distplot.py
@@ -28,10 +28,10 @@ def plot_dist(
     contourf_kwargs=None,
     pcolormesh_kwargs=None,
     hist_kwargs=None,
+    is_circular=None,
     ax=None,
     backend=None,
     backend_kwargs=None,
-    is_circular=False,
     show=None,
     **kwargs
 ):
@@ -90,8 +90,8 @@ def plot_dist(
         Keywords passed to ax.pcolormesh. Ignored for 1D KDE.
     hist_kwargs : dict
         Keywords passed to the histogram.
-    is_circular : bool
-        Plot circular histogram or KDE plot.
+    is_circular : str
+        Select input type {"radians","degrees"} for circular histogram or KDE plot.
     ax: axes, optional
         Matplotlib axes or bokeh figures.
     backend: str, optional

--- a/arviz/plots/distplot.py
+++ b/arviz/plots/distplot.py
@@ -167,7 +167,10 @@ def plot_dist(
         hist_kwargs.setdefault("color", color)
         hist_kwargs.setdefault("label", label)
         hist_kwargs.setdefault("rwidth", 0.9)
-        hist_kwargs.setdefault("align", "left")
+        if is_circular:
+            hist_kwargs.setdefault("align", "mid")
+        else:
+            hist_kwargs.setdefault("align", "left")
         hist_kwargs.setdefault("density", True)
 
         if rotated:

--- a/arviz/plots/distplot.py
+++ b/arviz/plots/distplot.py
@@ -3,7 +3,6 @@
 
 import xarray as xr
 from .plot_utils import get_plotting_function, matplotlib_kwarg_dealiaser
-from ..numeric_utils import get_bins
 from ..data import InferenceData
 from ..rcparams import rcParams
 
@@ -32,6 +31,7 @@ def plot_dist(
     ax=None,
     backend=None,
     backend_kwargs=None,
+    is_circular=False,
     show=None,
     **kwargs
 ):
@@ -90,6 +90,8 @@ def plot_dist(
         Keywords passed to ax.pcolormesh. Ignored for 1D KDE.
     hist_kwargs : dict
         Keywords passed to the histogram.
+    is_circular : bool
+        Plot circular histogram or KDE plot.
     ax: axes, optional
         Matplotlib axes or bokeh figures.
     backend: str, optional
@@ -160,7 +162,7 @@ def plot_dist(
 
     if kind == "hist":
         hist_kwargs = matplotlib_kwarg_dealiaser(hist_kwargs, "hist")
-        hist_kwargs.setdefault("bins", get_bins(values))
+        hist_kwargs.setdefault("bins", None)
         hist_kwargs.setdefault("cumulative", cumulative)
         hist_kwargs.setdefault("color", color)
         hist_kwargs.setdefault("label", label)
@@ -197,6 +199,7 @@ def plot_dist(
         hist_kwargs=hist_kwargs,
         ax=ax,
         backend_kwargs=backend_kwargs,
+        is_circular=is_circular,
         show=show,
         **kwargs,
     )

--- a/arviz/plots/distplot.py
+++ b/arviz/plots/distplot.py
@@ -167,10 +167,7 @@ def plot_dist(
         hist_kwargs.setdefault("color", color)
         hist_kwargs.setdefault("label", label)
         hist_kwargs.setdefault("rwidth", 0.9)
-        if is_circular:
-            hist_kwargs.setdefault("align", "mid")
-        else:
-            hist_kwargs.setdefault("align", "left")
+        hist_kwargs.setdefault("align", "left")
         hist_kwargs.setdefault("density", True)
 
         if rotated:

--- a/arviz/plots/distplot.py
+++ b/arviz/plots/distplot.py
@@ -90,8 +90,8 @@ def plot_dist(
         Keywords passed to ax.pcolormesh. Ignored for 1D KDE.
     hist_kwargs : dict
         Keywords passed to the histogram.
-    is_circular : {True, False, "degrees"}, default False
-        Select input type {"radians","degrees"} for circular histogram or KDE plot. If True,
+    is_circular : {False, True, "radians", "degrees"}. Default False.
+        Select input type {"radians", "degrees"} for circular histogram or KDE plot. If True,
         default input type is "radians".
     ax: axes, optional
         Matplotlib axes or bokeh figures.

--- a/arviz/plots/distplot.py
+++ b/arviz/plots/distplot.py
@@ -28,7 +28,7 @@ def plot_dist(
     contourf_kwargs=None,
     pcolormesh_kwargs=None,
     hist_kwargs=None,
-    is_circular=None,
+    is_circular=False,
     ax=None,
     backend=None,
     backend_kwargs=None,
@@ -90,8 +90,9 @@ def plot_dist(
         Keywords passed to ax.pcolormesh. Ignored for 1D KDE.
     hist_kwargs : dict
         Keywords passed to the histogram.
-    is_circular : str
-        Select input type {"radians","degrees"} for circular histogram or KDE plot.
+    is_circular : {True, False, "degrees"}, default False
+        Select input type {"radians","degrees"} for circular histogram or KDE plot. If True,
+        default input type is "radians".
     ax: axes, optional
         Matplotlib axes or bokeh figures.
     backend: str, optional
@@ -162,7 +163,6 @@ def plot_dist(
 
     if kind == "hist":
         hist_kwargs = matplotlib_kwarg_dealiaser(hist_kwargs, "hist")
-        hist_kwargs.setdefault("bins", None)
         hist_kwargs.setdefault("cumulative", cumulative)
         hist_kwargs.setdefault("color", color)
         hist_kwargs.setdefault("label", label)

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -82,8 +82,8 @@ def plot_kde(
         Keywords passed to ax.contourf to draw filled contours. Ignored for 1D KDE.
     pcolormesh_kwargs : dict
         Keywords passed to ax.pcolormesh. Ignored for 1D KDE.
-    is_circular : bool
-        Plot circular KDE plot.
+    is_circular : str
+        Select input type {"radians","degrees"} for circular histogram or KDE plot.
     ax: axes, optional
         Matplotlib axes or bokeh figures.
     legend : bool
@@ -250,6 +250,7 @@ def plot_kde(
         kde_plot_args.pop("textsize")
         kde_plot_args.pop("label")
         kde_plot_args.pop("legend")
+        kde_plot_args.pop("is_circular")
     else:
         kde_plot_args.pop("return_glyph")
 

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -26,6 +26,7 @@ def plot_kde(
     contour_kwargs=None,
     contourf_kwargs=None,
     pcolormesh_kwargs=None,
+    is_circular=False,
     ax=None,
     legend=True,
     backend=None,
@@ -81,6 +82,8 @@ def plot_kde(
         Keywords passed to ax.contourf to draw filled contours. Ignored for 1D KDE.
     pcolormesh_kwargs : dict
         Keywords passed to ax.pcolormesh. Ignored for 1D KDE.
+    is_circular : bool
+        Plot circular KDE plot.
     ax: axes, optional
         Matplotlib axes or bokeh figures.
     legend : bool
@@ -230,6 +233,7 @@ def plot_kde(
         contour_kwargs=contour_kwargs,
         contourf_kwargs=contourf_kwargs,
         pcolormesh_kwargs=pcolormesh_kwargs,
+        is_circular=is_circular,
         ax=ax,
         legend=legend,
         backend_kwargs=backend_kwargs,

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -82,8 +82,9 @@ def plot_kde(
         Keywords passed to ax.contourf to draw filled contours. Ignored for 1D KDE.
     pcolormesh_kwargs : dict
         Keywords passed to ax.pcolormesh. Ignored for 1D KDE.
-    is_circular : str
-        Select input type {"radians","degrees"} for circular histogram or KDE plot.
+    is_circular : {False, True, "radians", "degrees"}. Default False.
+        Select input type {"radians", "degrees"} for circular histogram or KDE plot. If True,
+        default input type is "radians".
     ax: axes, optional
         Matplotlib axes or bokeh figures.
     legend : bool

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -717,3 +717,51 @@ def sample_reference_distribution(dist, shape):
         x_ss.append(x_s)
         densities.append(density)
     return np.array(x_ss).T, np.array(densities).T
+
+
+def set_bokeh_circular_ticks_labels(ax, hist, labels):
+    """Place ticks and ticklabels on Bokeh's circular histogram"""
+    ticks = np.linspace(-np.pi, np.pi, len(labels), endpoint=False)
+    ax.annular_wedge(
+        x=0,
+        y=0,
+        inner_radius=0,
+        outer_radius=np.max(hist) * 1.1,
+        start_angle=ticks,
+        end_angle=ticks,
+        line_color="grey",
+    )
+
+    radii_circles = np.linspace(0, np.max(hist) * 1.1, 4)
+    ax.circle(0, 0, radius=radii_circles, fill_color=None, line_color="grey")
+
+    offset = np.max(hist * 1.05) * 0.15
+    ticks_labels_pos_1 = np.max(hist * 1.05)
+    ticks_labels_pos_2 = ticks_labels_pos_1 * np.sqrt(2) / 2
+
+    ax.text(
+        [
+            ticks_labels_pos_1 + offset,
+            ticks_labels_pos_2 + offset,
+            0,
+            -ticks_labels_pos_2 - offset,
+            -ticks_labels_pos_1 - offset,
+            -ticks_labels_pos_2 - offset,
+            0,
+            ticks_labels_pos_2 + offset,
+        ],
+        [
+            0,
+            ticks_labels_pos_2 + offset / 2,
+            ticks_labels_pos_1 + offset,
+            ticks_labels_pos_2 + offset / 2,
+            0,
+            -ticks_labels_pos_2 - offset,
+            -ticks_labels_pos_1 - offset,
+            -ticks_labels_pos_2 - offset,
+        ],
+        text=labels,
+        text_align="center",
+    )
+
+    return ax

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -720,7 +720,7 @@ def sample_reference_distribution(dist, shape):
 
 
 def set_bokeh_circular_ticks_labels(ax, hist, labels):
-    """Place ticks and ticklabels on Bokeh's circular histogram"""
+    """Place ticks and ticklabels on Bokeh's circular histogram."""
     ticks = np.linspace(-np.pi, np.pi, len(labels), endpoint=False)
     ax.annular_wedge(
         x=0,

--- a/arviz/tests/base_tests/test_plot_utils.py
+++ b/arviz/tests/base_tests/test_plot_utils.py
@@ -269,13 +269,14 @@ def test_dealiase_sel_kwargs():
 
 # Check if Bokeh is installed
 bokeh_installed = importlib.util.find_spec("bokeh") is not None  # pylint: disable=invalid-name
+
+
 @pytest.mark.skipif(
     not (bokeh_installed | running_on_ci()), reason="test requires bokeh which is not installed",
 )
 def test_set_bokeh_circular_ticks_labels():
     """Assert the axes returned after placing ticks and tick labels for circular plots."""
     import bokeh.plotting as bkp
-
 
     ax = bkp.figure(x_axis_type=None, y_axis_type=None)
     hist = np.linspace(0, 1, 10)

--- a/arviz/tests/base_tests/test_plot_utils.py
+++ b/arviz/tests/base_tests/test_plot_utils.py
@@ -6,7 +6,7 @@ import pytest
 import xarray as xr
 
 from ...data import from_dict
-from ..helpers import running_on_ci, importorskip
+from ..helpers import running_on_ci
 from ...plots.plot_utils import (
     filter_plotters_list,
     format_sig_figs,
@@ -267,12 +267,18 @@ def test_dealiase_sel_kwargs():
     assert res["line_color"] == "red"
 
 
-# Skip tests if bokeh not installed
-bkp = importorskip("bokeh.plotting")  # pylint: disable=invalid-name
+# Check if Bokeh is installed
+bokeh_installed = importlib.util.find_spec("bokeh") is not None  # pylint: disable=invalid-name
+pytest.mark.skipif(
+    not (bokeh_installed | running_on_ci()), reason="test requires bokeh which is not installed",
+)
 
 
 def test_set_bokeh_circular_ticks_labels():
+    import bokeh.plotting as bkp
+
     """Assert the axes returned after placing ticks and tick labels for circular plots."""
+
     ax = bkp.figure(x_axis_type=None, y_axis_type=None)
     hist = np.linspace(0, 1, 10)
     labels = ["0°", "45°", "90°", "135°", "180°", "225°", "270°", "315°"]

--- a/arviz/tests/base_tests/test_plot_utils.py
+++ b/arviz/tests/base_tests/test_plot_utils.py
@@ -17,6 +17,7 @@ from ...plots.plot_utils import (
     xarray_var_iter,
     vectorized_to_hex,
     _dealiase_sel_kwargs,
+    set_bokeh_circular_ticks_labels,
 )
 from ...rcparams import rc_context
 from ...numeric_utils import get_bins
@@ -264,3 +265,15 @@ def test_dealiase_sel_kwargs():
     assert res["alpha"] == 0.4
     assert "line_color" in res
     assert res["line_color"] == "red"
+
+
+def test_set_bokeh_circular_ticks_labels():
+    """Assert the axes returned after placing ticks and tick labels for circular plots."""
+    ax = bkp.figure(x_axis_type=None, y_axis_type=None)
+    hist = np.linspace(0, 1, 10)
+    labels = ["0°", "45°", "90°", "135°", "180°", "225°", "270°", "315°"]
+    ax = set_bokeh_circular_ticks_labels(ax, hist, labels)
+    renderes = ax.renderers
+    assert len(renderers) == 4
+    assert a[3].data_source.data["text"] == labels
+    assert len(a[1].data_source.data["start_angle"]) == len(labels)

--- a/arviz/tests/base_tests/test_plot_utils.py
+++ b/arviz/tests/base_tests/test_plot_utils.py
@@ -269,15 +269,13 @@ def test_dealiase_sel_kwargs():
 
 # Check if Bokeh is installed
 bokeh_installed = importlib.util.find_spec("bokeh") is not None  # pylint: disable=invalid-name
-pytest.mark.skipif(
+@pytest.mark.skipif(
     not (bokeh_installed | running_on_ci()), reason="test requires bokeh which is not installed",
 )
-
-
 def test_set_bokeh_circular_ticks_labels():
+    """Assert the axes returned after placing ticks and tick labels for circular plots."""
     import bokeh.plotting as bkp
 
-    """Assert the axes returned after placing ticks and tick labels for circular plots."""
 
     ax = bkp.figure(x_axis_type=None, y_axis_type=None)
     hist = np.linspace(0, 1, 10)

--- a/arviz/tests/base_tests/test_plot_utils.py
+++ b/arviz/tests/base_tests/test_plot_utils.py
@@ -6,7 +6,7 @@ import pytest
 import xarray as xr
 
 from ...data import from_dict
-from ..helpers import running_on_ci
+from ..helpers import running_on_ci, importorskip
 from ...plots.plot_utils import (
     filter_plotters_list,
     format_sig_figs,
@@ -267,13 +267,17 @@ def test_dealiase_sel_kwargs():
     assert res["line_color"] == "red"
 
 
+# Skip tests if bokeh not installed
+bkp = importorskip("bokeh.plotting")  # pylint: disable=invalid-name
+
+
 def test_set_bokeh_circular_ticks_labels():
     """Assert the axes returned after placing ticks and tick labels for circular plots."""
     ax = bkp.figure(x_axis_type=None, y_axis_type=None)
     hist = np.linspace(0, 1, 10)
     labels = ["0°", "45°", "90°", "135°", "180°", "225°", "270°", "315°"]
     ax = set_bokeh_circular_ticks_labels(ax, hist, labels)
-    renderes = ax.renderers
+    renderers = ax.renderers
     assert len(renderers) == 4
-    assert a[3].data_source.data["text"] == labels
-    assert len(a[1].data_source.data["start_angle"]) == len(labels)
+    assert renderers[3].data_source.data["text"] == labels
+    assert len(renderers[1].data_source.data["start_angle"]) == len(labels)

--- a/arviz/tests/base_tests/test_plot_utils.py
+++ b/arviz/tests/base_tests/test_plot_utils.py
@@ -278,6 +278,6 @@ def test_set_bokeh_circular_ticks_labels():
     labels = ["0°", "45°", "90°", "135°", "180°", "225°", "270°", "315°"]
     ax = set_bokeh_circular_ticks_labels(ax, hist, labels)
     renderers = ax.renderers
-    assert len(renderers) == 4
-    assert renderers[3].data_source.data["text"] == labels
-    assert len(renderers[1].data_source.data["start_angle"]) == len(labels)
+    assert len(renderers) == 3
+    assert renderers[2].data_source.data["text"] == labels
+    assert len(renderers[0].data_source.data["start_angle"]) == len(labels)

--- a/arviz/tests/base_tests/test_plots_bokeh.py
+++ b/arviz/tests/base_tests/test_plots_bokeh.py
@@ -191,7 +191,7 @@ def test_plot_kde_cumulative(continuous_model, kwargs):
     assert axes
 
 
-@pytest.mark.parametrize("kwargs", [{"kind": "hist"}, {"kind": "kde"}])
+@pytest.mark.parametrize("kwargs", [{"kind": "hist"}, {"kind": "kde"}, {'is_circular':'radians'}, {'is_circular':'degrees'}])
 def test_plot_dist(continuous_model, kwargs):
     axes = plot_dist(continuous_model["x"], backend="bokeh", show=False, **kwargs)
     assert axes

--- a/arviz/tests/base_tests/test_plots_bokeh.py
+++ b/arviz/tests/base_tests/test_plots_bokeh.py
@@ -197,9 +197,13 @@ def test_plot_kde_cumulative(continuous_model, kwargs):
         {"kind": "hist"},
         {"kind": "kde"},
         {"is_circular": False},
+        {"is_circular": False, "kind": "hist"},
         {"is_circular": True},
+        {"is_circular": True, "kind": "hist"},
         {"is_circular": "radians"},
+        {"is_circular": "radians", "kind": "hist"},
         {"is_circular": "degrees"},
+        {"is_circular": "degrees", "kind": "hist"},
     ],
 )
 def test_plot_dist(continuous_model, kwargs):

--- a/arviz/tests/base_tests/test_plots_bokeh.py
+++ b/arviz/tests/base_tests/test_plots_bokeh.py
@@ -193,7 +193,7 @@ def test_plot_kde_cumulative(continuous_model, kwargs):
 
 @pytest.mark.parametrize(
     "kwargs",
-    [{"kind": "hist"}, {"kind": "kde"}, {"is_circular": "radians"}, {"is_circular": "degrees"}],
+    [{"kind": "hist"}, {"kind": "kde"}, {"is_circular": True}, {"is_circular": "degrees"}],
 )
 def test_plot_dist(continuous_model, kwargs):
     axes = plot_dist(continuous_model["x"], backend="bokeh", show=False, **kwargs)

--- a/arviz/tests/base_tests/test_plots_bokeh.py
+++ b/arviz/tests/base_tests/test_plots_bokeh.py
@@ -193,7 +193,13 @@ def test_plot_kde_cumulative(continuous_model, kwargs):
 
 @pytest.mark.parametrize(
     "kwargs",
-    [{"kind": "hist"}, {"kind": "kde"}, {"is_circular": True}, {"is_circular": "degrees"}],
+    [
+        {"kind": "hist"},
+        {"kind": "kde"},
+        {"is_circular": True},
+        {"is_circular": "degrees"},
+        {"is_circular": "radians"},
+    ],
 )
 def test_plot_dist(continuous_model, kwargs):
     axes = plot_dist(continuous_model["x"], backend="bokeh", show=False, **kwargs)

--- a/arviz/tests/base_tests/test_plots_bokeh.py
+++ b/arviz/tests/base_tests/test_plots_bokeh.py
@@ -191,7 +191,10 @@ def test_plot_kde_cumulative(continuous_model, kwargs):
     assert axes
 
 
-@pytest.mark.parametrize("kwargs", [{"kind": "hist"}, {"kind": "kde"}, {'is_circular':'radians'}, {'is_circular':'degrees'}])
+@pytest.mark.parametrize(
+    "kwargs",
+    [{"kind": "hist"}, {"kind": "kde"}, {"is_circular": "radians"}, {"is_circular": "degrees"}],
+)
 def test_plot_dist(continuous_model, kwargs):
     axes = plot_dist(continuous_model["x"], backend="bokeh", show=False, **kwargs)
     assert axes

--- a/arviz/tests/base_tests/test_plots_bokeh.py
+++ b/arviz/tests/base_tests/test_plots_bokeh.py
@@ -196,9 +196,10 @@ def test_plot_kde_cumulative(continuous_model, kwargs):
     [
         {"kind": "hist"},
         {"kind": "kde"},
+        {"is_circular": False},
         {"is_circular": True},
-        {"is_circular": "degrees"},
         {"is_circular": "radians"},
+        {"is_circular": "degrees"},
     ],
 )
 def test_plot_dist(continuous_model, kwargs):

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -380,9 +380,13 @@ def test_plot_kde_cumulative(continuous_model, kwargs):
         {"kind": "hist"},
         {"kind": "kde"},
         {"is_circular": False},
+        {"is_circular": False, "kind": "hist"},
         {"is_circular": True},
+        {"is_circular": True, "kind": "hist"},
         {"is_circular": "radians"},
+        {"is_circular": "radians", "kind": "hist"},
         {"is_circular": "degrees"},
+        {"is_circular": "degrees", "kind": "hist"},
     ],
 )
 def test_plot_dist(continuous_model, kwargs):

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -340,7 +340,7 @@ def test_plot_joint_bad(models):
         {"contour": False},
         {"contour": False, "pcolormesh_kwargs": {"cmap": "plasma"}},
         {"is_circular": True},
-        {"is_circular": "degrees"}
+        {"is_circular": "degrees"},
     ],
 )
 def test_plot_kde(continuous_model, kwargs):

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -370,7 +370,7 @@ def test_plot_kde_cumulative(continuous_model, kwargs):
     assert axes
 
 
-@pytest.mark.parametrize("kwargs", [{"kind": "hist"}, {"kind": "kde"}])
+@pytest.mark.parametrize("kwargs", [{"kind": "hist"}, {"kind": "kde"}, {"is_circular": True}])
 def test_plot_dist(continuous_model, kwargs):
     axes = plot_dist(continuous_model["x"], **kwargs)
     assert axes

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -339,9 +339,10 @@ def test_plot_joint_bad(models):
         },
         {"contour": False},
         {"contour": False, "pcolormesh_kwargs": {"cmap": "plasma"}},
+        {"is_circular": False},
         {"is_circular": True},
-        {"is_circular": "degrees"},
         {"is_circular": "radians"},
+        {"is_circular": "degrees"},
     ],
 )
 def test_plot_kde(continuous_model, kwargs):
@@ -378,9 +379,10 @@ def test_plot_kde_cumulative(continuous_model, kwargs):
     [
         {"kind": "hist"},
         {"kind": "kde"},
+        {"is_circular": False},
         {"is_circular": True},
-        {"is_circular": "degrees"},
         {"is_circular": "radians"},
+        {"is_circular": "degrees"},
     ],
 )
 def test_plot_dist(continuous_model, kwargs):

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -372,7 +372,7 @@ def test_plot_kde_cumulative(continuous_model, kwargs):
 
 @pytest.mark.parametrize(
     "kwargs",
-    [{"kind": "hist"}, {"kind": "kde"}, {"is_circular": True}, {"is_circular": "degrees"}]
+    [{"kind": "hist"}, {"kind": "kde"}, {"is_circular": True}, {"is_circular": "degrees"},],
 )
 def test_plot_dist(continuous_model, kwargs):
     axes = plot_dist(continuous_model["x"], **kwargs)

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -339,6 +339,8 @@ def test_plot_joint_bad(models):
         },
         {"contour": False},
         {"contour": False, "pcolormesh_kwargs": {"cmap": "plasma"}},
+        {"is_circular": True},
+        {"is_circular": "degrees"}
     ],
 )
 def test_plot_kde(continuous_model, kwargs):

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -370,7 +370,10 @@ def test_plot_kde_cumulative(continuous_model, kwargs):
     assert axes
 
 
-@pytest.mark.parametrize("kwargs", [{"kind": "hist"}, {"kind": "kde"}, {"is_circular": True}])
+@pytest.mark.parametrize(
+    "kwargs",
+    [{"kind": "hist"}, {"kind": "kde"}, {"is_circular": True}, {"is_circular": "degrees"}]
+)
 def test_plot_dist(continuous_model, kwargs):
     axes = plot_dist(continuous_model["x"], **kwargs)
     assert axes

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -341,6 +341,7 @@ def test_plot_joint_bad(models):
         {"contour": False, "pcolormesh_kwargs": {"cmap": "plasma"}},
         {"is_circular": True},
         {"is_circular": "degrees"},
+        {"is_circular": "radians"},
     ],
 )
 def test_plot_kde(continuous_model, kwargs):
@@ -374,7 +375,13 @@ def test_plot_kde_cumulative(continuous_model, kwargs):
 
 @pytest.mark.parametrize(
     "kwargs",
-    [{"kind": "hist"}, {"kind": "kde"}, {"is_circular": True}, {"is_circular": "degrees"},],
+    [
+        {"kind": "hist"},
+        {"kind": "kde"},
+        {"is_circular": True},
+        {"is_circular": "degrees"},
+        {"is_circular": "radians"},
+    ],
 )
 def test_plot_dist(continuous_model, kwargs):
     axes = plot_dist(continuous_model["x"], **kwargs)


### PR DESCRIPTION
## Description

This PR adds circular histogram and circular KDE plot.
Histogram example (matplotlib):
![kde_radians_degrees](https://user-images.githubusercontent.com/8028618/85760184-fa399600-b6e7-11ea-8dc0-45daac054085.png)

Histogram example (bokeh):
![bokeh_circ_hist](https://user-images.githubusercontent.com/8028618/86257478-fa2a1200-bb8f-11ea-90b5-5ae37ea2f894.png)


Although with this code you can get a circular KDE, there are a couple of things to improve in the KDE that will result in better behavior in a circular setting. We are planning to follow on Tomas Capretto's work on KDE. You can read the details in his [report](https://tcapretto.netlify.app/files/report/).

## Checklist
- [X] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [X] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [X] New features are properly documented (with an example if appropriate)?
- [x] Includes new or updated tests to cover the new feature
- [X] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)
