### PR TITLE
Resolve RcParams MRO confusion and delete unnecessary methods.

### DIFF
--- a/arviz/rcparams.py
+++ b/arviz/rcparams.py
@@ -283,7 +283,7 @@ defaultParams = {  # pylint: disable=invalid-name
 }
 
 
-class RcParams(MutableMapping, dict):  # pylint: disable=too-many-ancestors
+class RcParams(dict):
     """Class to contain ArviZ default parameters.
 
     It is implemented as a dict with validation when setting items.
@@ -292,7 +292,8 @@ class RcParams(MutableMapping, dict):  # pylint: disable=too-many-ancestors
     validate = {key: validate_fun for key, (_, validate_fun) in defaultParams.items()}
 
     # validate values on the way in
-    def __init__(self, *args, **kwargs):  # pylint: disable=super-init-not-called
+    def __init__(self, *args, **kwargs):
+        super().__init__()
         self.update(*args, **kwargs)
 
     def __setitem__(self, key, val):
@@ -308,10 +309,6 @@ class RcParams(MutableMapping, dict):  # pylint: disable=too-many-ancestors
                 "{} is not a valid rc parameter (see rcParams.keys() for "
                 "a list of valid parameters)".format(key)
             ) from err
-
-    def __getitem__(self, key):
-        """Use dict getitem method."""
-        return dict.__getitem__(self, key)
 
     def __delitem__(self, key):
         """Raise TypeError if someone ever tries to delete a key from RcParams."""
@@ -341,18 +338,6 @@ class RcParams(MutableMapping, dict):  # pylint: disable=too-many-ancestors
             ""
         )
 
-    def items(self):
-        """Explicit use of MutableMapping attributes."""
-        return MutableMapping.items(self)
-
-    def keys(self):
-        """Explicit use of MutableMapping attributes."""
-        return MutableMapping.keys(self)
-
-    def values(self):
-        """Explicit use of MutableMapping attributes."""
-        return MutableMapping.values(self)
-
     def __repr__(self):
         """Customize repr of RcParams objects."""
         class_name = self.__class__.__name__
@@ -368,10 +353,6 @@ class RcParams(MutableMapping, dict):  # pylint: disable=too-many-ancestors
     def __iter__(self):
         """Yield sorted list of keys."""
         yield from sorted(dict.__iter__(self))
-
-    def __len__(self):
-        """Use dict len method."""
-        return dict.__len__(self)
 
     def find_all(self, pattern):
         """

--- a/arviz/rcparams.py
+++ b/arviz/rcparams.py
@@ -385,7 +385,7 @@ class RcParams(MutableMapping):
 
     def copy(self):
         """Get a copy of the RcParams object."""
-        return {k: dict.__getitem__(self, k) for k in self}
+        return dict(self._underlying_storage)
 
 
 def get_arviz_rcfile():

--- a/arviz/rcparams.py
+++ b/arviz/rcparams.py
@@ -6,7 +6,6 @@ import pprint
 import re
 import sys
 import warnings
-from collections.abc import MutableMapping
 from pathlib import Path
 
 import numpy as np

--- a/arviz/tests/base_tests/test_rcparams.py
+++ b/arviz/tests/base_tests/test_rcparams.py
@@ -114,7 +114,9 @@ def test_rctemplate_updated():
         key for key in rc_defaults.keys() if key not in rc_pars_template
     ]
     assert all([value == rc_pars_template[key] for key, value in rc_defaults.items()]), [
-        key for key, value in rc_defaults.items() if value != rc_pars_template[key]
+        (key, value, rc_pars_template[key])
+        for key, value in rc_defaults.items()
+        if value != rc_pars_template[key]
     ]
 
 

--- a/arviz/tests/base_tests/test_rcparams.py
+++ b/arviz/tests/base_tests/test_rcparams.py
@@ -114,9 +114,7 @@ def test_rctemplate_updated():
         key for key in rc_defaults.keys() if key not in rc_pars_template
     ]
     assert all([value == rc_pars_template[key] for key, value in rc_defaults.items()]), [
-        (key, value, rc_pars_template[key])
-        for key, value in rc_defaults.items()
-        if value != rc_pars_template[key]
+        key for key, value in rc_defaults.items() if value != rc_pars_template[key]
     ]
 
 


### PR DESCRIPTION
## Description
Working to resolve the following issue raised by `mypy`:
```
arviz/rcparams.py:286: error: Cannot determine consistent method resolution order (MRO) for "RcParams"  [misc]
```

It seems that `RcParams` inherits from both `dict` and `MutableMapping`, which is confusing `mypy` because `dict` is also a `MutableMapping`. Additionally, it seems that this confusing MRO situation has led to the need to redefine several of the `MutableMapping` methods explicitly, to avoid MRO-related dispatch issues.

I'm not sure why `RcParams` needs `MutableMapping` _in addition to_ having `dict` as a superclass, so I'm leaving this PR as a draft for now. None of the documentation for the class seems to explain this quirk, so I'm hoping that either test cases surface some leads, or one of the maintainers recalls what the reason might be.

If the tests don't show any issues, and none of the maintainers see a reason to have the multiple inheritance setup and its associated MRO issues, then it may be worth removing `MutableMapping` as this PR does, and clearing up the `mypy` error and the two associated (and currently suppressed) `pylint` errors.

## Checklist
- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Code style correct (follows pylint and black guidelines)