### PR TITLE
plot_trace, do not plot divergences with rankplots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 * Automatically get the current axes instance for `plt_kde`, `plot_dist` and `plot_hdi` ([1452](https://github.com/arviz-devs/arviz/pull/1452))
 * Add grid argument to manually specify the number of rows and columns ([1459](https://github.com/arviz-devs/arviz/pull/1459))
 * Switch to `compact=True` by default in our plots ([1468](https://github.com/arviz-devs/arviz/issues/1468))
-
+* Do not plot divergences in `plot_trace` when `kind=rank_vlines` or `kind=rank_bars` ([1476](https://github.com/arviz-devs/arviz/issues/1476)) 
 
 ### Deprecation
 

--- a/arviz/plots/backends/bokeh/traceplot.py
+++ b/arviz/plots/backends/bokeh/traceplot.py
@@ -338,10 +338,11 @@ def plot_trace(
                     else:
                         y_div_trace = value.min()
                     glyph_density = Dash(x="y", y=0.0, **div_density_kwargs)
-                    glyph_trace = Dash(x="x", y=y_div_trace, **div_trace_kwargs)
+                    if kind == "trace":
+                        glyph_trace = Dash(x="x", y=y_div_trace, **div_trace_kwargs)
+                        axes[idx, 1].add_glyph(tmp_cds, glyph_trace)
 
                     axes[idx, 0].add_glyph(tmp_cds, glyph_density)
-                    axes[idx, 1].add_glyph(tmp_cds, glyph_trace)
 
     show_layout(axes, show)
 

--- a/arviz/plots/backends/matplotlib/traceplot.py
+++ b/arviz/plots/backends/matplotlib/traceplot.py
@@ -368,7 +368,7 @@ def plot_trace(
                                     alpha=hist_kwargs["alpha"],
                                     zorder=0.6,
                                 )
-                            else:
+                            elif not idy:
                                 ax.plot(
                                     values,
                                     np.zeros_like(values) + ylocs,


### PR DESCRIPTION
When kind = rank_vlines or rank_bars, and if divergences are present they will be plotted only under the KDE/histogram

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)

Update. A few examples of how it look without this fix

![lala_old](https://user-images.githubusercontent.com/1338958/103137637-4a021580-46a9-11eb-8557-ab777dea5943.png)


![lala_old2](https://user-images.githubusercontent.com/1338958/103137605-027b8980-46a9-11eb-8d94-e2ad8e0253d7.png)

![bokeh](https://user-images.githubusercontent.com/1338958/103137606-060f1080-46a9-11eb-9bfa-233d3bc0d0ad.png)

![bokeh2](https://user-images.githubusercontent.com/1338958/103137608-08716a80-46a9-11eb-81fe-a174b9efc390.png)
