### PR TITLE
Add support for discrete variables in rank plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add `ref_line`, `bar`, `vlines` and `marker_vlines` kwargs to `plot_rank` ([1419](https://github.com/arviz-devs/arviz/pull/1419))
 * Add observed argument to (un)plot observed data in `plot_ppc` ([1422](https://github.com/arviz-devs/arviz/pull/1422))
 * Add support for named dims and coordinates with multivariate observations ([1429](https://github.com/arviz-devs/arviz/pull/1429))
+* Add support for discrete variables in rank plots ([1433](https://github.com/arviz-devs/arviz/pull/1433))
 
 ### Maintenance and fixes
 * prevent wrapping group names in InferenceData repr_html ([1407](https://github.com/arviz-devs/arviz/pull/1407))

--- a/arviz/plots/backends/bokeh/rankplot.py
+++ b/arviz/plots/backends/bokeh/rankplot.py
@@ -1,13 +1,12 @@
 """Bokeh rankplot."""
 import numpy as np
-import scipy.stats
-from scipy.interpolate import CubicSpline
+
 from bokeh.models import Span
 from bokeh.models.annotations import Title
 from bokeh.models.tickers import FixedTicker
 
 from ....stats.density_utils import histogram
-from ...plot_utils import _scale_fig_size, make_label
+from ...plot_utils import _scale_fig_size, make_label, compute_ranks
 from .. import show_layout
 from . import backend_kwarg_defaults, create_axes_grid
 
@@ -75,17 +74,7 @@ def plot_rank(
     for ax, (var_name, selection, var_data) in zip(
         (item for item in axes.flatten() if item is not None), plotters
     ):
-        if var_data.dtype.kind == "i":
-            var_data_shape = var_data.shape
-            var_data = var_data.flatten()
-            min_var_data, max_var_data = min(var_data), max(var_data)
-            x = np.linspace(min_var_data, max_var_data, len(var_data))
-            csi = CubicSpline(x, var_data)
-            var_data = csi(
-                np.linspace(min_var_data + 0.001, max_var_data - 0.001, len(var_data))
-            ).reshape(var_data_shape)
-
-        ranks = scipy.stats.rankdata(var_data, method="average").reshape(var_data.shape)
+        ranks = compute_ranks(var_data)
         bin_ary = np.histogram_bin_edges(ranks, bins=bins, range=(0, ranks.size))
         all_counts = np.empty((len(ranks), len(bin_ary) - 1))
         for idx, row in enumerate(ranks):

--- a/arviz/plots/backends/bokeh/rankplot.py
+++ b/arviz/plots/backends/bokeh/rankplot.py
@@ -1,6 +1,7 @@
 """Bokeh rankplot."""
 import numpy as np
 import scipy.stats
+from scipy.interpolate import CubicSpline
 from bokeh.models import Span
 from bokeh.models.annotations import Title
 from bokeh.models.tickers import FixedTicker
@@ -74,6 +75,16 @@ def plot_rank(
     for ax, (var_name, selection, var_data) in zip(
         (item for item in axes.flatten() if item is not None), plotters
     ):
+        if var_data.dtype.kind == "i":
+            var_data_shape = var_data.shape
+            var_data = var_data.flatten()
+            min_var_data, max_var_data = min(var_data), max(var_data)
+            x = np.linspace(min_var_data, max_var_data, len(var_data))
+            csi = CubicSpline(x, var_data)
+            var_data = csi(
+                np.linspace(min_var_data + 0.001, max_var_data - 0.001, len(var_data))
+            ).reshape(var_data_shape)
+
         ranks = scipy.stats.rankdata(var_data, method="average").reshape(var_data.shape)
         bin_ary = np.histogram_bin_edges(ranks, bins=bins, range=(0, ranks.size))
         all_counts = np.empty((len(ranks), len(bin_ary) - 1))

--- a/arviz/plots/backends/matplotlib/rankplot.py
+++ b/arviz/plots/backends/matplotlib/rankplot.py
@@ -2,6 +2,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.stats
+from scipy.interpolate import CubicSpline
 
 from ....stats.density_utils import histogram
 from ...plot_utils import _scale_fig_size, make_label
@@ -66,6 +67,16 @@ def plot_rank(
         )
 
     for ax, (var_name, selection, var_data) in zip(np.ravel(axes), plotters):
+        if var_data.dtype.kind == "i":
+            var_data_shape = var_data.shape
+            var_data = var_data.flatten()
+            min_var_data, max_var_data = min(var_data), max(var_data)
+            x = np.linspace(min_var_data, max_var_data, len(var_data))
+            csi = CubicSpline(x, var_data)
+            var_data = csi(
+                np.linspace(min_var_data + 0.001, max_var_data - 0.001, len(var_data))
+            ).reshape(var_data_shape)
+
         ranks = scipy.stats.rankdata(var_data, method="average").reshape(var_data.shape)
         bin_ary = np.histogram_bin_edges(ranks, bins=bins, range=(0, ranks.size))
         all_counts = np.empty((len(ranks), len(bin_ary) - 1))

--- a/arviz/plots/backends/matplotlib/rankplot.py
+++ b/arviz/plots/backends/matplotlib/rankplot.py
@@ -1,11 +1,9 @@
 """Matplotlib rankplot."""
 import matplotlib.pyplot as plt
 import numpy as np
-import scipy.stats
-from scipy.interpolate import CubicSpline
 
 from ....stats.density_utils import histogram
-from ...plot_utils import _scale_fig_size, make_label
+from ...plot_utils import _scale_fig_size, make_label, compute_ranks
 from . import backend_kwarg_defaults, backend_show, create_axes_grid
 
 
@@ -67,17 +65,7 @@ def plot_rank(
         )
 
     for ax, (var_name, selection, var_data) in zip(np.ravel(axes), plotters):
-        if var_data.dtype.kind == "i":
-            var_data_shape = var_data.shape
-            var_data = var_data.flatten()
-            min_var_data, max_var_data = min(var_data), max(var_data)
-            x = np.linspace(min_var_data, max_var_data, len(var_data))
-            csi = CubicSpline(x, var_data)
-            var_data = csi(
-                np.linspace(min_var_data + 0.001, max_var_data - 0.001, len(var_data))
-            ).reshape(var_data_shape)
-
-        ranks = scipy.stats.rankdata(var_data, method="average").reshape(var_data.shape)
+        ranks = compute_ranks(var_data)
         bin_ary = np.histogram_bin_edges(ranks, bins=bins, range=(0, ranks.size))
         all_counts = np.empty((len(ranks), len(bin_ary) - 1))
         for idx, row in enumerate(ranks):

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -656,7 +656,7 @@ def set_bokeh_circular_ticks_labels(ax, hist, labels):
 
 
 def compute_ranks(ary):
-    """Computes ranks for continuos and discrete variables"""
+    """Compute ranks for continuos and discrete variables."""
     if ary.dtype.kind == "i":
         ary_shape = ary.shape
         ary = ary.flatten()

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -9,7 +9,9 @@ import numpy as np
 import packaging
 import xarray as xr
 from matplotlib.colors import to_hex
-from scipy.stats import mode
+from scipy.stats import mode, rankdata
+from scipy.interpolate import CubicSpline
+
 
 from ..rcparams import rcParams
 from ..stats.density_utils import kde
@@ -651,3 +653,17 @@ def set_bokeh_circular_ticks_labels(ax, hist, labels):
     )
 
     return ax
+
+
+def compute_ranks(ary):
+    """Computes ranks for continuos and discrete variables"""
+    if ary.dtype.kind == "i":
+        ary_shape = ary.shape
+        ary = ary.flatten()
+        min_ary, max_ary = min(ary), max(ary)
+        x = np.linspace(min_ary, max_ary, len(ary))
+        csi = CubicSpline(x, ary)
+        ary = csi(np.linspace(min_ary + 0.001, max_ary - 0.001, len(ary))).reshape(ary_shape)
+    ranks = rankdata(ary, method="average").reshape(ary.shape)
+
+    return ranks

--- a/arviz/tests/base_tests/test_plot_utils.py
+++ b/arviz/tests/base_tests/test_plot_utils.py
@@ -16,6 +16,7 @@ from ...plots.plot_utils import (
     vectorized_to_hex,
     xarray_to_ndarray,
     xarray_var_iter,
+    compute_ranks,
 )
 from ...rcparams import rc_context
 from ...stats.density_utils import get_bins
@@ -322,3 +323,20 @@ def test_set_bokeh_circular_ticks_labels():
     assert len(renderers) == 3
     assert renderers[2].data_source.data["text"] == labels
     assert len(renderers[0].data_source.data["start_angle"]) == len(labels)
+
+
+def test_compute_ranks():
+    pois_data = np.array([[5, 4, 1, 4, 0], [2, 8, 2, 1, 1]])
+    expected = np.array([[9.0, 7.0, 3.0, 8.0, 1.0], [5.0, 10.0, 6.0, 2.0, 4.0]])
+    ranks = compute_ranks(pois_data)
+    np.testing.assert_equal(ranks, expected)
+
+    norm_data = np.array(
+        [
+            [0.2644187, -1.3004813, -0.80428456, 1.01319068, 0.62631143],
+            [1.34498018, -0.13428933, -0.69855487, -0.9498981, -0.34074092],
+        ]
+    )
+    expected = np.array([[7.0, 1.0, 3.0, 9.0, 8.0], [10.0, 6.0, 4.0, 2.0, 5.0]])
+    ranks = compute_ranks(norm_data)
+    np.testing.assert_equal(ranks, expected)


### PR DESCRIPTION
Use a similar trick to the one used in `plot_bpv` for discrete variables.

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [ ] New features are properly documented (with an example if appropriate)?
- [x] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)

Good sample

OLD
![trace_rank_old](https://user-images.githubusercontent.com/1338958/97210068-d6708480-179b-11eb-9c35-95b2d42f1de6.png)

NEW

![trace_rank_new](https://user-images.githubusercontent.com/1338958/97210088-dc666580-179b-11eb-837a-4e4e2be07905.png)


Bad sample (excess of 2s in one chain)

OLD
![trace_rank_old_bad_00](https://user-images.githubusercontent.com/1338958/97210108-e25c4680-179b-11eb-9ec8-e60e47aa5175.png)


NEW
![trace_rank_new_bad_00](https://user-images.githubusercontent.com/1338958/97210126-e720fa80-179b-11eb-9ccb-76527e942246.png)


Bad sample (two different distributions)

OLD
![trace_rank_old_bad_01](https://user-images.githubusercontent.com/1338958/97210150-ee480880-179b-11eb-8c5a-bb4b3be25768.png)


NEW
![trace_rank_new_bad_01](https://user-images.githubusercontent.com/1338958/97210157-f1db8f80-179b-11eb-9de9-45581ddc0202.png)


As you can see with the old version discrete samples always look bad (and more or less the same). With the new version not only they look good when they should, they actually reflect the nature of problem with the sampling went wrong.


