### PR TITLE
Use relative link with sphinx

### DIFF
--- a/doc/source/getting_started/Introduction.ipynb
+++ b/doc/source/getting_started/Introduction.ipynb
@@ -4,6 +4,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "(quickstart)="
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# ArviZ Quickstart"
    ]
   },
@@ -92,13 +99,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## ArviZ rcParams\n",
     "\n",
     "You may have noticed that for both `plot_posterior` and `plot_forest`, the Highest Density Interval (HDI) is 94%, which you may find weird at first. This particular value is a friendly reminder of the arbitrary nature of choosing any single value without further justification, including common values like 95%, 50% and even our own default, 94%. ArviZ includes default values for a few parameters, you can access them with `az.rcParams`. To change the default HDI value to let's say 90% you can do:"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -8632,7 +8639,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -18,7 +18,7 @@ We welcome `contributions <https://github.com/arviz-devs/arviz/blob/master/CONTR
 QuickStart
 ##########
 If new to the library the best place to start is the
-`quickstart <https://arviz-devs.github.io/arviz/notebooks/Introduction.html>`_
+:ref:`quickstart <quickstart>`_
 
 
 Example Gallery


### PR DESCRIPTION
Fix broken link and replace with relative link (adding anchor to quickstart notebook and updating usage page to link to that anchor)

It looks like some extra metadata got changed when added a line to the notebook. Let me know if I should get rid of those changes.

Closes #1457 