### PR TITLE
Fix ci pylint fail on pytest not callable error on markers

### DIFF
--- a/.azure-pipelines/azure-pipelines-external.yml
+++ b/.azure-pipelines/azure-pipelines-external.yml
@@ -108,14 +108,6 @@ jobs:
     displayName: 'Print packages'
 
   - script: |
-      pytest arviz/tests/helpers.py
-    displayName: 'precompile models'
-
-  - script: |
-      python -m pytest arviz/tests/external_tests --cov arviz --cov-report=xml
-    displayName: 'pytest'
-
-  - script: |
       python -m pylint arviz
     displayName: 'pylint'
 
@@ -126,6 +118,14 @@ jobs:
   - script: |
       python -m black --check arviz examples asv_benchmarks
     displayName: 'black'
+
+  - script: |
+      pytest arviz/tests/helpers.py
+    displayName: 'precompile models'
+
+  - script: |
+      python -m pytest arviz/tests/external_tests --cov arviz --cov-report=xml
+    displayName: 'pytest'
 
   - task: PublishTestResults@2
     condition: succeededOrFailed()

--- a/arviz/tests/base_tests/test_rcparams.py
+++ b/arviz/tests/base_tests/test_rcparams.py
@@ -287,7 +287,7 @@ def test_stats_information_criterion(models):
     assert "loo" in df_comp.columns
 
 
-def test_http_type_request(models, monkeypatch):
+def test_http_type_request(monkeypatch):
     def _urlretrive(url, _):
         raise Exception("URL Retrieved: {}".format(url))
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 astroid==2.3.3
 numpydoc
 pydocstyle
-pylint==2.4.4
+pylint
 pytest
 pytest-cov
 black ; python_version >= '3.6'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-astroid==2.3.3
+astroid
 numpydoc
 pydocstyle
 pylint


### PR DESCRIPTION
pytest said they fixed the pylint error but we're still seeing it. Kicking off CI to run see if unpinning works

https://docs.pytest.org/en/stable/changelog.html
![image](https://user-images.githubusercontent.com/7213793/88967671-01157480-d263-11ea-80e1-286a50843e50.png)
