### PR TITLE
Adapt summary function to circular variables 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added `is_circular` argument to `plot_dist` and `plot_kde` allowing for a circular histogram (Matplotlib, Bokeh) or 1D KDE plot (Matplotlib). (#1266)
 ### Maintenance and fixes
 * plot_posterior: fix overlap of hdi and rope (#1263)
+* improve handling of circular variables in `az.summary` (#1313)
 
 ### Deprecation
 

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -1270,7 +1270,7 @@ def summary(
 
         if kind != "diagnostics":
             for metric, circ_stat in zip(
-                # Replace the first 5 statistics
+                # Replace only the first 5 statistics for their circular equivalent
                 metrics[:5],
                 (circ_mean, circ_sd, circ_hdi_lower, circ_hdi_higher, circ_mcse),
             ):

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -1270,7 +1270,9 @@ def summary(
 
         if kind != "diagnostics":
             for metric, circ_stat in zip(
-                metrics[:5], (circ_mean, circ_sd, circ_hdi_lower, circ_hdi_higher, circ_mcse)
+                # Replace the first 5 statistics
+                metrics[:5],
+                (circ_mean, circ_sd, circ_hdi_lower, circ_hdi_higher, circ_mcse),
             ):
                 for circ_var in circ_var_names:
                     metric[circ_var] = circ_stat[circ_var]

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -992,6 +992,7 @@ def summary(
     fmt: str = "wide",
     kind: str = "all",
     round_to=None,
+    include_circ=None,
     circ_var_names=None,
     stat_funcs=None,
     extend=True,
@@ -1027,6 +1028,9 @@ def summary(
         them.
     round_to: int
         Number of decimals used to round results. Defaults to 2. Use "none" to return raw numbers.
+    include_circ: boolean
+        Whether to include circular statistics
+        deprecated: Please see circ_var_names
     circ_var_names: list
         A list of circular variables to compute circular stats for
     stat_funcs: dict
@@ -1116,6 +1120,9 @@ def summary(
            ...: )
 
     """
+    if include_circ:
+        warnings.warn(("include_circ will be deprecated " "Please use circ_var_names"),)
+
     if credible_interval:
         hdi_prob = credible_interval_warning(hdi_prob, hdi_prob)
 

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -1121,7 +1121,10 @@ def summary(
 
     """
     if include_circ:
-        warnings.warn(("include_circ will be deprecated " "Please use circ_var_names"),)
+        warnings.warn(
+            "include_circ is deprecated and will be ignored. Use circ_var_names instead", 
+            DeprecationWarning
+        )
 
     if credible_interval:
         hdi_prob = credible_interval_warning(hdi_prob, hdi_prob)

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -1122,8 +1122,8 @@ def summary(
     """
     if include_circ:
         warnings.warn(
-            "include_circ is deprecated and will be ignored. Use circ_var_names instead", 
-            DeprecationWarning
+            "include_circ is deprecated and will be ignored. Use circ_var_names instead",
+            DeprecationWarning,
         )
 
     if credible_interval:

--- a/arviz/tests/base_tests/test_stats_numba.py
+++ b/arviz/tests/base_tests/test_stats_numba.py
@@ -22,12 +22,12 @@ pytestmark = pytest.mark.skipif(  # pylint: disable=invalid-name
 rcParams["data.load"] = "eager"
 
 
-@pytest.mark.parametrize("include_circ", [True, False])
-def test_summary_include_circ(centered_eight, include_circ):
-    assert summary(centered_eight, include_circ=include_circ) is not None
+@pytest.mark.parametrize("circ_var_names", [["mu"], None])
+def test_summary_circ_vars(centered_eight, circ_var_names):
+    assert summary(centered_eight, circ_var_names=circ_var_names) is not None
     state = Numba.numba_flag
     Numba.disable_numba()
-    assert summary(centered_eight, include_circ=include_circ) is not NotImplementedError
+    assert summary(centered_eight, circ_var_names=circ_var_names) is not NotImplementedError
     Numba.enable_numba()
     assert state == Numba.numba_flag
 

--- a/arviz/tests/base_tests/test_stats_numba.py
+++ b/arviz/tests/base_tests/test_stats_numba.py
@@ -23,11 +23,18 @@ rcParams["data.load"] = "eager"
 
 
 @pytest.mark.parametrize("circ_var_names", [["mu"], None])
-def test_summary_circ_vars(centered_eight, circ_var_names):
-    assert summary(centered_eight, circ_var_names=circ_var_names) is not None
+@pytest.mark.parametrize("include_circ", [True, False])
+def test_summary_circ_vars(centered_eight, circ_var_names, include_circ):
+    assert (
+        summary(centered_eight, circ_var_names=circ_var_names, include_circ=include_circ)
+        is not None
+    )
     state = Numba.numba_flag
     Numba.disable_numba()
-    assert summary(centered_eight, circ_var_names=circ_var_names) is not NotImplementedError
+    assert (
+        summary(centered_eight, circ_var_names=circ_var_names, include_circ=include_circ)
+        is not NotImplementedError
+    )
     Numba.enable_numba()
     assert state == Numba.numba_flag
 


### PR DESCRIPTION
## Description

In this PR I changed the `az.summary` function to display statistics for circular variables more neatly. It is related to issue #339. 

`torsionals = az.load_arviz_data('glycan_torsion_angles')`
`az.summary(torsionals, circ_var_names=['tors'])` 

outputs:

![sc_summary](https://user-images.githubusercontent.com/8028618/88214754-0e15e080-cc31-11ea-88b6-8844155870b2.PNG)

## Checklist
- [X] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [X] New features are properly documented (with an example if appropriate)?
- [X] Includes new or updated tests to cover the new feature
- [X] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)