### PR TITLE
Fix labels and use circular KDE in plot_trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Fix typo in `loo_pit` extraction of log likelihood ([1418](https://github.com/arviz-devs/arviz/pull/1418))
 * Have `from_pystan` store attrs as strings to allow netCDF storage ([1417](https://github.com/arviz-devs/arviz/pull/1417))
 * Remove ticks and spines in `plot_violin`  ([1426 ](https://github.com/arviz-devs/arviz/pull/1426))
+* Use circular KDE function and fix tick labels in circular `plot_trace` ([1428](https://github.com/arviz-devs/arviz/pull/1428))
 
 ### Deprecation
 

--- a/arviz/plots/backends/matplotlib/kdeplot.py
+++ b/arviz/plots/backends/matplotlib/kdeplot.py
@@ -85,14 +85,14 @@ def plot_kde(
 
             if is_circular == "radians":
                 labels = [
-                    r"0",
-                    r"π/4",
-                    r"π/2",
-                    r"3π/4",
-                    r"π",
-                    r"5π/4",
-                    r"3π/2",
-                    r"7π/4",
+                    "0",
+                    f"{np.pi/4:.2f}",
+                    f"{np.pi/2:.2f}",
+                    f"{3*np.pi/4:.2f}",
+                    f"{np.pi:.2f}",
+                    f"{-3*np.pi/4:.2f}",
+                    f"{-np.pi/2:.2f}",
+                    f"{-np.pi/4:.2f}",
                 ]
 
                 ax.set_xticklabels(labels)
@@ -130,7 +130,7 @@ def plot_kde(
                 fill_x,
                 fill_y,
                 where=np.isin(fill_x, fill_x[idx], invert=True, assume_unique=True),
-                **fill_kwargs
+                **fill_kwargs,
             )
         else:
             fill_kwargs.setdefault("alpha", 0)

--- a/arviz/plots/backends/matplotlib/traceplot.py
+++ b/arviz/plots/backends/matplotlib/traceplot.py
@@ -467,9 +467,8 @@ def _plot_chains_mpl(
                 axes.plot(data.draw.values, row, **aux_kwargs)
                 if circ_units_trace == "degrees":
                     y_tick_locs = axes.get_yticks()
-                    y_tick_labels_deg = np.rad2deg(y_tick_locs)
-                    labels = [i + 2 * 180 if i < 0 else i for i in y_tick_labels_deg]
-                    axes.set_yticklabels([f"{i:.0f}°" for i in labels])
+                    y_tick_labels = [i + 2 * 180 if i < 0 else i for i in np.rad2deg(y_tick_locs)]
+                    axes.set_yticklabels([f"{i:.0f}°" for i in y_tick_labels])
 
         if not combined:
             aux_kwargs = dealiase_sel_kwargs(plot_kwargs, chain_prop, chain_idx)

--- a/arviz/plots/backends/matplotlib/traceplot.py
+++ b/arviz/plots/backends/matplotlib/traceplot.py
@@ -460,6 +460,9 @@ def _plot_chains_mpl(
     circ_units_trace,
 ):
 
+    if not circular:
+        circ_var_units = False
+
     for chain_idx, row in enumerate(value):
         if kind == "trace":
             aux_kwargs = dealiase_sel_kwargs(trace_kwargs, chain_prop, chain_idx)

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -192,7 +192,7 @@ def test_plot_separation(kwargs):
         {"lines": [("mu", {}, [1, 2])]},
         {"lines": [("mu", {}, 8)]},
         {"circ_var_names": ["mu"]},
-        {"circ_var_units": "degrees"},
+        {"circ_var_names": ["mu"], "circ_var_units": "degrees"},
     ],
 )
 def test_plot_trace(models, kwargs):


### PR DESCRIPTION
## Description
I noticed that the KDE plot in `plot_trace` was not using the circular KDE function (#1284). I also fixed the labels so that both columns share the same units.

Degrees:

![traceplot_circ_degrees](https://user-images.githubusercontent.com/8028618/96608619-f6053a00-12cf-11eb-8e55-1a7953164b2d.png)

Radians:

![traceplot_circ_radians](https://user-images.githubusercontent.com/8028618/96608653-00bfcf00-12d0-11eb-83d5-7fd6228cc031.png)


## Checklist
- [X] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [X] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/master/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
