### PR TITLE
Add missing ax that is breaking docs

### DIFF
--- a/examples/bokeh/bokeh_plot_bpv.py
+++ b/examples/bokeh/bokeh_plot_bpv.py
@@ -7,4 +7,4 @@ _thumb: .6, .5
 import arviz as az
 
 data = az.load_arviz_data("regression1d")
-az.plot_bpv(data, backend="bokeh")
+ax = az.plot_bpv(data, backend="bokeh")


### PR DESCRIPTION
Found out docs were broken because in the bokeh examples you have to return ax

Exploratory PR is here
https://github.com/arviz-devs/arviz/pull/1271
