### PR TITLE
Fix type mismatches in traceplot.py.

### DIFF
--- a/arviz/plots/traceplot.py
+++ b/arviz/plots/traceplot.py
@@ -20,7 +20,7 @@ def plot_trace(
     rug: bool = False,
     lines: Optional[List[Tuple[str, CoordSpec, Any]]] = None,
     circ_var_names: Optional[List[str]] = None,
-    circ_var_units: bool = "radians",
+    circ_var_units: str = "radians",
     compact: bool = True,
     compact_prop: Optional[Union[str, Mapping[str, Any]]] = None,
     combined: bool = False,
@@ -160,7 +160,7 @@ def plot_trace(
         try:
             divergence_data = convert_to_dataset(data, group="sample_stats").diverging
         except (ValueError, AttributeError):  # No sample_stats, or no `.diverging`
-            divergences = False
+            divergences = None
 
     if coords is None:
         coords = {}


### PR DESCRIPTION
## Description
Fixing a couple more `mypy` errors, closing in toward #1496:
```
arviz/plots/traceplot.py:23: error: Incompatible default for argument "circ_var_units" (default has type "str", argument has type "bool")  [assignment]
arviz/plots/traceplot.py:163: error: Incompatible types in assignment (expression has type "bool", variable has type "Optional[str]")  [assignment]
```

## Checklist
- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Code style  correct (follows pylint and black guidelines)