### PR TITLE
Fix bug in warning that raises TypeError

### DIFF
--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -565,7 +565,7 @@ def _hdi_multimodal(ary, hdi_prob, skipna, max_modes):
     for i, interval in enumerate(intervals_splitted):
         if i == max_modes:
             warnings.warn(
-                "found more modes than {0}, returning only the first {0} modes", max_modes
+                "found more modes than {0}, returning only the first {0} modes".format(max_modes)
             )
             break
         if interval.size == 0:


### PR DESCRIPTION
## Description

This PR fixes a bug in a warning message that causes ArviZ to instead throw a `TypeError`.

## Checklist

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Code style  correct (follows pylint and black guidelines)