### PR TITLE
Disable KDE domain narrower than data limits

### DIFF
--- a/arviz/stats/density_utils.py
+++ b/arviz/stats/density_utils.py
@@ -8,6 +8,7 @@ from scipy.optimize import brentq
 from scipy.signal import convolve, convolve2d, gaussian  # pylint: disable=no-name-in-module
 from scipy.sparse import coo_matrix
 from scipy.special import ive  # pylint: disable=no-name-in-module
+from scipy.integrate import simps # pylint: disable=no-name-in-module
 
 from ..utils import _cov, _dot, _stack, conditional_jit
 
@@ -640,7 +641,10 @@ def _kde_linear(
 
     if cumulative:
         pdf = pdf.cumsum() / pdf.sum()
-
+	
+    if grid[0] > x_min or grid[-1] < x_max:
+    	pdf = pdf / simps(pdf, grid)
+    	
     if bw_return:
         return grid, pdf, bw
     else:

--- a/arviz/stats/density_utils.py
+++ b/arviz/stats/density_utils.py
@@ -8,7 +8,6 @@ from scipy.optimize import brentq
 from scipy.signal import convolve, convolve2d, gaussian  # pylint: disable=no-name-in-module
 from scipy.sparse import coo_matrix
 from scipy.special import ive  # pylint: disable=no-name-in-module
-from scipy.integrate import simps # pylint: disable=no-name-in-module
 
 from ..utils import _cov, _dot, _stack, conditional_jit
 
@@ -358,7 +357,10 @@ def _check_custom_lims(custom_lims, x_min, x_max):
         )
 
     if not custom_lims[0] < custom_lims[1]:
-        raise AttributeError("`custom_lims[0]` must be smaller than `custom_lims[1]`.")
+        raise ValueError("`custom_lims[0]` must be smaller than `custom_lims[1]`.")
+    
+    if custom_lims[0] > x_min or custom_lims[1] < x_max:
+    	raise ValueError("Some observations are outside `custom_lims` boundaries.")
 
     return custom_lims
 
@@ -642,9 +644,6 @@ def _kde_linear(
     if cumulative:
         pdf = pdf.cumsum() / pdf.sum()
 	
-    if grid[0] > x_min or grid[-1] < x_max:
-    	pdf = pdf / simps(pdf, grid)
-    	
     if bw_return:
         return grid, pdf, bw
     else:

--- a/arviz/stats/density_utils.py
+++ b/arviz/stats/density_utils.py
@@ -358,9 +358,9 @@ def _check_custom_lims(custom_lims, x_min, x_max):
 
     if not custom_lims[0] < custom_lims[1]:
         raise ValueError("`custom_lims[0]` must be smaller than `custom_lims[1]`.")
-    
+
     if custom_lims[0] > x_min or custom_lims[1] < x_max:
-    	raise ValueError("Some observations are outside `custom_lims` boundaries.")
+        raise ValueError("Some observations are outside `custom_lims` boundaries.")
 
     return custom_lims
 
@@ -643,7 +643,7 @@ def _kde_linear(
 
     if cumulative:
         pdf = pdf.cumsum() / pdf.sum()
-	
+
     if bw_return:
         return grid, pdf, bw
     else:


### PR DESCRIPTION
## Description
Currently, the KDE returns a pdf with an area under the curve smaller than 1 if a narrower custom domain is specified.
This PR fixes that. 

- [x] Includes a sample plot to visually illustrate the changes (only for plot-related functions)

**Old**

![old](https://user-images.githubusercontent.com/25507629/92479259-b1a75a00-f1b9-11ea-9b25-cd263a9c7f2d.png)

**New**

![now_1](https://user-images.githubusercontent.com/25507629/92479268-b79d3b00-f1b9-11ea-8018-0f99ba6b74a1.png)
![new_2](https://user-images.githubusercontent.com/25507629/92479280-b9ff9500-f1b9-11ea-97c0-571b17e82e13.png)
