### PR TITLE
Pass bool instead of int values to pytest.mark.skipif

### DIFF
--- a/arviz/tests/base_tests/test_diagnostics_numba.py
+++ b/arviz/tests/base_tests/test_diagnostics_numba.py
@@ -14,7 +14,7 @@ from ..helpers import running_on_ci
 from .test_diagnostics import data  # pylint: disable=unused-import
 
 pytestmark = pytest.mark.skipif(  # pylint: disable=invalid-name
-    (importlib.util.find_spec("numba") is None) & ~running_on_ci(),
+    (importlib.util.find_spec("numba") is None) and not running_on_ci(),
     reason="test requires numba which is not installed",
 )
 

--- a/arviz/tests/base_tests/test_plot_utils.py
+++ b/arviz/tests/base_tests/test_plot_utils.py
@@ -23,6 +23,10 @@ from ...utils import get_coords
 from ..helpers import running_on_ci
 
 
+# Check if Bokeh is installed
+bokeh_installed = importlib.util.find_spec("bokeh") is not None  # pylint: disable=invalid-name
+
+
 @pytest.mark.parametrize(
     "value, default, expected",
     [
@@ -200,7 +204,7 @@ def test_filter_plotter_list_warning():
 
 
 @pytest.mark.skipif(
-    (importlib.util.find_spec("bokeh") is None) & ~running_on_ci(),
+    not (bokeh_installed or running_on_ci()),
     reason="test requires bokeh which is not installed",
 )
 def test_bokeh_import():
@@ -278,7 +282,7 @@ def test_mpl_dealiase_sel_kwargs():
 
 
 @pytest.mark.skipif(
-    (importlib.util.find_spec("bokeh") is None) & ~running_on_ci(),
+    not (bokeh_installed or running_on_ci()),
     reason="test requires bokeh which is not installed",
 )
 def test_bokeh_dealiase_sel_kwargs():
@@ -302,12 +306,8 @@ def test_bokeh_dealiase_sel_kwargs():
     assert res["line_color"] == "red"
 
 
-# Check if Bokeh is installed
-bokeh_installed = importlib.util.find_spec("bokeh") is not None  # pylint: disable=invalid-name
-
-
 @pytest.mark.skipif(
-    not (bokeh_installed | running_on_ci()),
+    not (bokeh_installed or running_on_ci()),
     reason="test requires bokeh which is not installed",
 )
 def test_set_bokeh_circular_ticks_labels():

--- a/arviz/tests/base_tests/test_stats_numba.py
+++ b/arviz/tests/base_tests/test_stats_numba.py
@@ -15,7 +15,7 @@ from ..helpers import (  # pylint: disable=unused-import
 from .test_stats import centered_eight, non_centered_eight  # pylint: disable=unused-import
 
 pytestmark = pytest.mark.skipif(  # pylint: disable=invalid-name
-    (importlib.util.find_spec("numba") is None) & ~running_on_ci(),
+    (importlib.util.find_spec("numba") is None) and not running_on_ci(),
     reason="test requires numba which is not installed",
 )
 

--- a/arviz/tests/base_tests/test_utils_numba.py
+++ b/arviz/tests/base_tests/test_utils_numba.py
@@ -12,7 +12,7 @@ from ..helpers import running_on_ci
 from .test_utils import utils_with_numba_import_fail  # pylint: disable=unused-import
 
 pytestmark = pytest.mark.skipif(  # pylint: disable=invalid-name
-    (importlib.util.find_spec("numba") is None) & ~running_on_ci(),
+    (importlib.util.find_spec("numba") is None) and not running_on_ci(),
     reason="test requires numba which is not installed",
 )
 


### PR DESCRIPTION
Resolves the following type errors that mypy points out:
```
arviz/tests/base_tests/test_utils_numba.py:15: error: Argument 1 to "__call__" of "_SkipifMarkDecorator" has incompatible type "int"; expected "Union[str, bool]"  [arg-type]
arviz/tests/base_tests/test_plot_utils.py:203: error: Argument 1 to "__call__" of "_SkipifMarkDecorator" has incompatible type "int"; expected "Union[str, bool]"  [arg-type]
arviz/tests/base_tests/test_plot_utils.py:281: error: Argument 1 to "__call__" of "_SkipifMarkDecorator" has incompatible type "int"; expected "Union[str, bool]"  [arg-type]
arviz/tests/base_tests/test_diagnostics_numba.py:17: error: Argument 1 to "__call__" of "_SkipifMarkDecorator" has incompatible type "int"; expected "Union[str, bool]"  [arg-type]
arviz/tests/base_tests/test_stats_numba.py:18: error: Argument 1 to "__call__" of "_SkipifMarkDecorator" has incompatible type "int"; expected "Union[str, bool]"  [arg-type]
```