### PR TITLE
Add always-visible titles to the example gallery.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
   for markdown/notebook parsing in docs ([1406](https://github.com/arviz-devs/arviz/pull/1406))
 * Incorporated `input_core_dims` in `hdi` and `plot_hdi` docstrings ([1410](https://github.com/arviz-devs/arviz/pull/1410))
 * Add documentation pages about experimental `SamplingWrapper`s usage ([1373](https://github.com/arviz-devs/arviz/pull/1373))
+* Show example titles in gallery page ([1484](https://github.com/arviz-devs/arviz/pull/1484))
 
 ### Experimental
 * Modified `SamplingWrapper` base API ([1373](https://github.com/arviz-devs/arviz/pull/1373))

--- a/arviz/plots/khatplot.py
+++ b/arviz/plots/khatplot.py
@@ -35,7 +35,7 @@ def plot_khat(
     show=None,
     **kwargs
 ):
-    """
+    r"""
     Plot Pareto tail indices for diagnosing convergence.
 
     Parameters
@@ -43,9 +43,11 @@ def plot_khat(
     khats : ELPDData cointaining Pareto shapes information or array of
         Pareto tail indices.
     color : str or array_like, optional
-        Colors of the scatter plot, if color is a str all dots will have the same color,
-        if it is the size of the observations, each dot will have the specified color,
-        otherwise, it will be interpreted as a list of the dims to be used for the color code
+        Colors of the scatter plot, if color is a str all dots will
+        have the same color, if it is the size of the observations,
+        each dot will have the specified color, otherwise, it will be
+        interpreted as a list of the dims to be used for the color
+        code
     xlabels : bool, optional
         Use coords as xticklabels
     show_hlines : bool, optional

--- a/arviz/plots/khatplot.py
+++ b/arviz/plots/khatplot.py
@@ -36,11 +36,11 @@ def plot_khat(
     **kwargs
 ):
     """
-    Plot Pareto tail indices.
+    Plot Pareto tail indices for diagnosing convergence.
 
     Parameters
     ----------
-    khats : ELPDData cointaining pareto shapes information or array
+    khats : ELPDData cointaining Pareto shapes information or array of
         Pareto tail indices.
     color : str or array_like, optional
         Colors of the scatter plot, if color is a str all dots will have the same color,
@@ -125,6 +125,25 @@ def plot_khat(
         ... ]
         >>> az.plot_khat(loo_radon, color=colors)
 
+    Notes
+    -----
+    The Generalized Pareto distribution (GPD) may be used to diagnose
+    convergence rates for importance sampling.  GPD has parameters
+    offset, scale, and shape. The shape parameter is usually denoted
+    with ``k``. ``k`` also tells how many finite moments the
+    distribution has. The pre-asymptotic convergence rate of
+    importance sampling can be estimated based on the fractional
+    number of finite moments of the importance ratio distribution. GPD
+    is fitted to the largest importance ratios and the estimated shape
+    parameter ``k``, i.e., ``\hat{k}` can then be used as a diagnostic
+    (most importantly if ``\hat{k} > 0.7``, then the convergence rate
+    is impractically low). See [1]_.
+
+    References
+    ----------
+    ..[1] Vehtari, A., Simpson, D., Gelman, A., Yao, Y., Gabry, J.,
+    2019. Pareto Smoothed Importance Sampling. arXiv:1507.02646
+    [stat].
     """
     if annotate:
         _log.warning("annotate will be deprecated, please use threshold instead")

--- a/arviz/plots/separationplot.py
+++ b/arviz/plots/separationplot.py
@@ -77,7 +77,10 @@ def plot_separation(
 
     References
     ----------
-    * Greenhill, B. et al (2011) see https://doi.org/10.1111/j.1540-5907.2011.00525.x
+    * Greenhill, B. *et al.*, The Separation Plot: A New Visual Method
+      for Evaluating the Fit of Binary Models, *American Journal of
+      Political Science, (2011) see
+      https://doi.org/10.1111/j.1540-5907.2011.00525.x
 
     Examples
     --------

--- a/doc/sphinxext/gallery_generator.py
+++ b/doc/sphinxext/gallery_generator.py
@@ -178,7 +178,6 @@ CONTENTS_ENTRY_TEMPLATE = (
 
 
 def create_thumbnail(infile, thumbfile, width=275, height=275, cx=0.5, cy=0.5, border=4):
-    # baseout, extout = op.splitext(thumbfile)
 
     im = image.imread(infile)
     rows, cols = im.shape[:2]
@@ -220,6 +219,7 @@ class ExampleGenerator:
         self.thumb_dir = thumb_dir
         self.backend = backend
         self.thumbloc = 0.5, 0.5
+        self._title = None
         self.extract_docstring()
         with open(filename, "r") as fid:
             self.filetext = fid.read()
@@ -326,19 +326,20 @@ class ExampleGenerator:
         title: Optional[str] = None
         ex_title: str = ""
         for line in docstring.split("\n"):
-            # capture the first non-empty line of the docstring as title
-            if ex_title == "":
-                ex_title = line
+            # we've found everything we need...
+            if thumbloc and title and ex_title != "":
+                break
             m = re.match(r"^_thumb: (\.\d+),\s*(\.\d+)", line)
             if m:
                 thumbloc = float(m.group(1)), float(m.group(2))
-                if thumbloc and title:
-                    break
+                continue
             m = re.match(r"^_example_title: (.*)$", line)
             if m:
                 title = m.group(1)
-                if thumbloc and title:
-                    break
+                continue
+            # capture the first non-empty line of the docstring as title
+            if ex_title == "":
+                ex_title = line
         assert ex_title != ""
         if thumbloc is not None:
             self.thumbloc = thumbloc

--- a/examples/bokeh/bokeh_plot_loo_pit_ecdf.py
+++ b/examples/bokeh/bokeh_plot_loo_pit_ecdf.py
@@ -3,6 +3,7 @@ LOO-PIT ECDF Plot
 =================
 
 _thumb: .5, .7
+_example_title: Plot LOO predictive ECDF compared to ECDF of uniform distribution to assess predictive calibration.
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_loo_pit_overlay.py
+++ b/examples/bokeh/bokeh_plot_loo_pit_overlay.py
@@ -3,6 +3,7 @@ LOO-PIT Overlay Plot
 ====================
 
 _thumb: .5, .7
+_example_title: Plot LOO-PIT KDE overlaid on KDEs of uniform samples to assess predictive calibration.
 """
 import arviz as az
 

--- a/examples/matplotlib/mpl_plot_autocorr.py
+++ b/examples/matplotlib/mpl_plot_autocorr.py
@@ -3,6 +3,7 @@ Autocorrelation Plot
 ====================
 
 _thumb: .8, .8
+_example_title: Autocorrelation plot
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_compare.py
+++ b/examples/matplotlib/mpl_plot_compare.py
@@ -3,6 +3,7 @@ Compare Plot
 ============
 
 _thumb: .5, .5
+_example_title: Comparison plot
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_density.py
+++ b/examples/matplotlib/mpl_plot_density.py
@@ -3,6 +3,7 @@ Density Plot
 ============
 
 _thumb: .5, .5
+_example_title: Plot density
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_dist.py
+++ b/examples/matplotlib/mpl_plot_dist.py
@@ -3,6 +3,7 @@ Dist Plot
 =========
 
 _thumb: .2, .8
+_example_title: Plot distribution.
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/matplotlib/mpl_plot_energy.py
+++ b/examples/matplotlib/mpl_plot_energy.py
@@ -3,6 +3,7 @@ Energy Plot
 ===========
 
 _thumb: .7, .5
+_example_title: Plot energy
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_ess_evolution.py
+++ b/examples/matplotlib/mpl_plot_ess_evolution.py
@@ -3,7 +3,7 @@ ESS Quantile Plot
 =================
 
 _thumb: .2, .8
-_example_title: Plot evolution of Expected Sample Size (ESS)
+_example_title: Plot evolution of Effective Sample Size (ESS)
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_ess_evolution.py
+++ b/examples/matplotlib/mpl_plot_ess_evolution.py
@@ -3,6 +3,7 @@ ESS Quantile Plot
 =================
 
 _thumb: .2, .8
+_example_title: Plot evolution of Expected Sample Size (ESS)
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_ess_local.py
+++ b/examples/matplotlib/mpl_plot_ess_local.py
@@ -3,6 +3,7 @@ ESS Local Plot
 ==============
 
 _thumb: .6, .5
+_example_title: Plot local ESS -- ESS of specific variables
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_ess_local.py
+++ b/examples/matplotlib/mpl_plot_ess_local.py
@@ -3,7 +3,7 @@ ESS Local Plot
 ==============
 
 _thumb: .6, .5
-_example_title: Plot local ESS -- ESS of specific variables
+_example_title: Plot local ESS
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_ess_quantile.py
+++ b/examples/matplotlib/mpl_plot_ess_quantile.py
@@ -3,6 +3,7 @@ ESS Quantile Plot
 =================
 
 _thumb: .4, .5
+_example_title: Plot ESS of quantiles
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_forest.py
+++ b/examples/matplotlib/mpl_plot_forest.py
@@ -3,6 +3,7 @@ Forest Plot
 ===========
 
 _thumb: .5, .8
+_example_title: Forest plot
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_forest_ridge.py
+++ b/examples/matplotlib/mpl_plot_forest_ridge.py
@@ -3,6 +3,7 @@ Ridgeplot
 =========
 
 _thumb: .8, .5
+_example_title: Forest plot with individual ridges
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_joint.py
+++ b/examples/matplotlib/mpl_plot_joint.py
@@ -3,6 +3,7 @@ Joint Plot
 ==========
 
 _thumb: .5, .8
+_example_title: Plot joint distribution
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_kde.py
+++ b/examples/matplotlib/mpl_plot_kde.py
@@ -3,6 +3,7 @@ KDE Plot
 ========
 
 _thumb: .2, .8
+_example_title: Plot Kernel Density Estimation (KDE)
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/matplotlib/mpl_plot_kde_2d.py
+++ b/examples/matplotlib/mpl_plot_kde_2d.py
@@ -3,6 +3,7 @@
 ======
 
 _thumb: .1, .8
+_example_title: Plot KDE in two dimensions
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/matplotlib/mpl_plot_kde_quantiles.py
+++ b/examples/matplotlib/mpl_plot_kde_quantiles.py
@@ -3,6 +3,7 @@ KDE quantiles
 =============
 
 _thumb: .2, .8
+_example_title: Plot KDE of quantiles
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/matplotlib/mpl_plot_khat.py
+++ b/examples/matplotlib/mpl_plot_khat.py
@@ -3,6 +3,7 @@ Pareto Shape Plot
 =================
 
 _thumb: .7, .5
+_example_title: k&#x0302; plot
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_loo_pit_ecdf.py
+++ b/examples/matplotlib/mpl_plot_loo_pit_ecdf.py
@@ -3,7 +3,7 @@ LOO-PIT ECDF Plot
 =================
 
 _thumb: .5, .7
-_example_title: Plot LOO predictive check
+_example_title: Plot LOO predictive ECDF compared to ECDF of uniform distribution to assess predictive calibration.
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_loo_pit_ecdf.py
+++ b/examples/matplotlib/mpl_plot_loo_pit_ecdf.py
@@ -3,6 +3,7 @@ LOO-PIT ECDF Plot
 =================
 
 _thumb: .5, .7
+_example_title: Plot LOO predictive check
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_loo_pit_overlay.py
+++ b/examples/matplotlib/mpl_plot_loo_pit_overlay.py
@@ -3,6 +3,7 @@ LOO-PIT Overlay Plot
 ====================
 
 _thumb: .5, .7
+_example_title: Plot LOO overlayed on <i>some damn thing</i>.
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_loo_pit_overlay.py
+++ b/examples/matplotlib/mpl_plot_loo_pit_overlay.py
@@ -3,7 +3,7 @@ LOO-PIT Overlay Plot
 ====================
 
 _thumb: .5, .7
-_example_title: Plot LOO overlaid on uniform distributions to assess convergence.
+_example_title: Plot LOO-PIT KDE overlaid on KDEs of uniform samples to assess predictive calibration.
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_loo_pit_overlay.py
+++ b/examples/matplotlib/mpl_plot_loo_pit_overlay.py
@@ -3,7 +3,7 @@ LOO-PIT Overlay Plot
 ====================
 
 _thumb: .5, .7
-_example_title: Plot LOO overlayed on <i>some damn thing</i>.
+_example_title: Plot LOO overlaid on uniform distributions to assess convergence.
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_mcse.py
+++ b/examples/matplotlib/mpl_plot_mcse.py
@@ -3,6 +3,7 @@ Quantile Monte Carlo Standard Error Plot
 ========================================
 
 _thumb: .5, .8
+_example_title: Quantile Monte Carlo Standard Error Plot
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_mcse_errorbar.py
+++ b/examples/matplotlib/mpl_plot_mcse_errorbar.py
@@ -3,6 +3,7 @@ Quantile MCSE Errobar Plot
 ==========================
 
 _thumb: .6, .4
+_example_title: Quantile MCSE plot with errobars
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_pair.py
+++ b/examples/matplotlib/mpl_plot_pair.py
@@ -3,6 +3,7 @@ Pair Plot
 =========
 
 _thumb: .2, .5
+_example_title: Pair plot with divergences marked
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_pair_hex.py
+++ b/examples/matplotlib/mpl_plot_pair_hex.py
@@ -3,6 +3,7 @@ Hexbin PairPlot
 ===============
 
 _thumb: .2, .5
+_example_title: Pair plot on hex grid
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_pair_kde.py
+++ b/examples/matplotlib/mpl_plot_pair_kde.py
@@ -3,6 +3,7 @@ KDE Pair Plot
 =============
 
 _thumb: .2, .5
+_example_title: KDE pair plot
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_pair_point_estimate.py
+++ b/examples/matplotlib/mpl_plot_pair_point_estimate.py
@@ -3,6 +3,7 @@ Point Estimate Pairplot
 =======================
 
 _thumb: .2, .5
+_example_title: Pair plot with point estimate markings
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_parallel.py
+++ b/examples/matplotlib/mpl_plot_parallel.py
@@ -3,6 +3,7 @@ Parallel Plot
 =============
 
 _thumb: .2, .5
+_example_title: Parallel plot of posterior trace
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_parallel_minmax.py
+++ b/examples/matplotlib/mpl_plot_parallel_minmax.py
@@ -3,6 +3,7 @@ MinMax Parallel Plot
 ====================
 
 _thumb: .2, .5
+_example_title: Parallel plot with MinMax normalization
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_parallel_normal.py
+++ b/examples/matplotlib/mpl_plot_parallel_normal.py
@@ -3,6 +3,7 @@ Normal Parallel Plot
 ====================
 
 _thumb: .2, .5
+_example_title: Normalized parallel plot
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_posterior.py
+++ b/examples/matplotlib/mpl_plot_posterior.py
@@ -3,6 +3,7 @@ Posterior Plot
 ==============
 
 _thumb: .5, .8
+_example_title: Plot posterior
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_ppc.py
+++ b/examples/matplotlib/mpl_plot_ppc.py
@@ -3,6 +3,7 @@ Posterior Predictive Check Plot
 ===============================
 
 _thumb: .6, .5
+_example_title: Plot Posterior Predictive Checks (PPC)
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_ppc_cumulative.py
+++ b/examples/matplotlib/mpl_plot_ppc_cumulative.py
@@ -3,6 +3,7 @@ Posterior Predictive Check Cumulative Plot
 ==========================================
 
 _thumb: .6, .5
+_example_title: PPC Cumulative distribution plot
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_rank.py
+++ b/examples/matplotlib/mpl_plot_rank.py
@@ -3,6 +3,7 @@ Rank plot
 =========
 
 _thumb: .1, .8
+_example_title: Rank plot
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_separation.py
+++ b/examples/matplotlib/mpl_plot_separation.py
@@ -2,7 +2,7 @@
 Separation Plot
 ===============
 
-_thumb: .2, .8
+_thumb: .5, .5
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_trace.py
+++ b/examples/matplotlib/mpl_plot_trace.py
@@ -3,6 +3,7 @@ Traceplot
 =========
 
 _thumb: .1, .8
+_example_title: Plot trace
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_trace_bars.py
+++ b/examples/matplotlib/mpl_plot_trace_bars.py
@@ -3,6 +3,7 @@ Traceplot rank_bars
 ===================
 
 _thumb: .1, .8
+_example_title: Trace plot with rank bars
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_trace_vlines.py
+++ b/examples/matplotlib/mpl_plot_trace_vlines.py
@@ -3,6 +3,7 @@ Traceplot rank_vlines
 =====================
 
 _thumb: .1, .8
+_example_title: Trace plot with vertical lines for ranks
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_violin.py
+++ b/examples/matplotlib/mpl_plot_violin.py
@@ -1,8 +1,9 @@
 """
-Violinplot
+Violin plot
 ==========
 
 _thumb: .2, .8
+_example_title: Violin plot
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_styles.py
+++ b/examples/matplotlib/mpl_styles.py
@@ -3,6 +3,7 @@ Matplotlib styles
 =================
 
 _thumb: .8, .8
+_example_title: Matplotlib styles for ArviZ
 """
 import matplotlib.pyplot as plt
 import numpy as np


### PR DESCRIPTION
Previously the only titles were in tooltips, which made it near impossible to scan the page and find the example you wanted.

Note that this is a WIP if only because there's an Easter Egg in one of the titles that needs fixing!