### PR TITLE
violinplot remove ticks and spines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fixed a typo found in an error message raised in `distplot.py` ([1414](https://github.com/arviz-devs/arviz/pull/1414))
 * Fix typo in `loo_pit` extraction of log likelihood ([1418](https://github.com/arviz-devs/arviz/pull/1418))
 * Have `from_pystan` store attrs as strings to allow netCDF storage ([1417](https://github.com/arviz-devs/arviz/pull/1417))
+* Remove ticks and spines in `plot_violin`  ([1426 ](https://github.com/arviz-devs/arviz/pull/1426))
 
 ### Deprecation
 

--- a/arviz/plots/backends/bokeh/violinplot.py
+++ b/arviz/plots/backends/bokeh/violinplot.py
@@ -4,7 +4,7 @@ from bokeh.models.annotations import Title
 
 from ....stats import hdi
 from ....stats.density_utils import get_bins, histogram, kde
-from ...plot_utils import _scale_fig_size, make_label
+from ...plot_utils import _scale_fig_size, make_label, vectorized_to_hex
 from .. import show_layout
 from . import backend_kwarg_defaults, create_axes_grid
 
@@ -42,6 +42,7 @@ def plot_violin(
     (figsize, *_, linewidth, _) = _scale_fig_size(figsize, textsize, rows, cols)
 
     shade_kwargs = {} if shade_kwargs is None else shade_kwargs
+    shade_kwargs["color"] = vectorized_to_hex(shade_kwargs["color"])
     rug_kwargs = {} if rug_kwargs is None else rug_kwargs
     rug_kwargs.setdefault("fill_alpha", 0.1)
     rug_kwargs.setdefault("line_alpha", 0.1)

--- a/arviz/plots/backends/bokeh/violinplot.py
+++ b/arviz/plots/backends/bokeh/violinplot.py
@@ -42,7 +42,6 @@ def plot_violin(
     (figsize, *_, linewidth, _) = _scale_fig_size(figsize, textsize, rows, cols)
 
     shade_kwargs = {} if shade_kwargs is None else shade_kwargs
-    shade_kwargs["color"] = vectorized_to_hex(shade_kwargs["color"])
     rug_kwargs = {} if rug_kwargs is None else rug_kwargs
     rug_kwargs.setdefault("fill_alpha", 0.1)
     rug_kwargs.setdefault("line_alpha", 0.1)

--- a/arviz/plots/backends/bokeh/violinplot.py
+++ b/arviz/plots/backends/bokeh/violinplot.py
@@ -58,6 +58,7 @@ def plot_violin(
     else:
         ax = np.atleast_2d(ax)
 
+    current_col = 0
     for (var_name, selection, x), ax_ in zip(
         plotters, (item for item in ax.flatten() if item is not None)
     ):
@@ -89,11 +90,21 @@ def plot_violin(
         )
 
         _title = Title()
+        _title.align = "center"
         _title.text = make_label(var_name, selection)
         ax_.title = _title
         ax_.xaxis.major_tick_line_color = None
         ax_.xaxis.minor_tick_line_color = None
         ax_.xaxis.major_label_text_font_size = "0pt"
+        if current_col != 0:
+            ax_.xaxis.major_label_text_font_size = "0pt"
+            ax_.yaxis.major_label_text_font_size = "0pt"
+            ax_.yaxis.major_tick_line_color = None
+            ax_.yaxis.minor_tick_line_color = None
+            ax_.yaxis.axis_line_color = None
+        current_col += 1
+        if current_col == cols:
+            current_col = 0
 
     show_layout(ax, show)
 

--- a/arviz/plots/backends/bokeh/violinplot.py
+++ b/arviz/plots/backends/bokeh/violinplot.py
@@ -4,7 +4,7 @@ from bokeh.models.annotations import Title
 
 from ....stats import hdi
 from ....stats.density_utils import get_bins, histogram, kde
-from ...plot_utils import _scale_fig_size, make_label, vectorized_to_hex
+from ...plot_utils import _scale_fig_size, make_label
 from .. import show_layout
 from . import backend_kwarg_defaults, create_axes_grid
 

--- a/arviz/plots/backends/matplotlib/violinplot.py
+++ b/arviz/plots/backends/matplotlib/violinplot.py
@@ -88,7 +88,7 @@ def plot_violin(
         ax_.tick_params(labelsize=xt_labelsize)
         ax_.grid(None, axis="x")
         if current_col != 0:
-            ax_.spines['left'].set_visible(False)
+            ax_.spines["left"].set_visible(False)
             ax_.yaxis.set_ticks_position("none")
         current_col += 1
         if current_col == cols:

--- a/arviz/plots/backends/matplotlib/violinplot.py
+++ b/arviz/plots/backends/matplotlib/violinplot.py
@@ -63,6 +63,7 @@ def plot_violin(
 
     ax = np.atleast_1d(ax)
 
+    current_col = 0
     for (var_name, selection, x), ax_ in zip(plotters, ax.flatten()):
         val = x.flatten()
         if val[0].dtype.kind == "i":
@@ -82,10 +83,16 @@ def plot_violin(
         ax_.plot([0, 0], hdi_probs, lw=linewidth, color="k", solid_capstyle="round")
         ax_.plot(0, per[-1], "wo", ms=linewidth * 1.5)
 
-        ax_.set_xlabel(make_label(var_name, selection), fontsize=ax_labelsize)
+        ax_.set_title(make_label(var_name, selection), fontsize=ax_labelsize)
         ax_.set_xticks([])
         ax_.tick_params(labelsize=xt_labelsize)
         ax_.grid(None, axis="x")
+        if current_col != 0:
+            ax_.spines['left'].set_visible(False)
+            ax_.yaxis.set_ticks_position("none")
+        current_col += 1
+        if current_col == cols:
+            current_col = 0
 
     if backend_show(show):
         plt.show()


### PR DESCRIPTION

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)

This was passing silently because with the default arviz styles plots are "despined" (or because nobody use `plot_violin`, haha)


Old matplotlib
![old_style](https://user-images.githubusercontent.com/1338958/96459651-bb7c9e00-11f8-11eb-8a0a-dc7f429dc4d4.png)


New matplotlib
![new_style](https://user-images.githubusercontent.com/1338958/96459839-f4b50e00-11f8-11eb-9a3b-c6f1b578e418.png)



Old bokeh
![bokeh_0](https://user-images.githubusercontent.com/1338958/96459686-c46d6f80-11f8-11eb-81a1-9b718ede8674.png)


New bokeh
![bokeh_new](https://user-images.githubusercontent.com/1338958/96459699-c7686000-11f8-11eb-8d50-381f5d69b9c9.png)


Still don't know how to remove the space between subplots in bokeh, @ahartikainen?