### PR TITLE
automatically get the current axes instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Fix computation of weights in compare ([1438](https://github.com/arviz-devs/arviz/pull/1438))
 * Avoid repeated warning in summary ([1442](https://github.com/arviz-devs/arviz/pull/1442)) 
 * Fix hdi failure with boolean array ([1444](https://github.com/arviz-devs/arviz/pull/1444))
+* Automatically get the current axes instance for `plt_kde` and `plot_dist` ([1452](https://github.com/arviz-devs/arviz/pull/1452))
 
 ### Deprecation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 * Fix computation of weights in compare ([1438](https://github.com/arviz-devs/arviz/pull/1438))
 * Avoid repeated warning in summary ([1442](https://github.com/arviz-devs/arviz/pull/1442)) 
 * Fix hdi failure with boolean array ([1444](https://github.com/arviz-devs/arviz/pull/1444))
-* Automatically get the current axes instance for `plt_kde` and `plot_dist` ([1452](https://github.com/arviz-devs/arviz/pull/1452))
+* Automatically get the current axes instance for `plt_kde`, `plot_dist` and `plot_hdi` ([1452](https://github.com/arviz-devs/arviz/pull/1452))
 
 ### Deprecation
 

--- a/arviz/plots/backends/matplotlib/distplot.py
+++ b/arviz/plots/backends/matplotlib/distplot.py
@@ -54,9 +54,9 @@ def plot_dist(
     backend_kwargs["subplot_kw"].setdefault("polar", is_circular)
 
     if ax is None:
-        figManager = _pylab_helpers.Gcf.get_active()
-        if figManager is not None:
-            ax = figManager.canvas.figure.gca()
+        fig_manager = _pylab_helpers.Gcf.get_active()
+        if fig_manager is not None:
+            ax = fig_manager.canvas.figure.gca()
         else:
             _, ax = create_axes_grid(
                 1,

--- a/arviz/plots/backends/matplotlib/distplot.py
+++ b/arviz/plots/backends/matplotlib/distplot.py
@@ -1,5 +1,6 @@
 """Matplotlib distplot."""
 import matplotlib.pyplot as plt
+from matplotlib import _pylab_helpers
 import numpy as np
 
 from ....stats.density_utils import get_bins
@@ -53,7 +54,14 @@ def plot_dist(
     backend_kwargs["subplot_kw"].setdefault("polar", is_circular)
 
     if ax is None:
-        _, ax = create_axes_grid(1, backend_kwargs=backend_kwargs)
+        figManager = _pylab_helpers.Gcf.get_active()
+        if figManager is not None:
+            ax = figManager.canvas.figure.gca()
+        else:
+            _, ax = create_axes_grid(
+                1,
+                backend_kwargs=backend_kwargs,
+            )
 
     if kind == "hist":
         hist_kwargs = matplotlib_kwarg_dealiaser(hist_kwargs, "hist")

--- a/arviz/plots/backends/matplotlib/hdiplot.py
+++ b/arviz/plots/backends/matplotlib/hdiplot.py
@@ -1,5 +1,6 @@
 """Matplotlib hdiplot."""
 import matplotlib.pyplot as plt
+from matplotlib import _pylab_helpers
 
 from ...plot_utils import _scale_fig_size, vectorized_to_hex
 from . import backend_kwarg_defaults, backend_show, create_axes_grid, matplotlib_kwarg_dealiaser
@@ -28,10 +29,14 @@ def plot_hdi(ax, x_data, y_data, color, figsize, plot_kwargs, fill_kwargs, backe
     backend_kwargs["squeeze"] = True
 
     if ax is None:
-        _, ax = create_axes_grid(
-            1,
-            backend_kwargs=backend_kwargs,
-        )
+        fig_manager = _pylab_helpers.Gcf.get_active()
+        if fig_manager is not None:
+            ax = fig_manager.canvas.figure.gca()
+        else:
+            _, ax = create_axes_grid(
+                1,
+                backend_kwargs=backend_kwargs,
+            )
 
     ax.plot(x_data, y_data, **plot_kwargs)
     ax.fill_between(x_data, y_data[:, 0], y_data[:, 1], **fill_kwargs)

--- a/arviz/plots/backends/matplotlib/kdeplot.py
+++ b/arviz/plots/backends/matplotlib/kdeplot.py
@@ -1,6 +1,8 @@
 """Matplotlib kdeplot."""
 import numpy as np
 from matplotlib import pyplot as plt
+from matplotlib import _pylab_helpers
+
 
 from ...plot_utils import _scale_fig_size
 from . import backend_kwarg_defaults, backend_show, create_axes_grid, matplotlib_kwarg_dealiaser
@@ -56,10 +58,14 @@ def plot_kde(
     backend_kwargs["subplot_kw"].setdefault("polar", is_circular)
 
     if ax is None:
-        _, ax = create_axes_grid(
-            1,
-            backend_kwargs=backend_kwargs,
-        )
+        figManager = _pylab_helpers.Gcf.get_active()
+        if figManager is not None:
+            ax = figManager.canvas.figure.gca()
+        else:
+            _, ax = create_axes_grid(
+                1,
+                backend_kwargs=backend_kwargs,
+            )
 
     if values2 is None:
         plot_kwargs = matplotlib_kwarg_dealiaser(plot_kwargs, "plot")

--- a/arviz/plots/backends/matplotlib/kdeplot.py
+++ b/arviz/plots/backends/matplotlib/kdeplot.py
@@ -58,9 +58,9 @@ def plot_kde(
     backend_kwargs["subplot_kw"].setdefault("polar", is_circular)
 
     if ax is None:
-        figManager = _pylab_helpers.Gcf.get_active()
-        if figManager is not None:
-            ax = figManager.canvas.figure.gca()
+        fig_manager = _pylab_helpers.Gcf.get_active()
+        if fig_manager is not None:
+            ax = fig_manager.canvas.figure.gca()
         else:
             _, ax = create_axes_grid(
                 1,

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -398,7 +398,9 @@ def test_plot_joint_bad(models):
 )
 def test_plot_kde(continuous_model, kwargs):
     axes = plot_kde(continuous_model["x"], continuous_model["y"], **kwargs)
+    axes1 = plot_kde(continuous_model["x"], continuous_model["y"], **kwargs)
     assert axes
+    assert axes is axes1
 
 
 @pytest.mark.parametrize("shape", [(8,), (8, 8), (8, 8, 8)])
@@ -442,7 +444,9 @@ def test_plot_kde_cumulative(continuous_model, kwargs):
 )
 def test_plot_dist(continuous_model, kwargs):
     axes = plot_dist(continuous_model["x"], **kwargs)
+    axes1 = plot_dist(continuous_model["x"], **kwargs)
     assert axes
+    assert axes is axes1
 
 
 def test_plot_dist_hist(data_random):


### PR DESCRIPTION
- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [x] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)


This recover the old behavior, allowing to do this, without the need to explicitly need to pass the axes
 
a= np.random.normal(0, 1, 100)
b= np.random.normal(0, 1, 100)
az.plot_kde(a)
az.plot_kde(b)

![test](https://user-images.githubusercontent.com/1338958/100450167-eed20880-3093-11eb-8cbb-bd01d56b214e.png)
