### PR TITLE
Partial mpl 3.3 fixes

### DIFF
--- a/arviz/plots/backends/matplotlib/jointplot.py
+++ b/arviz/plots/backends/matplotlib/jointplot.py
@@ -33,7 +33,7 @@ def plot_joint(
     }
     if ax is None:
         # Instantiate figure and grid
-        fig, _ = plt.subplots(0, 0, figsize=figsize, **backend_kwargs)
+        fig = plt.figure(figsize=figsize, **backend_kwargs)
         grid = plt.GridSpec(4, 4, hspace=0.1, wspace=0.1, figure=fig)
 
         # Set up main plot

--- a/arviz/plots/backends/matplotlib/pairplot.py
+++ b/arviz/plots/backends/matplotlib/pairplot.py
@@ -113,7 +113,7 @@ def plot_pair(
                 # Instantiate figure and grid
                 widths = [2, 2, 2, 1]
                 heights = [1.4, 2, 2, 2]
-                fig, _ = plt.subplots(0, 0, figsize=figsize, **backend_kwargs)
+                fig = plt.figure(figsize=figsize, **backend_kwargs)
                 grid = plt.GridSpec(
                     4,
                     4,

--- a/arviz/plots/backends/matplotlib/rankplot.py
+++ b/arviz/plots/backends/matplotlib/rankplot.py
@@ -69,10 +69,10 @@ def plot_rank(
             if labels:
                 ax.set_ylabel("Chain", fontsize=ax_labelsize)
         elif kind == "vlines":
-            ymin = np.full(len(all_counts), all_counts.mean())
+            ymin = all_counts.mean()
             for idx, counts in enumerate(all_counts):
                 ax.plot(bin_ary, counts, "o", color=colors[idx])
-                ax.vlines(bin_ary, ymin, counts, lw=2, color=colors[idx])
+                ax.vlines(bin_ary, ymin, counts, lw=2, colors=colors[idx])
             ax.set_ylim(0, all_counts.mean() * 2)
             if ref_line:
                 ax.axhline(y=all_counts.mean(), linestyle="--", color="k")


### PR DESCRIPTION
## Description

There are certain errors we need to fix

- [x] Fix vlines/hlines ymin array size **(compatible with mpl<3.3.0)**
- [x] Fix empty subplots error with figure call **(compatible with mpl<3.3.0)**
~~- [ ] Fix duplicate default parameter problem **(compatible with mpl<3.3.0)**~~
~~- [ ] fix changed return types (need to be careful to be compatible with previous versions of mpl)~~

I think the first two are fixed, but we need to update and fix the last point by thinking about how we define the default parameters. For example test are failing due to both `c` and `color` are defined. This used to be ignored, but in 3.1 it started to give a warning, and now it raises an exception.

Is there any mpl function we can use or do we want to manually create one. (There are not too many defaults we currently use). We also should use the main kw for each function. For example in color case, most mpl functions use color, but some use colors (e.g. vlines).

- `linewidth`, `linewidths`, `lw` --> `linewidth`/`linewidths`
- `color`, `colors`, `c` --> `color`, `colors`

edit.

This PR only fixes first two bugs.