### PR TITLE
fix compare and make stacking default method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add observed argument to (un)plot observed data in `plot_ppc` ([1422](https://github.com/arviz-devs/arviz/pull/1422))
 * Add support for named dims and coordinates with multivariate observations ([1429](https://github.com/arviz-devs/arviz/pull/1429))
 * Add skipna argument to `plot_posterior` ([1432](https://github.com/arviz-devs/arviz/pull/1432))
+* Make stacking the default method to compute weights in `compare` ([1438](https://github.com/arviz-devs/arviz/pull/1438))
 
 
 ### Maintenance and fixes
@@ -20,8 +21,9 @@
 * Have `from_pystan` store attrs as strings to allow netCDF storage ([1417](https://github.com/arviz-devs/arviz/pull/1417))
 * Remove ticks and spines in `plot_violin`  ([1426 ](https://github.com/arviz-devs/arviz/pull/1426))
 * Use circular KDE function and fix tick labels in circular `plot_trace` ([1428](https://github.com/arviz-devs/arviz/pull/1428))
-*  Fix `pair_plot` for mixed discrete and continuous variables ([1434](https://github.com/arviz-devs/arviz/pull/1434))
+* Fix `pair_plot` for mixed discrete and continuous variables ([1434](https://github.com/arviz-devs/arviz/pull/1434))
 * Fix in-sample deviance in `plot_compare` ([1435](https://github.com/arviz-devs/arviz/pull/1435))
+* Fix computation of weights in compare ([1438](https://github.com/arviz-devs/arviz/pull/1438))
 
 ### Deprecation
 

--- a/arviz/tests/base_tests/test_stats.py
+++ b/arviz/tests/base_tests/test_stats.py
@@ -163,7 +163,7 @@ def test_compare_unknown_ic_and_method(centered_eight, non_centered_eight):
 def test_compare_different(centered_eight, non_centered_eight, ic, method, scale):
     model_dict = {"centered": centered_eight, "non_centered": non_centered_eight}
     weight = compare(model_dict, ic=ic, method=method, scale=scale)["weight"]
-    assert weight["non_centered"] >= weight["centered"]
+    assert weight["non_centered"] > weight["centered"]
     assert_allclose(np.sum(weight), 1.0)
 
 
@@ -174,7 +174,7 @@ def test_compare_different_multidim(multidim_models, ic, method):
     weight = compare(model_dict, ic=ic, method=method)["weight"]
 
     # this should hold because the same seed is always used
-    assert weight["model_1"] >= weight["model_2"]
+    assert weight["model_1"] > weight["model_2"]
     assert_allclose(np.sum(weight), 1.0)
 
 


### PR DESCRIPTION
When using "bb-pseudo-bma" overflows could happen when a weight much more larger than the rest.
I found mistakes in stacking, the retains where not ok and the minimization always return the initial guess 1/(number of model)   oddly I know for sure it used to run OK. Anyway, this fix the problem and makes stacking the default method.

This also add a warning message that we changed the default method. I guess we should keep it at least during one release cycle.


- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)
