### PR TITLE
Prevent wrapping group names in InferenceData HTML repr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added `__getitem__` magic to InferenceData ([1395](https://github.com/arviz-devs/arviz/pull/1395))
 
 ### Maintenance and fixes
+* prevent wrapping group names in InferenceData repr_html ([1407](https://github.com/arviz-devs/arviz/pull/1407))
 
 ### Deprecation
 

--- a/arviz/static/css/style.css
+++ b/arviz/static/css/style.css
@@ -66,6 +66,10 @@ body.vscode-dark {
   grid-template-columns: 150px auto auto 1fr 20px 20px;
 }
 
+.xr-sections.group-sections {
+  grid-template-columns: auto;
+}
+
 .xr-section-item {
   display: contents;
 }

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -691,7 +691,7 @@ class HtmlTemplate:
               <div class='xr-header'>
                 <div class="xr-obj-type">arviz.InferenceData</div>
               </div>
-              <ul class="xr-sections">
+              <ul class="xr-sections group-sections">
               {}
               </ul>
             </div>


### PR DESCRIPTION
## Description

The HTML repr for `InferenceData` reuses some of the classes of xarray's HTML repr for `xarray.Dataset`.
The `xr-sections` class determines the grid layout of the list of sections in the `Dataset` repr. However, the same class is applied to the list of groups in the `InferenceData` repr. The result is that the same grid layout is applied to both (note that the left-most and two right-most columns are the same width):
![Screen Shot 2020-10-04 at 8 50 36 PM](https://user-images.githubusercontent.com/8673634/95040126-9ed45800-0687-11eb-87af-f81b7b515577.png)
This isn't a problem in the arviz docs or Jupyter notebooks with the default theme, but a different Jupyter theme is used or the `InferenceData` HTML repr is used in a different page, then if the font size is too large, the group names can exceed the fixed width of the grid. This happens in the [ArviZ.jl docs](https://arviz-devs.github.io/ArviZ.jl/v0.4.5/quickstart/#Plotting-with-CmdStan.jl-outputs), because they use a different font size than the arviz docs (thanks to @ColCarroll for pointing that out!)
![Screen Shot 2020-10-04 at 9 05 25 PM](https://user-images.githubusercontent.com/8673634/95040392-5f5a3b80-0688-11eb-98e5-f647e921eac4.png)

This PR adds a `group-sections` subclass to `xr-sections` that is used for the groups list, and in the CSS resets the grid for just that list while keeping all other CSS attributes. The result is that only the grid is changed:
![Screen Shot 2020-10-04 at 8 53 33 PM](https://user-images.githubusercontent.com/8673634/95040504-b3fdb680-0688-11eb-8874-b067b3898a93.png)

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Includes new or updated tests to cover the new feature
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)