### PR TITLE
Minor improvements to type checking and error checks in stats.py.

### DIFF
--- a/arviz/tests/base_tests/test_stats.py
+++ b/arviz/tests/base_tests/test_stats.py
@@ -332,13 +332,19 @@ def test_summary_skip_nan(centered_eight):
 
 @pytest.mark.parametrize("fmt", [1, "bad_fmt"])
 def test_summary_bad_fmt(centered_eight, fmt):
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="Invalid format"):
         summary(centered_eight, fmt=fmt)
+
+
+@pytest.mark.parametrize("kind", [1, "bad_kind"])
+def test_summary_bad_kind(centered_eight, kind):
+    with pytest.raises(TypeError, match="Invalid kind"):
+        summary(centered_eight, kind=kind)
 
 
 @pytest.mark.parametrize("order", [1, "bad_order"])
 def test_summary_bad_unpack_order(centered_eight, order):
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="Invalid order"):
         summary(centered_eight, order=order)
 
 


### PR DESCRIPTION
## Description
- Added a missing error check on the `summary()` function's `kind` parameter. Since the check was missing, that meant that illegal `kind` values could be passed, and cause unexpected, self-inconsistent behavior in the function.
- Improved type hints to use explicit `Literal` types instead of `str`, making errors like the ones mentioned in the prior bullet point less likely to happen as `mypy` would catch them statically.
- Resolved a type error caused by unintentional variable-sharing across unrelated portions of the same function.

As with my other PRs, there are no substantive changes to existing functionality and there is no new functionality, so existing tests should cover everything already.

## Checklist
- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Code style correct (follows pylint and black guidelines)
