### PR TITLE
Resolve a few straightforward mypy type errors.

### DIFF
--- a/arviz/data/base.py
+++ b/arviz/data/base.py
@@ -12,7 +12,9 @@ import xarray as xr
 try:
     import ujson as json
 except ImportError:
-    import json
+    # mypy struggles with conditional imports expressed as catching ImportError:
+    # https://github.com/python/mypy/issues/1153
+    import json  # type: ignore
 
 from .. import __version__, utils
 

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -20,7 +20,9 @@ from .base import _extend_xr_method, _make_json_serializable, dict_to_dataset
 try:
     import ujson as json
 except ImportError:
-    import json
+    # mypy struggles with conditional imports expressed as catching ImportError:
+    # https://github.com/python/mypy/issues/1153
+    import json  # type: ignore
 
 SUPPORTED_GROUPS = [
     "posterior",

--- a/arviz/data/io_json.py
+++ b/arviz/data/io_json.py
@@ -6,7 +6,9 @@ try:
     import ujson as json
 except ImportError:
     # Can't find ujson using json
-    import json
+    # mypy struggles with conditional imports expressed as catching ImportError:
+    # https://github.com/python/mypy/issues/1153
+    import json  # type: ignore
 
 
 def from_json(filename):

--- a/arviz/data/io_pystan.py
+++ b/arviz/data/io_pystan.py
@@ -17,7 +17,9 @@ try:
     import ujson as json
 except ImportError:
     # Can't find ujson using json
-    import json
+    # mypy struggles with conditional imports expressed as catching ImportError:
+    # https://github.com/python/mypy/issues/1153
+    import json  # type: ignore
 
 
 class PyStanConverter:

--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -241,7 +241,7 @@ def check_multiple_attrs(
     in ``sample_stats``, also against what was expected.
 
     """
-    failed_attrs = []
+    failed_attrs: List[Union[str, Tuple[str, str]]] = []
     for dataset_name, attributes in test_dict.items():
         if dataset_name.startswith("~"):
             if hasattr(parent, dataset_name[1:]):


### PR DESCRIPTION
## Description
This PR is only about improving type hint coverage and quality. It contains no new features and makes no substantive changes to existing functionality, so it should be fully covered by existing tests. This is similar in spirit to #1397 and #1398.

In particular, this PR:
- Applies a `mypy`-suggested type hint to a test helper that requires it in order to type-check.
- Applies `# type: ignore` suppressions to a few instances of a known and still-unresolved `mypy` issue https://github.com/python/mypy/issues/1153

The following `mypy`-reported errors are resolved as a result:
```
arviz/data/io_pystan.py:20: error: Name 'json' already defined (by an import)  [no-redef]
arviz/data/io_json.py:9: error: Name 'json' already defined (by an import)  [no-redef]
arviz/data/base.py:15: error: Name 'json' already defined (by an import)  [no-redef]
arviz/tests/helpers.py:259: error: Incompatible return value type (got "List[str]", expected "List[Union[str, Tuple[str, str]]]")  [return-value]
arviz/tests/helpers.py:259: note: "List" is invariant -- see http://mypy.readthedocs.io/en/latest/common_issues.html#variance
arviz/tests/helpers.py:259: note: Consider using "Sequence" instead, which is covariant
arviz/tests/helpers.py:259: note: Perhaps you need a type annotation for "failed_attrs"? Suggestion: "List[Union[str, Tuple[str, str]]]"
```

Additionally, a similar `mypy` type error related to a conditional `ujson` import that would be uncovered if https://github.com/arviz-devs/arviz/pull/1491 merges is also addressed here.

## Checklist
- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Code style  correct (follows pylint and black guidelines)