### PR TITLE
remove default scale warning in compare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * prevent wrapping group names in InferenceData repr_html ([1407](https://github.com/arviz-devs/arviz/pull/1407))
 * Updated CmdStanPy interface ([1409](https://github.com/arviz-devs/arviz/pull/1409))
 * prevent wrapping group names in InferenceData repr_html ([1407](https://github.com/arviz-devs/arviz/pull/1407))
+* Remove left out warning about default IC scale in `compare` ([1412](https://github.com/arviz-devs/arviz/pull/1412))
 
 ### Deprecation
 

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -146,12 +146,6 @@ def compare(
     if scale == "log":
         scale_value = 1
         ascending = False
-        warnings.warn(
-            "\nThe scale is now log by default. Use 'scale' argument or "
-            "'stats.ic_scale' rcParam if you rely on a specific value.\nA higher "
-            "log-score (or a lower deviance) indicates a model with better predictive "
-            "accuracy."
-        )
     else:
         if scale == "negative_log":
             scale_value = -1


### PR DESCRIPTION
loo and waic had it removed already IIRC

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/master/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
