### PR TITLE
Auto conversion of list to numpy array in distplot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added `to_dict` method for InferenceData object (#1223)
 
 ### Maintenance and fixes
+* automatic conversion of list/tuple to numpy array in distplot (#1277)
 * plot_posterior: fix overlap of hdi and rope (#1263)
 * `plot_dist` bins argument error fixed (#1306)
 * improve handling of circular variables in `az.summary` (#1313)

--- a/arviz/plots/distplot.py
+++ b/arviz/plots/distplot.py
@@ -1,6 +1,7 @@
 # pylint: disable=unexpected-keyword-arg
 """Plot distribution as histogram or kernel density estimates."""
 import xarray as xr
+import numpy as np
 
 from ..data import InferenceData
 from ..rcparams import rcParams
@@ -158,6 +159,8 @@ def plot_dist(
 
         >>> az.plot_dist(b, rug=True, quantiles=[.25, .5, .75], cumulative=True)
     """
+    values = np.asarray(values)
+
     if isinstance(values, (InferenceData, xr.Dataset)):
         raise ValueError(
             "InferenceData or xarray.Dateset object detected,"

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -96,9 +96,10 @@ def fig_ax():
 def data_random():
     return np.random.randint(1, 100, size=20)
 
+
 @pytest.fixture(scope="module")
 def data_list():
-    return list(range(11,31))
+    return list(range(11, 31))
 
 
 @pytest.mark.parametrize(
@@ -405,9 +406,11 @@ def test_plot_dist_hist(data_random):
     axes = plot_dist(data_random, hist_kwargs=dict(bins=30))
     assert axes
 
+
 def test_list_conversion(data_list):
     axes = plot_dist(data_list, hist_kwargs=dict(bins=30))
     assert axes
+
 
 @pytest.mark.parametrize(
     "kwargs",

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -96,6 +96,10 @@ def fig_ax():
 def data_random():
     return np.random.randint(1, 100, size=20)
 
+@pytest.fixture(scope="module")
+def data_list():
+    return list(range(11,31))
+
 
 @pytest.mark.parametrize(
     "kwargs",
@@ -401,6 +405,9 @@ def test_plot_dist_hist(data_random):
     axes = plot_dist(data_random, hist_kwargs=dict(bins=30))
     assert axes
 
+def test_list_conversion(data_list):
+    axes = plot_dist(data_list, hist_kwargs=dict(bins=30))
+    assert axes
 
 @pytest.mark.parametrize(
     "kwargs",


### PR DESCRIPTION
Automatically convert list/tuple to numpy array in distplot.
The distplot requires a numpy array as input. It throws an exception if a list or tuple is given as input. In the current changes made any list/tuple passed as input is automatically converted to numpy array.
Issue number #1277 

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)
