### PR TITLE
Increase code coverage (stats.density_utils.py)

### DIFF
--- a/arviz/stats/density_utils.py
+++ b/arviz/stats/density_utils.py
@@ -849,18 +849,6 @@ def _kde_adaptive(x, bw, grid_edges, grid_counts, grid_len, bound_correction, **
     return grid, pdf
 
 
-def _fast_kde(x, cumulative=False, bw=4.5, xmin=None, xmax=None):  # pylint: disable=unused-argument
-    """Kernel Density Estimate, Deprecated."""
-    if not (xmin is None and xmax is None):
-        custom_lims = (xmin, xmax)
-    else:
-        custom_lims = None
-    grid, pdf = kde(x, cumulative=cumulative, bw=bw, custom_lims=custom_lims)
-
-    warnings.warn("_fast_kde() has been replaced by kde() in stats.density_utils.py", FutureWarning)
-    return grid, pdf
-
-
 def _fast_kde_2d(x, y, gridsize=(128, 128), circular=False):
     """
     2D fft-based Gaussian kernel density estimate (KDE).

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -394,6 +394,7 @@ def test_plot_joint_bad(models):
         {"is_circular": True},
         {"is_circular": "radians"},
         {"is_circular": "degrees"},
+        {"adaptive": True}
     ],
 )
 def test_plot_kde(continuous_model, kwargs):

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -394,7 +394,7 @@ def test_plot_joint_bad(models):
         {"is_circular": True},
         {"is_circular": "radians"},
         {"is_circular": "degrees"},
-        {"adaptive": True}
+        {"adaptive": True},
     ],
 )
 def test_plot_kde(continuous_model, kwargs):


### PR DESCRIPTION
This PR tries to improve testing and code coverage of `arviz.stats.density_utils.py`.
* Add an argument to the `test_plots_kde()` function to cover the case of adaptive KDE.
* Remove the deprecated `_fast_kde()` function