### PR TITLE
Pin tensorflow version

### DIFF
--- a/.azure-pipelines/azure-pipelines-base.yml
+++ b/.azure-pipelines/azure-pipelines-base.yml
@@ -35,7 +35,7 @@ jobs:
 
   - script: |
       sudo apt-get update
-      sudo apt-get install -y ffmpeg git
+      sudo apt-get install -y ffmpeg
     displayName: 'Install external libraries'
 
   - script: |

--- a/.azure-pipelines/azure-pipelines-base.yml
+++ b/.azure-pipelines/azure-pipelines-base.yml
@@ -35,7 +35,7 @@ jobs:
 
   - script: |
       sudo apt-get update
-      sudo apt-get install -y ffmpeg
+      sudo apt-get install -y ffmpeg git
     displayName: 'Install external libraries'
 
   - script: |
@@ -55,7 +55,7 @@ jobs:
       python -m pip install pytest-azurepipelines codecov
     condition: and(succeeded(), eq(variables.PyPIGithub, false))
     displayName: 'Install requirements'
-  
+
   - script: |
       python -m pip install --upgrade pip
       python -m pip install wheel

--- a/.azure-pipelines/azure-pipelines-external.yml
+++ b/.azure-pipelines/azure-pipelines-external.yml
@@ -80,7 +80,7 @@ jobs:
       fi
 
       if [ "$(pymc3.version)" = "github" ]; then
-          # Pip installation is failing for some reason. This is the asme thing
+          # Pip installation is failing for some reason. This is the same thing
           git clone https://github.com/pymc-devs/pymc3
           pip install $PWD/pymc3
           # python -m pip --no-cache-dir --log log.txt install git+https://github.com/pymc-devs/pymc3

--- a/.azure-pipelines/azure-pipelines-external.yml
+++ b/.azure-pipelines/azure-pipelines-external.yml
@@ -80,6 +80,7 @@ jobs:
       fi
 
       if [ "$(pymc3.version)" = "github" ]; then
+          # Pip installation is failing for some reason. This is the asme thing
           git clone https://github.com/pymc-devs/pymc3
           pip install $PWD/pymc3
           # python -m pip --no-cache-dir --log log.txt install git+https://github.com/pymc-devs/pymc3

--- a/.azure-pipelines/azure-pipelines-external.yml
+++ b/.azure-pipelines/azure-pipelines-external.yml
@@ -82,7 +82,8 @@ jobs:
       if [ "$(pymc3.version)" = "github" ]; then
           python -m pip --no-cache-dir install git+https://github.com/pymc-devs/pymc3
       else
-          python -m pip --no-cache-dir install pymc3
+          python -m pip --no-cache-dir -v --log log.txt install pymc3
+          less logs.txt
       fi
 
       grep -Ev '^pystan|^pyro|^emcee|^pymc3' requirements-external.txt | xargs python -m pip install

--- a/.azure-pipelines/azure-pipelines-external.yml
+++ b/.azure-pipelines/azure-pipelines-external.yml
@@ -80,8 +80,10 @@ jobs:
       fi
 
       if [ "$(pymc3.version)" = "github" ]; then
-          python -m pip --no-cache-dir --log log.txt install git+https://github.com/pymc-devs/pymc3
-          cat log.txt
+          git clone https://github.com/pymc-devs/pymc3
+          pip install $PWD/pymc3
+          # python -m pip --no-cache-dir --log log.txt install git+https://github.com/pymc-devs/pymc3
+          # cat log.txt
       else
           python -m pip --no-cache-dir install pymc3
       fi

--- a/.azure-pipelines/azure-pipelines-external.yml
+++ b/.azure-pipelines/azure-pipelines-external.yml
@@ -83,7 +83,7 @@ jobs:
           python -m pip --no-cache-dir install git+https://github.com/pymc-devs/pymc3
       else
           python -m pip --no-cache-dir -v --log log.txt install pymc3
-          less logs.txt
+          cat logs.txt
       fi
 
       grep -Ev '^pystan|^pyro|^emcee|^pymc3' requirements-external.txt | xargs python -m pip install

--- a/.azure-pipelines/azure-pipelines-external.yml
+++ b/.azure-pipelines/azure-pipelines-external.yml
@@ -80,10 +80,10 @@ jobs:
       fi
 
       if [ "$(pymc3.version)" = "github" ]; then
-          python -m pip --no-cache-dir install git+https://github.com/pymc-devs/pymc3
+          python -m pip --no-cache-dir --log log.txt install git+https://github.com/pymc-devs/pymc3
+          cat log.txt
       else
-          python -m pip --no-cache-dir -v --log log.txt install pymc3
-          cat logs.txt
+          python -m pip --no-cache-dir install pymc3
       fi
 
       grep -Ev '^pystan|^pyro|^emcee|^pymc3' requirements-external.txt | xargs python -m pip install

--- a/requirements-external.txt
+++ b/requirements-external.txt
@@ -5,5 +5,5 @@ pystan
 cmdstanpy
 pyro-ppl>=1.0.0
 tensorflow
-tensorflow-probability
+tensorflow-probability==0.11.0
 numpyro>=0.2.1


### PR DESCRIPTION
Ci is failing for two reasons

* Tfp 0.12.0 deprecated edward apparently but our converter looks for it
* PyMC3 submoduled its notebooks and thats causing some clone failure