### PR TITLE
new gray scale

### DIFF
--- a/arviz/plots/styles/arviz-grayscale.mplstyle
+++ b/arviz/plots/styles/arviz-grayscale.mplstyle
@@ -36,4 +36,6 @@ ytick.major.size: 0
 xtick.minor.size: 0
 ytick.minor.size: 0
 
-axes.prop_cycle: cycler('color', ["000000", "585858", "A8A8A8", "D3D3D3", "2a2eec"])
+# First 4 colors are from colorcet and the last one is the "ArviZ-blue"
+# [to_hex(_linear_grey_0_100_c0[i]) for i in np.linspace(0, 195, 4).astype(int)]
+axes.prop_cycle: cycler('color', ["000000", "4a4a4a", "7e7f7f", "b8b8b8", "2a2eec"])


### PR DESCRIPTION
This is a small modification of the C0-C3  colors in arviz-grayscale. The C3 color was a little bit difficult to see specially if printed. 
