### PR TITLE
fix typo in loo_pit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@
 
 ### Maintenance and fixes
 * prevent wrapping group names in InferenceData repr_html ([1407](https://github.com/arviz-devs/arviz/pull/1407))
-* Updated CmdStanPy interface ([1409](https://github.com/arviz-devs/arviz/pull/1409) and [1416](https://github.com/arviz-devs/arviz/pull/1416))
-* prevent wrapping group names in InferenceData repr_html ([1407](https://github.com/arviz-devs/arviz/pull/1407))
 * Updated CmdStanPy interface ([1409](https://github.com/arviz-devs/arviz/pull/1409))
 * Remove left out warning about default IC scale in `compare` ([1412](https://github.com/arviz-devs/arviz/pull/1412))
 * Fixed a typo found in an error message raised in `distplot.py` ([1414](https://github.com/arviz-devs/arviz/pull/1414))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@
 * prevent wrapping group names in InferenceData repr_html ([1407](https://github.com/arviz-devs/arviz/pull/1407))
 * Updated CmdStanPy interface ([1409](https://github.com/arviz-devs/arviz/pull/1409) and [1416](https://github.com/arviz-devs/arviz/pull/1416))
 * prevent wrapping group names in InferenceData repr_html ([1407](https://github.com/arviz-devs/arviz/pull/1407))
+* Updated CmdStanPy interface ([1409](https://github.com/arviz-devs/arviz/pull/1409))
 * Remove left out warning about default IC scale in `compare` ([1412](https://github.com/arviz-devs/arviz/pull/1412))
 * Fixed a typo found in an error message raised in `distplot.py` ([1414](https://github.com/arviz-devs/arviz/pull/1414))
+* Fix typo in `loo_pit` extraction of log likelihood ([1418](https://github.com/arviz-devs/arviz/pull/1418))
 
 ### Deprecation
 

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -1585,7 +1585,7 @@ def loo_pit(idata=None, *, y=None, y_hat=None, log_weights=None):
         if log_weights is None:
             if y_str:
                 try:
-                    log_likelihood = _get_log_likelihood(idata, var_name=y)
+                    log_likelihood = _get_log_likelihood(idata, var_name=y_str)
                 except TypeError:
                     log_likelihood = _get_log_likelihood(idata)
             else:

--- a/arviz/tests/base_tests/test_stats.py
+++ b/arviz/tests/base_tests/test_stats.py
@@ -586,11 +586,12 @@ def test_loo_pit_multidim(multidim_models, args):
         loo_pit_data = loo_pit(idata=None, y=y_arr, y_hat=y_hat_arr, log_weights=log_weights_arr)
     assert np.all((loo_pit_data >= 0) & (loo_pit_data <= 1))
 
+
 def test_loo_pit_multi_lik():
     idata = load_arviz_data("radon")
-    idata.log_likelihood["by_county"] = idata.log_likelihood["y"].groupby(
-        idata.constant_data["county_idx"]
-    ).sum()
+    idata.log_likelihood["by_county"] = (
+        idata.log_likelihood["y"].groupby(idata.constant_data["county_idx"]).sum()
+    )
     loo_pit_data = loo_pit(idata, y="y")
     assert np.all((loo_pit_data >= 0) & (loo_pit_data <= 1))
 

--- a/arviz/tests/base_tests/test_stats.py
+++ b/arviz/tests/base_tests/test_stats.py
@@ -586,6 +586,14 @@ def test_loo_pit_multidim(multidim_models, args):
         loo_pit_data = loo_pit(idata=None, y=y_arr, y_hat=y_hat_arr, log_weights=log_weights_arr)
     assert np.all((loo_pit_data >= 0) & (loo_pit_data <= 1))
 
+def test_loo_pit_multi_lik():
+    idata = load_arviz_data("radon")
+    idata.log_likelihood["by_county"] = idata.log_likelihood["y"].groupby(
+        idata.constant_data["county_idx"]
+    ).sum()
+    loo_pit_data = loo_pit(idata, y="y")
+    assert np.all((loo_pit_data >= 0) & (loo_pit_data <= 1))
+
 
 @pytest.mark.parametrize("input_type", ["idataarray", "idatanone_ystr", "yarr_yhatnone"])
 def test_loo_pit_bad_input(centered_eight, input_type):


### PR DESCRIPTION
## Description
There is a clause of `if y_str` to use `var_name` when getting the log_likelihood that corresponds to the observations but then uses `y` as `var_name` instead of `y_str`.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/master/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
