### PR TITLE
Allow passing a single variable to plot_density with bokeh backend

### DIFF
--- a/arviz/plots/backends/bokeh/densityplot.py
+++ b/arviz/plots/backends/bokeh/densityplot.py
@@ -63,7 +63,7 @@ def plot_density(
             rows,
             cols,
             figsize=figsize,
-            squeeze=True,
+            squeeze=False,
             backend_kwargs=backend_kwargs,
         )
     else:

--- a/arviz/tests/base_tests/test_plots_bokeh.py
+++ b/arviz/tests/base_tests/test_plots_bokeh.py
@@ -112,7 +112,7 @@ def test_plot_density_no_subset():
             "c": np.random.normal(size=200),
         }
     )
-    axes = plot_density([model_ab, model_bc])
+    axes = plot_density([model_ab, model_bc], backend="bokeh", show=False)
     assert axes.size == 3
 
 

--- a/arviz/tests/base_tests/test_plots_bokeh.py
+++ b/arviz/tests/base_tests/test_plots_bokeh.py
@@ -116,6 +116,22 @@ def test_plot_density_no_subset():
     assert axes.size == 3
 
 
+def test_plot_density_one_var():
+    """Test plot_density works when there is only one variable (#1401)."""
+    model_ab = from_dict(
+        {
+            "a": np.random.normal(size=200),
+        }
+    )
+    model_bc = from_dict(
+        {
+            "a": np.random.normal(size=200),
+        }
+    )
+    axes = plot_density([model_ab, model_bc], backend="bokeh", show=False)
+    assert axes.size == 1
+
+
 def test_plot_density_bad_kwargs(models):
     obj = [getattr(models, model_fit) for model_fit in ["model_1", "model_2"]]
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Description
This PR resolves #1401 by removing the `squeeze=True` call to `create_axes_grid` within `plot_density` with the bokeh backend, which is contradicted by the later use of `.flatten`. It also adds missing `backend="bokeh"` kwarg to another bokeh test.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)