### PR TITLE
skip "event" dims in log likelihood group whenever necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added `__getitem__` magic to InferenceData ([1395](https://github.com/arviz-devs/arviz/pull/1395))
 * Added group argument to summary ([1408](https://github.com/arviz-devs/arviz/pull/1408))
 * Add observed argument to (un)plot observed data in `plot_ppc` ([1422](https://github.com/arviz-devs/arviz/pull/1422))
+* Add support for named dims and coordinates with multivariate observations ([1429](https://github.com/arviz-devs/arviz/pull/1429))
 
 ### Maintenance and fixes
 * prevent wrapping group names in InferenceData repr_html ([1407](https://github.com/arviz-devs/arviz/pull/1407))

--- a/arviz/data/base.py
+++ b/arviz/data/base.py
@@ -218,7 +218,7 @@ def dict_to_dataset(
     skip_event_dims : bool
         If True, cut extra dims whenever present to match the shape of the data.
         Necessary for PPLs which have the same name in both observed data and log
-        likelihood groups, to account for their different shapes when observations are 
+        likelihood groups, to account for their different shapes when observations are
         multivariate.
 
     Returns

--- a/arviz/data/base.py
+++ b/arviz/data/base.py
@@ -210,8 +210,9 @@ def dict_to_dataset(
         coordinates.
     skip_event_dims : bool
         If True, cut extra dims whenever present to match the shape of the data.
-        Necessary for PPLs who have the same name in both observed data and log
-        likelihood groups share variable names to account for their different shapes.
+        Necessary for PPLs which have the same name in both observed data and log
+        likelihood groups, to account for their different shapes when observations are 
+        multivariate.
 
     Returns
     -------

--- a/arviz/data/base.py
+++ b/arviz/data/base.py
@@ -83,6 +83,13 @@ def generate_dims_coords(
         dims = []
     if skip_event_dims is None:
         skip_event_dims = False
+
+    if coords is None:
+        coords = {}
+
+    coords = deepcopy(coords)
+    dims = deepcopy(dims)
+
     ndims = len([dim for dim in dims if dim not in default_dims])
     if ndims > len(shape):
         if skip_event_dims:
@@ -101,13 +108,13 @@ def generate_dims_coords(
                 ),
                 UserWarning,
             )
-
-    if coords is None:
-        coords = {}
-
-    coords = deepcopy(coords)
-    dims = deepcopy(dims)
-
+    if skip_event_dims:
+        # this is needed in case the reduction keeps the dimension with size 1
+        for i, (dim, dim_size) in enumerate(zip(dims, shape)):
+            print(f"{i}, dim: {dim}, {dim_size} =? {len(coords.get(dim, []))}")
+            if (dim in coords) and (dim_size != len(coords[dim])):
+                dims = dims[:i]
+                break
 
     for idx, dim_len in enumerate(shape):
         if (len(dims) < idx + 1) or (dims[idx] is None):

--- a/arviz/data/base.py
+++ b/arviz/data/base.py
@@ -46,7 +46,9 @@ class requires:  # pylint: disable=invalid-name
         return wrapped
 
 
-def generate_dims_coords(shape, var_name, dims=None, coords=None, default_dims=None):
+def generate_dims_coords(
+    shape, var_name, dims=None, coords=None, default_dims=None, skip_event_dims=None
+):
     """Generate default dimensions and coordinates for a variable.
 
     Parameters
@@ -66,6 +68,7 @@ def generate_dims_coords(shape, var_name, dims=None, coords=None, default_dims=N
         when manipulating Monte Carlo traces, the ``default_dims`` would be
         ``["chain" , "draw"]`` which ArviZ uses as its own names for dimensions
         of MCMC traces.
+    skip_event_dims : bool, default False
 
     Returns
     -------
@@ -78,25 +81,33 @@ def generate_dims_coords(shape, var_name, dims=None, coords=None, default_dims=N
         default_dims = []
     if dims is None:
         dims = []
-    if len([dim for dim in dims if dim not in default_dims]) > len(shape):
-        warnings.warn(
-            (
-                "In variable {var_name}, there are "
-                + "more dims ({dims_len}) given than exist ({shape_len}). "
-                + "Passed array should have shape ({defaults}*shape)"
-            ).format(
-                var_name=var_name,
-                dims_len=len(dims),
-                shape_len=len(shape),
-                defaults=",".join(default_dims) + ", " if default_dims is not None else "",
-            ),
-            UserWarning,
-        )
+    if skip_event_dims is None:
+        skip_event_dims = False
+    ndims = len([dim for dim in dims if dim not in default_dims])
+    if ndims > len(shape):
+        if skip_event_dims:
+            dims = dims[: len(shape)]
+        else:
+            warnings.warn(
+                (
+                    "In variable {var_name}, there are "
+                    + "more dims ({dims_len}) given than exist ({shape_len}). "
+                    + "Passed array should have shape ({defaults}*shape)"
+                ).format(
+                    var_name=var_name,
+                    dims_len=len(dims),
+                    shape_len=len(shape),
+                    defaults=",".join(default_dims) + ", " if default_dims is not None else "",
+                ),
+                UserWarning,
+            )
+
     if coords is None:
         coords = {}
 
     coords = deepcopy(coords)
     dims = deepcopy(dims)
+
 
     for idx, dim_len in enumerate(shape):
         if (len(dims) < idx + 1) or (dims[idx] is None):
@@ -112,7 +123,7 @@ def generate_dims_coords(shape, var_name, dims=None, coords=None, default_dims=N
     return dims, coords
 
 
-def numpy_to_data_array(ary, *, var_name="data", coords=None, dims=None):
+def numpy_to_data_array(ary, *, var_name="data", coords=None, dims=None, skip_event_dims=None):
     """Convert a numpy array to an xarray.DataArray.
 
     The first two dimensions will be (chain, draw), and any remaining
@@ -134,6 +145,7 @@ def numpy_to_data_array(ary, *, var_name="data", coords=None, dims=None):
         is the name of the dimension, the values are the index values.
     dims : List(str)
         A list of coordinate names for the variable
+    skip_event_dims : bool
 
     Returns
     -------
@@ -154,7 +166,12 @@ def numpy_to_data_array(ary, *, var_name="data", coords=None, dims=None):
         )
 
     dims, coords = generate_dims_coords(
-        shape, var_name, dims=dims, coords=coords, default_dims=default_dims
+        shape,
+        var_name,
+        dims=dims,
+        coords=coords,
+        default_dims=default_dims,
+        skip_event_dims=skip_event_dims,
     )
 
     # reversed order for default dims: 'chain', 'draw'
@@ -173,7 +190,9 @@ def numpy_to_data_array(ary, *, var_name="data", coords=None, dims=None):
     return xr.DataArray(ary, coords=coords, dims=dims)
 
 
-def dict_to_dataset(data, *, attrs=None, library=None, coords=None, dims=None):
+def dict_to_dataset(
+    data, *, attrs=None, library=None, coords=None, dims=None, skip_event_dims=None
+):
     """Convert a dictionary of numpy arrays to an xarray.Dataset.
 
     Parameters
@@ -189,6 +208,10 @@ def dict_to_dataset(data, *, attrs=None, library=None, coords=None, dims=None):
     dims : dict[str] -> list[str]
         Dimensions of each variable. The keys are variable names, values are lists of
         coordinates.
+    skip_event_dims : bool
+        If True, cut extra dims whenever present to match the shape of the data.
+        Necessary for PPLs who have the same name in both observed data and log
+        likelihood groups share variable names to account for their different shapes.
 
     Returns
     -------
@@ -205,7 +228,7 @@ def dict_to_dataset(data, *, attrs=None, library=None, coords=None, dims=None):
     data_vars = {}
     for key, values in data.items():
         data_vars[key] = numpy_to_data_array(
-            values, var_name=key, coords=coords, dims=dims.get(key)
+            values, var_name=key, coords=coords, dims=dims.get(key), skip_event_dims=skip_event_dims
         )
     return xr.Dataset(data_vars=data_vars, attrs=make_attrs(attrs=attrs, library=library))
 

--- a/arviz/data/io_cmdstan.py
+++ b/arviz/data/io_cmdstan.py
@@ -524,8 +524,8 @@ class CmdStanConverter:
             )
             attrs = None
         return (
-            dict_to_dataset(data, coords=self.coords, dims=self.dims, attrs=attrs),
-            dict_to_dataset(data_warmup, coords=self.coords, dims=self.dims, attrs=attrs),
+            dict_to_dataset(data, coords=self.coords, dims=self.dims, attrs=attrs, skip_event_dims=True),
+            dict_to_dataset(data_warmup, coords=self.coords, dims=self.dims, attrs=attrs, skip_event_dims=True),
         )
 
     def to_inference_data(self):

--- a/arviz/data/io_cmdstan.py
+++ b/arviz/data/io_cmdstan.py
@@ -524,8 +524,12 @@ class CmdStanConverter:
             )
             attrs = None
         return (
-            dict_to_dataset(data, coords=self.coords, dims=self.dims, attrs=attrs, skip_event_dims=True),
-            dict_to_dataset(data_warmup, coords=self.coords, dims=self.dims, attrs=attrs, skip_event_dims=True),
+            dict_to_dataset(
+                data, coords=self.coords, dims=self.dims, attrs=attrs, skip_event_dims=True
+            ),
+            dict_to_dataset(
+                data_warmup, coords=self.coords, dims=self.dims, attrs=attrs, skip_event_dims=True
+            ),
         )
 
     def to_inference_data(self):

--- a/arviz/data/io_cmdstanpy.py
+++ b/arviz/data/io_cmdstanpy.py
@@ -220,9 +220,19 @@ class CmdStanPyConverter:
         )
 
         return (
-            dict_to_dataset(data, library=self.cmdstanpy, coords=self.coords, dims=self.dims, skip_event_dims=True),
             dict_to_dataset(
-                data_warmup, library=self.cmdstanpy, coords=self.coords, dims=self.dims, skip_event_dims=True
+                data,
+                library=self.cmdstanpy,
+                coords=self.coords,
+                dims=self.dims,
+                skip_event_dims=True,
+            ),
+            dict_to_dataset(
+                data_warmup,
+                library=self.cmdstanpy,
+                coords=self.coords,
+                dims=self.dims,
+                skip_event_dims=True,
             ),
         )
 

--- a/arviz/data/io_cmdstanpy.py
+++ b/arviz/data/io_cmdstanpy.py
@@ -220,9 +220,9 @@ class CmdStanPyConverter:
         )
 
         return (
-            dict_to_dataset(data, library=self.cmdstanpy, coords=self.coords, dims=self.dims),
+            dict_to_dataset(data, library=self.cmdstanpy, coords=self.coords, dims=self.dims, skip_event_dims=True),
             dict_to_dataset(
-                data_warmup, library=self.cmdstanpy, coords=self.coords, dims=self.dims
+                data_warmup, library=self.cmdstanpy, coords=self.coords, dims=self.dims, skip_event_dims=True
             ),
         )
 

--- a/arviz/data/io_dict.py
+++ b/arviz/data/io_dict.py
@@ -138,10 +138,10 @@ class DictConverter:
 
         return (
             dict_to_dataset(
-                data, library=None, coords=self.coords, dims=self.dims, attrs=self.attrs
+                data, library=None, coords=self.coords, dims=self.dims, attrs=self.attrs, skip_event_dims=True
             ),
             dict_to_dataset(
-                data_warmup, library=None, coords=self.coords, dims=self.dims, attrs=self.attrs
+                data_warmup, library=None, coords=self.coords, dims=self.dims, attrs=self.attrs, skip_event_dims=True
             ),
         )
 

--- a/arviz/data/io_dict.py
+++ b/arviz/data/io_dict.py
@@ -138,10 +138,20 @@ class DictConverter:
 
         return (
             dict_to_dataset(
-                data, library=None, coords=self.coords, dims=self.dims, attrs=self.attrs, skip_event_dims=True
+                data,
+                library=None,
+                coords=self.coords,
+                dims=self.dims,
+                attrs=self.attrs,
+                skip_event_dims=True,
             ),
             dict_to_dataset(
-                data_warmup, library=None, coords=self.coords, dims=self.dims, attrs=self.attrs, skip_event_dims=True
+                data_warmup,
+                library=None,
+                coords=self.coords,
+                dims=self.dims,
+                attrs=self.attrs,
+                skip_event_dims=True,
             ),
         )
 

--- a/arviz/data/io_numpyro.py
+++ b/arviz/data/io_numpyro.py
@@ -163,7 +163,9 @@ class NumPyroConverter:
             for obs_name, log_like in log_likelihood_dict.items():
                 shape = (self.nchains, self.ndraws) + log_like.shape[1:]
                 data[obs_name] = np.reshape(log_like.copy(), shape)
-        return dict_to_dataset(data, library=self.numpyro, dims=self.dims, coords=self.coords, skip_event_dims=True)
+        return dict_to_dataset(
+            data, library=self.numpyro, dims=self.dims, coords=self.coords, skip_event_dims=True
+        )
 
     def translate_posterior_predictive_dict_to_xarray(self, dct, dims):
         """Convert posterior_predictive or prediction samples to xarray."""

--- a/arviz/data/io_numpyro.py
+++ b/arviz/data/io_numpyro.py
@@ -163,7 +163,7 @@ class NumPyroConverter:
             for obs_name, log_like in log_likelihood_dict.items():
                 shape = (self.nchains, self.ndraws) + log_like.shape[1:]
                 data[obs_name] = np.reshape(log_like.copy(), shape)
-        return dict_to_dataset(data, library=self.numpyro, dims=self.dims, coords=self.coords)
+        return dict_to_dataset(data, library=self.numpyro, dims=self.dims, coords=self.coords, skip_event_dims=True)
 
     def translate_posterior_predictive_dict_to_xarray(self, dct, dims):
         """Convert posterior_predictive or prediction samples to xarray."""

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -318,8 +318,16 @@ class PyMC3Converter:  # pylint: disable=too-many-instance-attributes
             except TypeError:
                 warnings.warn(warn_msg)
         return (
-            dict_to_dataset(data, library=self.pymc3, dims=self.dims, coords=self.coords, skip_event_dims=True),
-            dict_to_dataset(data_warmup, library=self.pymc3, dims=self.dims, coords=self.coords, skip_event_dims=True),
+            dict_to_dataset(
+                data, library=self.pymc3, dims=self.dims, coords=self.coords, skip_event_dims=True
+            ),
+            dict_to_dataset(
+                data_warmup,
+                library=self.pymc3,
+                dims=self.dims,
+                coords=self.coords,
+                skip_event_dims=True,
+            ),
         )
 
     def translate_posterior_predictive_dict_to_xarray(self, dct) -> xr.Dataset:

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -318,8 +318,8 @@ class PyMC3Converter:  # pylint: disable=too-many-instance-attributes
             except TypeError:
                 warnings.warn(warn_msg)
         return (
-            dict_to_dataset(data, library=self.pymc3, dims=self.dims, coords=self.coords),
-            dict_to_dataset(data_warmup, library=self.pymc3, dims=self.dims, coords=self.coords),
+            dict_to_dataset(data, library=self.pymc3, dims=self.dims, coords=self.coords, skip_event_dims=True),
+            dict_to_dataset(data_warmup, library=self.pymc3, dims=self.dims, coords=self.coords, skip_event_dims=True),
         )
 
     def translate_posterior_predictive_dict_to_xarray(self, dct) -> xr.Dataset:

--- a/arviz/data/io_pyro.py
+++ b/arviz/data/io_pyro.py
@@ -155,7 +155,7 @@ class PyroConverter:
                     "Check your model vectorization or set log_likelihood=False"
                 )
                 return None
-        return dict_to_dataset(data, library=self.pyro, coords=self.coords, dims=self.dims)
+        return dict_to_dataset(data, library=self.pyro, coords=self.coords, dims=self.dims, skip_event_dims=True)
 
     def translate_posterior_predictive_dict_to_xarray(self, dct, dims):
         """Convert posterior_predictive or prediction samples to xarray."""

--- a/arviz/data/io_pyro.py
+++ b/arviz/data/io_pyro.py
@@ -155,7 +155,9 @@ class PyroConverter:
                     "Check your model vectorization or set log_likelihood=False"
                 )
                 return None
-        return dict_to_dataset(data, library=self.pyro, coords=self.coords, dims=self.dims, skip_event_dims=True)
+        return dict_to_dataset(
+            data, library=self.pyro, coords=self.coords, dims=self.dims, skip_event_dims=True
+        )
 
     def translate_posterior_predictive_dict_to_xarray(self, dct, dims):
         """Convert posterior_predictive or prediction samples to xarray."""

--- a/arviz/data/io_pystan.py
+++ b/arviz/data/io_pystan.py
@@ -143,8 +143,16 @@ class PyStanConverter:
         }
 
         return (
-            dict_to_dataset(data, library=self.pystan, coords=self.coords, dims=self.dims, skip_event_dims=True),
-            dict_to_dataset(data_warmup, library=self.pystan, coords=self.coords, dims=self.dims, skip_event_dims=True),
+            dict_to_dataset(
+                data, library=self.pystan, coords=self.coords, dims=self.dims, skip_event_dims=True
+            ),
+            dict_to_dataset(
+                data_warmup,
+                library=self.pystan,
+                coords=self.coords,
+                dims=self.dims,
+                skip_event_dims=True,
+            ),
         )
 
     @requires("posterior")

--- a/arviz/data/io_pystan.py
+++ b/arviz/data/io_pystan.py
@@ -143,8 +143,8 @@ class PyStanConverter:
         }
 
         return (
-            dict_to_dataset(data, library=self.pystan, coords=self.coords, dims=self.dims),
-            dict_to_dataset(data_warmup, library=self.pystan, coords=self.coords, dims=self.dims),
+            dict_to_dataset(data, library=self.pystan, coords=self.coords, dims=self.dims, skip_event_dims=True),
+            dict_to_dataset(data_warmup, library=self.pystan, coords=self.coords, dims=self.dims, skip_event_dims=True),
         )
 
     @requires("posterior")

--- a/arviz/tests/base_tests/test_data.py
+++ b/arviz/tests/base_tests/test_data.py
@@ -160,6 +160,20 @@ def test_dims_coords_extra_dims():
     assert len(coords["xy"]) == 20
 
 
+@pytest.mark.parametrize("shape", [(4, 20), (4, 20, 1)])
+def test_dims_coords_skip_event_dims(shape):
+    coords = {"x": np.arange(4), "y": np.arange(20), "z": np.arange(5)}
+    dims, coords = generate_dims_coords(
+        shape, "name", dims=["x", "y", "z"], coords=coords, skip_event_dims=True
+    )
+    assert "x" in dims
+    assert "y" in dims
+    assert "z" not in dims
+    assert len(coords["x"]) == 4
+    assert len(coords["y"]) == 20
+    assert "z" not in coords
+
+
 def test_make_attrs():
     extra_attrs = {"key": "Value"}
     attrs = make_attrs(attrs=extra_attrs)
@@ -896,6 +910,14 @@ def test_dict_to_dataset():
 
     assert set(dataset.a.coords) == {"chain", "draw"}
     assert set(dataset.b.coords) == {"chain", "draw", "c"}
+
+
+def test_dict_to_dataset_event_dims_error():
+    datadict = {"a": np.random.randn(1, 100, 10)}
+    coords = {"b": np.arange(10), "c": ["x", "y", "z"]}
+    msg = "different number of dimensions on data and dims"
+    with pytest.raises(ValueError, match=msg):
+        convert_to_dataset(datadict, coords=coords, dims={"a": ["b", "c"]})
 
 
 def test_convert_to_dataset_idempotent():

--- a/arviz/tests/external_tests/test_data_pymc.py
+++ b/arviz/tests/external_tests/test_data_pymc.py
@@ -534,7 +534,7 @@ class TestDataPyMC3:
 
     def test_multivariate_observations(self):
         coords = {"direction": ["x", "y", "z"], "experiment": np.arange(20)}
-        data = np.random.multinomial(20, [.2, .3, .5], size=20)
+        data = np.random.multinomial(20, [0.2, 0.3, 0.5], size=20)
         with pm.Model(coords=coords):
             p = pm.Beta("p", 1, 1, shape=(3,))
             pm.Multinomial("y", 20, p, dims=("experiment", "direction"), observed=data)
@@ -543,13 +543,12 @@ class TestDataPyMC3:
             "posterior": ["p"],
             "sample_stats": ["lp"],
             "log_likelihood": ["y"],
-            "observed_data": ["y"]
+            "observed_data": ["y"],
         }
         fails = check_multiple_attrs(test_dict, idata)
         assert not fails
         assert "direction" not in idata.log_likelihood.dims
         assert "direction" in idata.observed_data.dims
-
 
 
 class TestPyMC3WarmupHandling:

--- a/arviz/tests/external_tests/test_data_pymc.py
+++ b/arviz/tests/external_tests/test_data_pymc.py
@@ -532,6 +532,25 @@ class TestDataPyMC3:
         fails = check_multiple_attrs(test_dict, inference_data)
         assert not fails
 
+    def test_multivariate_observations(self):
+        coords = {"direction": ["x", "y", "z"], "experiment": np.arange(20)}
+        data = np.random.multinomial(20, [.2, .3, .5], size=20)
+        with pm.Model(coords=coords):
+            p = pm.Beta("p", 1, 1, shape=(3,))
+            pm.Multinomial("y", 20, p, dims=("experiment", "direction"), observed=data)
+            idata = pm.sample(draws=50, tune=100, return_inferencedata=True)
+        test_dict = {
+            "posterior": ["p"],
+            "sample_stats": ["lp"],
+            "log_likelihood": ["y"],
+            "observed_data": ["y"]
+        }
+        fails = check_multiple_attrs(test_dict, idata)
+        assert not fails
+        assert "direction" not in idata.log_likelihood.dims
+        assert "direction" in idata.observed_data.dims
+
+
 
 class TestPyMC3WarmupHandling:
     @pytest.mark.skipif(


### PR DESCRIPTION
## Description
ArviZ schema recommends to use the same variable names in log likelihood group as the one in observed_data and posterior_predictive groups. This helps identifying to what terms does each pointwise log lik value correspond, and eases calculations like LOO-PIT. 

However, log likelihood and posterior predictive don't always have the same dimensions and shape. In multidimensional observations the _event_ dimensions (shape of a single _observation_) are reduced. The shape of posterior predictive is `(chain, draw, *batch_shape, *event_shape)` whereas for log likelihood it is `(chain, draw, *batch_shape)`, in scalar observations they are both the same, but for multidimensional observations such as multivariate normals or multinomials the two shapes are different and the converters error out.

This will automatically handle this event_shape difference _provided that they follow this convention_, that is, event dims are the last ones.

cc @AlexAndorra 

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/master/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
