### PR TITLE
Make yellow line visible in matplotlib plot_hdi example

### DIFF
--- a/examples/matplotlib/mpl_plot_hdi.py
+++ b/examples/matplotlib/mpl_plot_hdi.py
@@ -14,7 +14,7 @@ az.style.use("arviz-darkgrid")
 x_data = np.random.normal(0, 1, 100)
 y_data = 2 + x_data * 0.5
 y_data_rep = np.random.normal(y_data, 0.5, (200, 100))
-plt.plot(x_data, y_data, "C6")
 az.plot_hdi(x_data, y_data_rep, color="k", plot_kwargs={"ls": "--"})
+plt.plot(x_data, y_data, "C6")
 
 plt.show()


### PR DESCRIPTION
## Description
In the [example](https://arviz-devs.github.io/arviz/examples/matplotlib/mpl_plot_hdi.html), there seems to be a desire to show the line from which `y_data_rep` is sampled, but it is not visible because the call to `az.plot_hdi` is after `plt.plot`, and its shaded region covers it. Switching the lines makes the yellow line visible. 

### Current
![image](https://user-images.githubusercontent.com/10835345/93368349-7dfcad80-f813-11ea-83d8-95e3daff51fd.png)
### Possibly Intended
![image](https://user-images.githubusercontent.com/10835345/93368486-ad131f00-f813-11ea-87c3-f4afd662d455.png)
<!--
Thank you so much for your PR! To help us review your contribution, please consider the following points:

- The PR title should summarize the changes, for example "Add new group argument for the pair plot".
  Avoid non-descriptive titles such as "Addresses issue #348".

- The description should provide at least 1-2 sentences describing the pull request in detail and
  link to any relevant issues.

- Please prefix the title of incomplete contributions with [WIP] (to indicate a work in
  progress). WIPs may be useful to (1) indicate you are working on something to avoid
  duplicated work, (2) request broad review of functionality or API, or (3) seek collaborators. -->

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [x] Code style  correct (follows pylint and black guidelines)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/master/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
