### PR TITLE
Add missing type hint imports, as suggested by mypy.

### DIFF
--- a/arviz/data/io_numpyro.py
+++ b/arviz/data/io_numpyro.py
@@ -1,6 +1,6 @@
 """NumPyro-specific conversion code."""
 import logging
-from typing import Optional
+from typing import Callable, Optional
 
 import numpy as np
 import xarray as xr
@@ -17,7 +17,7 @@ class NumPyroConverter:
 
     # pylint: disable=too-many-instance-attributes
 
-    model = None  # type: Optional[callable]
+    model = None  # type: Optional[Callable]
     nchains = None  # type: int
     ndraws = None  # type: int
 

--- a/arviz/data/io_numpyro.py
+++ b/arviz/data/io_numpyro.py
@@ -1,5 +1,6 @@
 """NumPyro-specific conversion code."""
 import logging
+from typing import Optional
 
 import numpy as np
 import xarray as xr

--- a/arviz/data/io_pyro.py
+++ b/arviz/data/io_pyro.py
@@ -1,6 +1,6 @@
 """Pyro-specific conversion code."""
 import logging
-from typing import Optional
+from typing import Callable, Optional
 import warnings
 
 import numpy as np
@@ -19,7 +19,7 @@ class PyroConverter:
 
     # pylint: disable=too-many-instance-attributes
 
-    model = None  # type: Optional[callable]
+    model = None  # type: Optional[Callable]
     nchains = None  # type: int
     ndraws = None  # type: int
 

--- a/arviz/data/io_pyro.py
+++ b/arviz/data/io_pyro.py
@@ -1,5 +1,6 @@
 """Pyro-specific conversion code."""
 import logging
+from typing import Optional
 import warnings
 
 import numpy as np

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -4,7 +4,7 @@ import logging
 import warnings
 from collections import OrderedDict
 from copy import deepcopy
-from typing import List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
A few minor fixes for type hint issues reported by mypy:
```
arviz/stats/stats.py:1133: error: Name 'Dict' is not defined
arviz/stats/stats.py:1133: note: Did you forget to import it from "typing"? (Suggestion: "from typing import Dict")
arviz/data/io_pyro.py:21: error: Name 'Optional' is not defined
arviz/data/io_pyro.py:21: note: Did you forget to import it from "typing"? (Suggestion: "from typing import Optional")
arviz/data/io_numpyro.py:19: error: Name 'Optional' is not defined
arviz/data/io_numpyro.py:19: note: Did you forget to import it from "typing"? (Suggestion: "from typing import Optional")
```

I also replaced use of `builtins.callable` with `typing.Callable` in type hints since `mypy` doesn't consider the lowercase version a valid type:
```
arviz/data/io_pyro.py:22: error: Function "builtins.callable" is not valid as a type
arviz/data/io_pyro.py:22: note: Perhaps you need "Callable[...]" or a callback protocol?
```

Unfortunately, this isn't a comprehensive set of type hint fixes -- `mypy` is still quite unhappy even with these changes applied. I just figured something is better than nothing 😃 