### PR TITLE
Documentation fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,8 @@ There are 4 main ways of contributing to the ArviZ project (in descending order 
 * Contributing or improving the documentation (`docs`) or examples (`arviz/examples`)
 * Submitting issues related to bugs or desired enhancements
 
+This doc plus extra guidance is also available on [ArviZ documentation](https://arviz-devs.github.io/arviz/contributing/index.html)
+
 # Opening issues
 
 We appreciate being notified of problems with the existing ArviZ code. We prefer that issues be filed the on [Github Issue Tracker](https://github.com/arviz-devs/arviz/issues), rather than on social media or by direct email to the developers.
@@ -80,7 +82,7 @@ If changes are made to a method documented in the
 [ArviZ API Guide](https://numpydoc.readthedocs.io/en/latest/format.html)
 please consider adding inline documentation examples.
 `az.plot_posterior` is a particularly
-[good example](https://arviz-devs.github.io/arviz/generated/arviz.plot_posterior.html#arviz.plot_posterior).
+[good example](https://arviz-devs.github.io/arviz/api/generated/arviz.plot_posterior.html#arviz.plot_posterior).
 
 
 ## Steps

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ ArviZ also has a Julia wrapper available [ArviZ.jl](https://arviz-devs.github.io
 ## Documentation
 
 The ArviZ documentation can be found in the [official docs](https://arviz-devs.github.io/arviz/index.html).
-First time users may find the [quickstart](https://arviz-devs.github.io/arviz/notebooks/Introduction.html)
+First time users may find the [quickstart](https://arviz-devs.github.io/arviz/getting_started/Introduction.html)
 to be helpful. Additional guidance can be found in the
 [usage documentation](https://arviz-devs.github.io/arviz/usage.html).
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -59,6 +59,7 @@ extensions = [
     "IPython.sphinxext.ipython_console_highlighting",
     "gallery_generator",
     "myst_nb",
+    'notfound.extension',
 ]
 
 # ipython directive configuration
@@ -153,6 +154,8 @@ html_static_path = ["_static", thumb_directory]
 html_additional_pages = {
     '404': '404.html',
 }
+# configure notfound extension to not add any prefix to the urls
+notfound_urls_prefix = "/arviz/"
 
 
 # -- Options for HTMLHelp output ------------------------------------------

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -7,3 +7,4 @@ pydata_sphinx_theme
 selenium
 myst-parser
 myst-nb
+sphinx-notfound-page


### PR DESCRIPTION
## Description
Currently the 404 page only works for pages on the base directory, i.e. https://arviz-devs.github.io/arviz/badpage.html looks great and links work, but https://arviz-devs.github.io/arviz/api/badpage.html does not. Not sure if this is the ideal way to do this, but it seems to work, at least partially. 

It also fixes a couple links that were broken due to the reorganization.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/master/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
