### PR TITLE
Add to_dataframe to InferenceData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.x.x Unreleased
 ### New features
+* Added `to_dataframe` method to InferenceData ([1395](https://github.com/arviz-devs/arviz/pull/1395))
+* Added `__getitem__` magic to InferenceData ([1395](https://github.com/arviz-devs/arviz/pull/1395))
 
 ### Maintenance and fixes
 

--- a/arviz/data/base.py
+++ b/arviz/data/base.py
@@ -301,7 +301,7 @@ def _make_json_serializable(data: dict) -> dict:
     for key, value in data.items():
         try:
             json.dumps(value)
-        except TypeError:
+        except (TypeError, OverflowError):
             pass
         else:
             ret[key] = value

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -301,7 +301,7 @@ class InferenceData:
         ret = defaultdict(dict)
         attrs = None
         if self._groups_all:  # check's whether a group is present or not.
-            if groups is None or filter_groups is not None:
+            if groups is None:
                 groups = self._group_names(groups, filter_groups)
             else:
                 groups = [group for group in self._groups_all if group in groups]

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -453,7 +453,6 @@ class InferenceData:
         for group in groups:
             dataset = self[group]
             df = None
-            index_origin = 1
             coords_to_idx = {
                 name: dict(map(reversed, enumerate(dataset.coords[name].values, index_origin)))
                 for name in list(filter(lambda x: x not in ("chain", "draw"), dataset.coords))

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -190,6 +190,11 @@ class InferenceData:
         for group in self._groups_all:
             yield group
 
+    def __getitem__(self, key):
+        if key not in self._groups_all:
+            raise KeyError(key)
+        return getattr(self, key)
+
     def groups(self):
         """Return all groups present in InferenceData object."""
         return self._groups_all
@@ -278,7 +283,13 @@ class InferenceData:
         Parameters
         ----------
         groups : list, optional
-            Write only these groups to netcdf file.
+            Groups where the transformation is to be applied. Can either be group names
+            or metagroup names.
+        filter_groups: {None, "like", "regex"}, optional, default=None
+            If `None` (default), interpret groups as the real group or metagroup names.
+            If "like", interpret groups as substrings of the real group or metagroup names.
+            If "regex", interpret groups as regular expressions on the real group or
+            metagroup names. A la `pandas.filter`.
 
         Returns
         -------
@@ -289,7 +300,7 @@ class InferenceData:
         ret = defaultdict(dict)
         attrs = None
         if self._groups_all:  # check's whether a group is present or not.
-            if groups is None:
+            if groups is None or filter_groups is not None:
                 groups = self._group_names(groups, filter_groups)
             else:
                 groups = [group for group in self._groups_all if group in groups]
@@ -328,13 +339,21 @@ class InferenceData:
         ret["attrs"] = attrs
         return ret
 
-    def to_json(self, filename, **kwargs):
+    def to_json(self, filename, groups=None, filter_groups=None, **kwargs):
         """Write InferenceData to a json file.
 
         Parameters
         ----------
         filename : str
             Location to write to
+        groups : list, optional
+            Groups where the transformation is to be applied. Can either be group names
+            or metagroup names.
+        filter_groups: {None, "like", "regex"}, optional, default=None
+            If `None` (default), interpret groups as the real group or metagroup names.
+            If "like", interpret groups as substrings of the real group or metagroup names.
+            If "regex", interpret groups as regular expressions on the real group or
+            metagroup names. A la `pandas.filter`.
         kwargs : dict
             kwargs passed to json.dump()
 
@@ -343,12 +362,150 @@ class InferenceData:
         str
             Location of json file
         """
-        idata_dict = _make_json_serializable(self.to_dict())
+        idata_dict = _make_json_serializable(
+            self.to_dict(groups=groups, filter_groups=filter_groups)
+        )
 
         with open(filename, "w") as file:
             json.dump(idata_dict, file, **kwargs)
 
         return filename
+
+    def to_dataframe(
+        self,
+        groups=None,
+        filter_groups=None,
+        include_coords=True,
+        include_index=True,
+        index_origin=0,
+    ):
+        """Convert InferenceData to a pandas DataFrame following xarray naming conventions.
+
+        This returns dataframe in a "wide" -format, where each item in ndimensional array is
+        unpacked. To access "tidy" -format, use xarray functionality found for each dataset.
+
+        In case of a duplicate keys when combining multiple groups, function adds
+        group identification to the var name.
+
+        Parameters
+        ----------
+        groups: str or list of str, optional
+            Groups where the transformation is to be applied. Can either be group names
+            or metagroup names.
+        filter_groups: {None, "like", "regex"}, optional, default=None
+            If `None` (default), interpret groups as the real group or metagroup names.
+            If "like", interpret groups as substrings of the real group or metagroup names.
+            If "regex", interpret groups as regular expressions on the real group or
+            metagroup names. A la `pandas.filter`.
+        include_coords: bool
+            Add coordinate values to column name (tuple).
+        include_index: bool
+            Add index information for multidimensional arrays.
+        index_origin: {0, 1}
+            Starting index  for multidimensional objects. 0- or 1-based.
+
+        Returns
+        -------
+        pandas.DataFrame
+            A pandas DataFrame containing all selected groups of InferenceData object.
+        """
+        # pylint: disable=too-many-nested-blocks
+        if not include_coords and not include_index:
+            raise TypeError("Both include_coords and include_index can not be False.")
+        if index_origin not in [0, 1]:
+            raise TypeError(f"index_origin must be 0 or 1, saw {index_origin}")
+        if groups is None:
+            groups = list(filter(lambda x: "data" not in x, self._groups_all))
+        elif groups == "posterior_groups":
+            groups = [
+                group
+                for group in (
+                    "posterior",
+                    "posterior_predictive",
+                    "predictions",
+                    "log_likelihood",
+                    "sample_stats",
+                )
+                if group in self._groups_all
+            ]
+        elif groups == "prior_groups":
+            groups = [
+                group
+                for group in ("prior", "prior_predictive", "sample_stats_prior")
+                if group in self._groups_all
+            ]
+
+        if isinstance(groups, str):
+            groups = list(
+                filter(lambda x: "data" not in x, self._group_names(groups, filter_groups))
+            )
+
+        if any(
+            group in ["observed_data", "constant_data", "predictions_constant_data"]
+            for group in groups
+        ):
+            raise ValueError("Cannot transform data groups to dataframe")
+
+        if not all(group in self._groups_all for group in groups):
+            raise ValueError(f"Invalid groups: {[g for g in group if g not in self._groups_all]}")
+
+        dfs = {}
+        for group in groups:
+            dataset = self[group]
+            df = None
+            index_origin = 1
+            coords_to_idx = {
+                name: dict(map(reversed, enumerate(dataset.coords[name].values, index_origin)))
+                for name in list(filter(lambda x: x not in ("chain", "draw"), dataset.coords))
+            }
+            for data_array in dataset.values():
+                dataframe = data_array.to_dataframe()
+                if list(filter(lambda x: x not in ("chain", "draw"), data_array.dims)):
+                    levels = [
+                        idx
+                        for idx, dim in enumerate(data_array.dims)
+                        if dim not in set(["chain", "draw"])
+                    ]
+                    dataframe = dataframe.unstack(level=levels)
+                    tuple_columns = []
+                    for name, *coords in dataframe.columns:
+                        if include_index:
+                            idxs = []
+                            for coordname, coorditem in zip(dataframe.columns.names[1:], coords):
+                                idxs.append(coords_to_idx[coordname][coorditem])
+                            if include_coords:
+                                tuple_columns.append(
+                                    (f"{name}[{','.join(map(str, idxs))}]", *coords)
+                                )
+                            else:
+                                tuple_columns.append(f"{name}[{','.join(map(str, idxs))}]")
+                        else:
+                            tuple_columns.append((name, *coords))
+
+                    dataframe.columns = tuple_columns
+                    dataframe.sort_index(axis=1, inplace=True)
+                if df is None:
+                    df = dataframe
+                    continue
+                df = df.join(dataframe, how="outer")
+            df = df.reset_index()
+            dfs[group] = df
+        if len(dfs) > 1:
+            for group, df in dfs.items():
+                df.columns = [
+                    col
+                    if col in ("draw", "chain")
+                    else (group, col)
+                    if not isinstance(col, tuple)
+                    else (group, *col)
+                    for col in df.columns
+                ]
+            dfs, *dfs_tail = list(dfs.values())
+            for df in dfs_tail:
+                dfs = dfs.merge(df, how="outer", copy=False)
+        else:
+            (dfs,) = dfs.values()
+        return dfs
 
     def __add__(self, other):
         """Concatenate two InferenceData objects."""

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -191,6 +191,7 @@ class InferenceData:
             yield group
 
     def __getitem__(self, key):
+        """Get item by key."""
         if key not in self._groups_all:
             raise KeyError(key)
         return getattr(self, key)
@@ -413,7 +414,7 @@ class InferenceData:
         if not include_coords and not include_index:
             raise TypeError("Both include_coords and include_index can not be False.")
         if index_origin not in [0, 1]:
-            raise TypeError(f"index_origin must be 0 or 1, saw {index_origin}")
+            raise TypeError("index_origin must be 0 or 1, saw {}".format(index_origin))
         if groups is None:
             groups = list(filter(lambda x: "data" not in x, self._groups_all))
         elif groups == "posterior_groups":
@@ -447,7 +448,11 @@ class InferenceData:
             raise ValueError("Cannot transform data groups to dataframe")
 
         if not all(group in self._groups_all for group in groups):
-            raise ValueError(f"Invalid groups: {[g for g in group if g not in self._groups_all]}")
+            raise ValueError(
+                "Invalid groups: {}".format(
+                    [group for group in groups if group in self._groups_all]
+                )
+            )
 
         dfs = {}
         for group in groups:
@@ -474,10 +479,12 @@ class InferenceData:
                                 idxs.append(coords_to_idx[coordname][coorditem])
                             if include_coords:
                                 tuple_columns.append(
-                                    (f"{name}[{','.join(map(str, idxs))}]", *coords)
+                                    ("{}[{}]".format(name, ",".join(map(str, idxs))), *coords)
                                 )
                             else:
-                                tuple_columns.append(f"{name}[{','.join(map(str, idxs))}]")
+                                tuple_columns.append(
+                                    "{}[{}]".format(name, ",".join(map(str, idxs)))
+                                )
                         else:
                             tuple_columns.append((name, *coords))
 

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -385,8 +385,10 @@ class InferenceData:
         This returns dataframe in a "wide" -format, where each item in ndimensional array is
         unpacked. To access "tidy" -format, use xarray functionality found for each dataset.
 
-        In case of a duplicate keys when combining multiple groups, function adds
-        group identification to the var name.
+        In case of a multiple groups, function adds a group identification to the var name.
+
+        Data groups ("observed_data", "constant_data", "predictions_constant_data") are
+        skipped implicitly.
 
         Parameters
         ----------
@@ -476,8 +478,10 @@ class InferenceData:
             dfs, *dfs_tail = list(dfs.values())
             for df in dfs_tail:
                 dfs = dfs.merge(df, how="outer", copy=False)
-        else:
+        elif len(dfs) == 1:
             (dfs,) = dfs.values()
+        else:
+            dfs = pd.DataFrame()
         return dfs
 
     def __add__(self, other):

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -418,44 +418,8 @@ class InferenceData:
             index_origin = rcParams["data.index_origin"]
         if index_origin not in [0, 1]:
             raise TypeError("index_origin must be 0 or 1, saw {}".format(index_origin))
-        if groups is None:
-            groups = list(filter(lambda x: "data" not in x, self._groups_all))
-        elif groups == "posterior_groups":
-            groups = [
-                group
-                for group in (
-                    "posterior",
-                    "posterior_predictive",
-                    "predictions",
-                    "log_likelihood",
-                    "sample_stats",
-                )
-                if group in self._groups_all
-            ]
-        elif groups == "prior_groups":
-            groups = [
-                group
-                for group in ("prior", "prior_predictive", "sample_stats_prior")
-                if group in self._groups_all
-            ]
 
-        if isinstance(groups, str):
-            groups = list(
-                filter(lambda x: "data" not in x, self._group_names(groups, filter_groups))
-            )
-
-        if any(
-            group in ["observed_data", "constant_data", "predictions_constant_data"]
-            for group in groups
-        ):
-            raise ValueError("Cannot transform data groups to dataframe")
-
-        if not all(group in self._groups_all for group in groups):
-            raise ValueError(
-                "Invalid groups: {}".format(
-                    [group for group in groups if group in self._groups_all]
-                )
-            )
+        groups = list(filter(lambda x: "data" not in x, self._group_names(groups, filter_groups)))
 
         dfs = {}
         for group in groups:
@@ -471,7 +435,7 @@ class InferenceData:
                     levels = [
                         idx
                         for idx, dim in enumerate(data_array.dims)
-                        if dim not in set(["chain", "draw"])
+                        if dim not in ("chain", "draw")
                     ]
                     dataframe = dataframe.unstack(level=levels)
                     tuple_columns = []

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -378,7 +378,7 @@ class InferenceData:
         filter_groups=None,
         include_coords=True,
         include_index=True,
-        index_origin=0,
+        index_origin=None,
     ):
         """Convert InferenceData to a pandas DataFrame following xarray naming conventions.
 
@@ -402,8 +402,9 @@ class InferenceData:
             Add coordinate values to column name (tuple).
         include_index: bool
             Add index information for multidimensional arrays.
-        index_origin: {0, 1}
+        index_origin: {0, 1}, optional
             Starting index  for multidimensional objects. 0- or 1-based.
+            Defaults to rcParams["data.index_origin"].
 
         Returns
         -------
@@ -413,6 +414,8 @@ class InferenceData:
         # pylint: disable=too-many-nested-blocks
         if not include_coords and not include_index:
             raise TypeError("Both include_coords and include_index can not be False.")
+        if index_origin is None:
+            index_origin = rcParams["data.index_origin"]
         if index_origin not in [0, 1]:
             raise TypeError("index_origin must be 0 or 1, saw {}".format(index_origin))
         if groups is None:

--- a/arviz/tests/base_tests/test_data.py
+++ b/arviz/tests/base_tests/test_data.py
@@ -587,7 +587,7 @@ class TestInferenceData:  # pylint: disable=too-many-public-methods
             ]
         )
         test_data = from_dict(**idata.to_dict(), save_warmup=True)
-        assert not test_data
+        assert test_data
         for group in idata._groups_all:  # pylint: disable=protected-access
             xr_data = getattr(idata, group)
             test_xr_data = getattr(test_data, group)

--- a/arviz/tests/base_tests/test_data.py
+++ b/arviz/tests/base_tests/test_data.py
@@ -624,7 +624,7 @@ class TestInferenceData:  # pylint: disable=too-many-public-methods
         )
         test_data = idata.to_dataframe(**kwargs)
         assert not test_data.empty
-        groups = kwargs.get("groups", idata._groups_all)
+        groups = kwargs.get("groups", idata._groups_all)  # pylint: disable=protected-access
         for group in idata._groups_all:  # pylint: disable=protected-access
             if "data" in group:
                 continue

--- a/arviz/tests/base_tests/test_data.py
+++ b/arviz/tests/base_tests/test_data.py
@@ -587,7 +587,7 @@ class TestInferenceData:  # pylint: disable=too-many-public-methods
             ]
         )
         test_data = from_dict(**idata.to_dict(), save_warmup=True)
-        assert not test_data.empty
+        assert not test_data
         for group in idata._groups_all:  # pylint: disable=protected-access
             xr_data = getattr(idata, group)
             test_xr_data = getattr(test_data, group)

--- a/arviz/tests/base_tests/test_data.py
+++ b/arviz/tests/base_tests/test_data.py
@@ -664,7 +664,8 @@ class TestInferenceData:  # pylint: disable=too-many-public-methods
         with pytest.raises(TypeError):
             idata.to_dataframe(include_coords=False, include_index=False)
 
-        assert idata.to_dataframe(groups=["observed_data"]).empty
+        with pytest.raises(TypeError):
+            idata.to_dataframe(groups=["observed_data"])
 
         with pytest.raises(KeyError):
             idata.to_dataframe(groups=["invalid_group"])

--- a/arviz/tests/base_tests/test_data.py
+++ b/arviz/tests/base_tests/test_data.py
@@ -664,10 +664,9 @@ class TestInferenceData:  # pylint: disable=too-many-public-methods
         with pytest.raises(TypeError):
             idata.to_dataframe(include_coords=False, include_index=False)
 
-        with pytest.raises(ValueError):
-            idata.to_dataframe(groups=["observed_data"])
+        assert idata.to_dataframe(groups=["observed_data"]).empty
 
-        with pytest.raises(ValueError):
+        with pytest.raises(KeyError):
             idata.to_dataframe(groups=["invalid_group"])
 
     @pytest.mark.parametrize("use", (None, "args", "kwargs"))


### PR DESCRIPTION
## Description

Add `.to_dataframe` function to InferenceData. The result is a dataframe in a "wide" format.

This PR also adds `__getitem__` magic for the InferenceData.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [ ] New features are properly documented (with an example if appropriate)?
- [x] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)

![image](https://user-images.githubusercontent.com/13161958/94323238-acaa1f00-ff9d-11ea-8d25-7ed9a31a340c.png)

![image](https://user-images.githubusercontent.com/13161958/94323269-c5b2d000-ff9d-11ea-8435-75c82f3da8bf.png)

![image](https://user-images.githubusercontent.com/13161958/94323301-e0854480-ff9d-11ea-92ce-833204e2582c.png)

![image](https://user-images.githubusercontent.com/13161958/94323327-014d9a00-ff9e-11ea-9f8f-cbf7877a1cb6.png)

![image](https://user-images.githubusercontent.com/13161958/94323351-1c200e80-ff9e-11ea-9281-72dd866deab1.png)
