### PR TITLE
Dist plot error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added `is_circular` argument to `plot_dist` and `plot_kde` allowing for a circular histogram (Matplotlib, Bokeh) or 1D KDE plot (Matplotlib). (#1266)
 ### Maintenance and fixes
 * plot_posterior: fix overlap of hdi and rope (#1263)
+* `plot_dist` bins argument error fixed (#1306)
 
 ### Deprecation
 

--- a/arviz/plots/backends/matplotlib/distplot.py
+++ b/arviz/plots/backends/matplotlib/distplot.py
@@ -123,7 +123,7 @@ def _histplot_mpl_op(values, values2, rotated, ax, hist_kwargs, is_circular):
     if bins is None:
         bins = get_bins(values)
 
-    n, _, _ = ax.hist(np.asarray(values).flatten(), bins=bins, **hist_kwargs)
+    n, bins, _ = ax.hist(np.asarray(values).flatten(), bins=bins, **hist_kwargs)
 
     if rotated:
         ax.set_yticks(bins[:-1])

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -90,9 +90,11 @@ def fig_ax():
     fig, ax = plt.subplots(1, 1)
     return fig, ax
 
+
 @pytest.fixture(scope="module")
 def data_random():
-    return np.random.randint(1,100,size=20)
+    return np.random.randint(1, 100, size=20)
+
 
 @pytest.mark.parametrize(
     "kwargs",
@@ -396,9 +398,11 @@ def test_plot_dist(continuous_model, kwargs):
     axes = plot_dist(continuous_model["x"], **kwargs)
     assert axes
 
+
 def test_plot_dist_hist(data_random):
     axes = plot_dist(data_random, hist_kwargs=dict(bins=30))
     assert axes
+
 
 @pytest.mark.parametrize(
     "kwargs",

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -90,6 +90,9 @@ def fig_ax():
     fig, ax = plt.subplots(1, 1)
     return fig, ax
 
+@pytest.fixture(scope="module")
+def data_random():
+    return np.random.randint(1,100,size=20)
 
 @pytest.mark.parametrize(
     "kwargs",
@@ -393,6 +396,9 @@ def test_plot_dist(continuous_model, kwargs):
     axes = plot_dist(continuous_model["x"], **kwargs)
     assert axes
 
+def test_plot_dist_hist(data_random):
+    axes = plot_dist(data_random, hist_kwargs=dict(bins=30))
+    assert axes
 
 @pytest.mark.parametrize(
     "kwargs",


### PR DESCRIPTION
## Description

Plot-distribution bins argument error fixed. The plot_dist is given a numpy.ndarray and the bin size, which plots a histogram. The error was caused by the bins variable which was not a list to index, but by collecting the return value for bins after plotting this error is solved.

[Issue number #1306](https://github.com/arviz-devs/arviz/issues/1306)

## Checklist

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)


Thank you so much for allowing me to work on this issue. I am new to open source, please let me know if the updates are correct and if I need to make any other changes.