### PR TITLE
json dump nested dicts and lists attrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Remove left out warning about default IC scale in `compare` ([1412](https://github.com/arviz-devs/arviz/pull/1412))
 * Fixed a typo found in an error message raised in `distplot.py` ([1414](https://github.com/arviz-devs/arviz/pull/1414))
 * Fix typo in `loo_pit` extraction of log likelihood ([1418](https://github.com/arviz-devs/arviz/pull/1418))
+* Have `from_pystan` store attrs as strings to allow netCDF storage ([1417](https://github.com/arviz-devs/arviz/pull/1417))
 
 ### Deprecation
 

--- a/arviz/data/io_pystan.py
+++ b/arviz/data/io_pystan.py
@@ -19,6 +19,7 @@ except ImportError:
     # Can't find ujson using json
     import json
 
+
 class PyStanConverter:
     """Encapsulate PyStan specific logic."""
 

--- a/arviz/data/io_pystan.py
+++ b/arviz/data/io_pystan.py
@@ -708,13 +708,13 @@ def get_attrs(fit):
                     list(map(float, item.split(",")))
                     for item in re.sub(r"#\s", "", inv_metric_str).splitlines()
                 ]
-            inv_metric = json.dumps(inv_metric)
         else:
             metric = "unit_e"
             inv_metric = None
 
         attrs["metric"].append(metric)
         attrs["inv_metric"].append(inv_metric)
+    attrs["inv_metric"] = json.dumps(attrs["inv_metric"])
 
     if not attrs["step_size"]:
         del attrs["step_size"]


### PR DESCRIPTION
## Description
I have had some problems when saving to netcdf with the new extended attrs, seems related to https://github.com/pydata/xarray/issues/2868. This uses json.dumps to convert the nested objects to strings that can be stored in netcdf and if necessary recovered by parsing the json again.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Includes new or updated tests to cover the new feature. Should there be a writing test in test_pystan?
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/master/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
