### PR TITLE
add skipna argument to plot_posterior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added group argument to summary ([1408](https://github.com/arviz-devs/arviz/pull/1408))
 * Add `ref_line`, `bar`, `vlines` and `marker_vlines` kwargs to `plot_rank` ([1419](https://github.com/arviz-devs/arviz/pull/1419))
 * Add observed argument to (un)plot observed data in `plot_ppc` ([1422](https://github.com/arviz-devs/arviz/pull/1422))
+* Add skipna argument to `plot_posterior` ([1432](https://github.com/arviz-devs/arviz/pull/1432))
 
 ### Maintenance and fixes
 * prevent wrapping group names in InferenceData repr_html ([1407](https://github.com/arviz-devs/arviz/pull/1407))

--- a/arviz/plots/backends/bokeh/posteriorplot.py
+++ b/arviz/plots/backends/bokeh/posteriorplot.py
@@ -34,6 +34,7 @@ def plot_posterior(
     round_to,
     hdi_prob,
     multimodal,
+    skipna,
     textsize,
     ref_val,
     rope,
@@ -82,6 +83,7 @@ def plot_posterior(
             round_to=round_to,
             hdi_prob=hdi_prob,
             multimodal=multimodal,
+            skipna=skipna,
             linewidth=linewidth,
             ref_val=ref_val,
             rope=rope,
@@ -112,6 +114,7 @@ def _plot_posterior_op(
     point_estimate,
     hdi_prob,
     multimodal,
+    skipna,
     ref_val,
     rope,
     ax_labelsize,
@@ -205,7 +208,9 @@ def _plot_posterior_op(
     def display_hdi(max_data):
         # np.ndarray with 2 entries, min and max
         # pylint: disable=line-too-long
-        hdi_probs = hdi(values, hdi_prob=hdi_prob, multimodal=multimodal)  # type: np.ndarray
+        hdi_probs = hdi(
+            values, hdi_prob=hdi_prob, multimodal=multimodal, skipna=skipna
+        )  # type: np.ndarray
 
         for hdi_i in np.atleast_2d(hdi_probs):
             ax.line(
@@ -230,6 +235,9 @@ def _plot_posterior_op(
         ax.yaxis.major_label_text_font_size = "0pt"
         ax.xgrid.grid_line_color = None
         ax.ygrid.grid_line_color = None
+
+    if skipna:
+        values = values[~np.isnan(values)]
 
     if kind == "kde" and values.dtype.kind == "f":
         kwargs.setdefault("line_width", linewidth)

--- a/arviz/plots/backends/matplotlib/posteriorplot.py
+++ b/arviz/plots/backends/matplotlib/posteriorplot.py
@@ -32,6 +32,7 @@ def plot_posterior(
     round_to,
     hdi_prob,
     multimodal,
+    skipna,
     textsize,
     ref_val,
     rope,
@@ -83,6 +84,7 @@ def plot_posterior(
             round_to=round_to,
             hdi_prob=hdi_prob,
             multimodal=multimodal,
+            skipna=skipna,
             ref_val=ref_val,
             rope=rope,
             ax_labelsize=ax_labelsize,
@@ -112,6 +114,7 @@ def _plot_posterior_op(
     point_estimate,
     hdi_prob,
     multimodal,
+    skipna,
     ref_val,
     rope,
     ax_labelsize,
@@ -215,7 +218,7 @@ def _plot_posterior_op(
     def display_point_estimate():
         if not point_estimate:
             return
-        point_value = calculate_point_estimate(point_estimate, values, bw, circular)
+        point_value = calculate_point_estimate(point_estimate, values, bw, circular, skipna)
         sig_figs = format_sig_figs(point_value, round_to)
         point_text = "{point_estimate}={point_value:.{sig_figs}g}".format(
             point_estimate=point_estimate, point_value=point_value, sig_figs=sig_figs
@@ -231,7 +234,9 @@ def _plot_posterior_op(
     def display_hdi():
         # np.ndarray with 2 entries, min and max
         # pylint: disable=line-too-long
-        hdi_probs = hdi(values, hdi_prob=hdi_prob, multimodal=multimodal)  # type: np.ndarray
+        hdi_probs = hdi(
+            values, hdi_prob=hdi_prob, multimodal=multimodal, skipna=skipna
+        )  # type: np.ndarray
 
         for hdi_i in np.atleast_2d(hdi_probs):
             ax.plot(

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -558,7 +558,6 @@ def calculate_point_estimate(point_estimate, values, bw="default", circular=Fals
     point_value : float
         best estimate of data distribution
     """
-    print("ski", skipna)
     point_value = None
     if point_estimate == "auto":
         point_estimate = rcParams["plot.point_estimate"]

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -531,7 +531,7 @@ def get_plotting_function(plot_name, plot_module, backend):
     return plotting_method
 
 
-def calculate_point_estimate(point_estimate, values, bw="default", circular=False):
+def calculate_point_estimate(point_estimate, values, bw="default", circular=False, skipna=False):
     """Validate and calculate the point estimate.
 
     Parameters
@@ -550,12 +550,15 @@ def calculate_point_estimate(point_estimate, values, bw="default", circular=Fals
     circular: Optional[bool]
         If True, it interprets the values passed are from a circular variable measured in radians
         and a circular KDE is used. Only valid for 1D KDE. Defaults to False.
+    skipna=True,
+        If true ignores nan values when computing the hdi. Defaults to false.
 
     Returns
     -------
     point_value : float
         best estimate of data distribution
     """
+    print("ski", skipna)
     point_value = None
     if point_estimate == "auto":
         point_estimate = rcParams["plot.point_estimate"]
@@ -566,7 +569,10 @@ def calculate_point_estimate(point_estimate, values, bw="default", circular=Fals
             )
         )
     if point_estimate == "mean":
-        point_value = values.mean()
+        if skipna:
+            point_value = np.nanmean(values)
+        else:
+            point_value = np.mean(values)
     elif point_estimate == "mode":
         if isinstance(values[0], float):
             if bw == "default":
@@ -579,7 +585,10 @@ def calculate_point_estimate(point_estimate, values, bw="default", circular=Fals
         else:
             point_value = mode(values)[0][0]
     elif point_estimate == "median":
-        point_value = np.median(values)
+        if skipna:
+            point_value = np.nanmedian(values)
+        else:
+            point_value = np.median(values)
 
     return point_value
 

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -15,6 +15,7 @@ def plot_posterior(
     textsize=None,
     hdi_prob=None,
     multimodal=False,
+    skipna=False,
     round_to=None,
     point_estimate="auto",
     group="posterior",
@@ -61,6 +62,8 @@ def plot_posterior(
     multimodal: bool
         If true (default) it may compute more than one credible interval if the distribution is
         multimodal and the modes are well separated.
+    skipna : bool
+        If true ignores nan values when computing the hdi and point estimates. Defaults to false.
     round_to: int, optional
         Controls formatting of floats. Defaults to 2 or the integer part, whichever is bigger.
     point_estimate: Optional[str]
@@ -234,6 +237,7 @@ def plot_posterior(
         round_to=round_to,
         hdi_prob=hdi_prob,
         multimodal=multimodal,
+        skipna=skipna,
         textsize=textsize,
         ref_val=ref_val,
         rope=rope,

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -374,16 +374,17 @@ def hdi(
         Any object that can be converted to an az.InferenceData object.
         Refer to documentation of az.convert_to_dataset for details.
     hdi_prob: float, optional
-        HDI prob for which interval will be computed. Defaults to ``stats.hdi_prob`` rcParam.
+        Prob for which the highest density interval will be computed. Defaults to
+        ``stats.hdi_prob`` rcParam.
     circular: bool, optional
         Whether to compute the hdi taking into account `x` is a circular variable
         (in the range [-np.pi, np.pi]) or not. Defaults to False (i.e non-circular variables).
         Only works if multimodal is False.
     multimodal: bool, optional
-        If true it may compute more than one hdi interval if the distribution is multimodal and the
+        If true it may compute more than one hdi if the distribution is multimodal and the
         modes are well separated.
     skipna: bool, optional
-        If true ignores nan values when computing the hdi interval. Defaults to false.
+        If true ignores nan values when computing the hdi. Defaults to false.
     group: str, optional
         Specifies which InferenceData group should be used to calculate hdi.
         Defaults to 'posterior'
@@ -412,7 +413,7 @@ def hdi(
 
     See Also
     --------
-    plot_hdi : Plot HDI intervals for regression data.
+    plot_hdi : Plot highest density intervals for regression data.
     xarray.Dataset.quantile : Calculate quantiles of array for given probabilities.
 
     Examples
@@ -1054,8 +1055,8 @@ def summary(
         If True, use the statistics returned by ``stat_funcs`` in addition to, rather than in place
         of, the default statistics. This is only meaningful when ``stat_funcs`` is not None.
     hdi_prob: float, optional
-        HDI interval to compute. Defaults to 0.94. This is only meaningful when ``stat_funcs`` is
-        None.
+        Highest density interval to compute. Defaults to 0.94. This is only meaningful when
+        ``stat_funcs`` is None.
     order: {"C", "F"}
         If fmt is "wide", use either C or F unpacking order. Defaults to C.
     index_origin: int

--- a/arviz/tests/base_tests/test_plots_bokeh.py
+++ b/arviz/tests/base_tests/test_plots_bokeh.py
@@ -1023,6 +1023,14 @@ def test_plot_posterior_point_estimates(models, point_estimate):
     assert axes.shape == (1, 2)
 
 
+def test_plot_posterior_skipna():
+    sample = np.linspace(0, 1)
+    sample[:10] = np.nan
+    plot_posterior({"a": sample}, backend="bokeh", show=False, skipna=True)
+    with pytest.raises(ValueError):
+        plot_posterior({"a": sample}, backend="bokeh", show=False, skipna=False)
+
+
 @pytest.mark.parametrize(
     "kwargs",
     [

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -927,6 +927,14 @@ def test_plot_posterior_point_estimates(models, point_estimate):
     assert axes.size == 2
 
 
+def test_plot_posterior_skipna():
+    sample = np.linspace(0, 1)
+    sample[:10] = np.nan
+    plot_posterior({"a": sample}, skipna=True)
+    with pytest.raises(ValueError):
+        plot_posterior({"a": sample}, skipna=False)
+
+
 @pytest.mark.parametrize(
     "kwargs", [{"insample_dev": False}, {"plot_standard_error": False}, {"plot_ic_diff": False}]
 )


### PR DESCRIPTION
Plot posterior fails if `nan` are present, this adds a skipna argument, defaults to False. 


- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] New features are properly documented (with an example if appropriate)?
- [x] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)
