### PR TITLE
loo_pit for discrete data

### DIFF
--- a/arviz/plots/backends/bokeh/bpvplot.py
+++ b/arviz/plots/backends/bokeh/bpvplot.py
@@ -3,9 +3,9 @@ import numpy as np
 from bokeh.models import BoxAnnotation
 from bokeh.models.annotations import Title
 from scipy import stats
-from scipy.interpolate import CubicSpline
 
 from ....stats.density_utils import kde
+from ....stats.stats_utils import smooth_data
 from ...kdeplot import plot_kde
 from ...plot_utils import (
     _scale_fig_size,
@@ -90,13 +90,7 @@ def plot_bpv(
         pp_vals = pp_vals.reshape(total_pp_samples, -1)
 
         if obs_vals.dtype.kind == "i" or pp_vals.dtype.kind == "i":
-            x = np.linspace(0, 1, len(obs_vals))
-            csi = CubicSpline(x, obs_vals)
-            obs_vals = csi(np.linspace(0.001, 0.999, len(obs_vals)))
-
-            x = np.linspace(0, 1, pp_vals.shape[1])
-            csi = CubicSpline(x, pp_vals, axis=1)
-            pp_vals = csi(np.linspace(0.001, 0.999, pp_vals.shape[1]))
+            obs_vals, pp_vals = smooth_data(obs_vals, pp_vals)
 
         if kind == "p_value":
             tstat_pit = np.mean(pp_vals <= obs_vals, axis=-1)

--- a/arviz/plots/backends/matplotlib/bpvplot.py
+++ b/arviz/plots/backends/matplotlib/bpvplot.py
@@ -2,9 +2,9 @@
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import stats
-from scipy.interpolate import CubicSpline
 
 from ....stats.density_utils import kde
+from ....stats.stats_utils import smooth_data
 from ...kdeplot import plot_kde
 from ...plot_utils import (
     _scale_fig_size,
@@ -89,13 +89,7 @@ def plot_bpv(
         pp_vals = pp_vals.reshape(total_pp_samples, -1)
 
         if obs_vals.dtype.kind == "i" or pp_vals.dtype.kind == "i":
-            x = np.linspace(0, 1, len(obs_vals))
-            csi = CubicSpline(x, obs_vals)
-            obs_vals = csi(np.linspace(0.001, 0.999, len(obs_vals)))
-
-            x = np.linspace(0, 1, pp_vals.shape[1])
-            csi = CubicSpline(x, pp_vals, axis=1)
-            pp_vals = csi(np.linspace(0.001, 0.999, pp_vals.shape[1]))
+            obs_vals, pp_vals = smooth_data(obs_vals, pp_vals)
 
         if kind == "p_value":
             tstat_pit = np.mean(pp_vals <= obs_vals, axis=-1)

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -19,7 +19,7 @@ from .density_utils import get_bins as _get_bins
 from .density_utils import histogram as _histogram
 from .density_utils import kde as _kde
 from .diagnostics import _mc_error, _multichain_statistics, ess
-from .stats_utils import ELPDData, _circular_standard_deviation
+from .stats_utils import ELPDData, _circular_standard_deviation, smooth_data
 from .stats_utils import get_log_likelihood as _get_log_likelihood
 from .stats_utils import logsumexp as _logsumexp
 from .stats_utils import make_ufunc as _make_ufunc
@@ -1635,6 +1635,9 @@ def loo_pit(idata=None, *, y=None, y_hat=None, log_weights=None):
         "join": "left",
     }
     ufunc_kwargs = {"n_dims": 1}
+
+    if y.dtype.kind == "i" or y_hat.dtype.kind == "i":
+        y, y_hat = smooth_data(y, y_hat)
 
     return _wrap_xarray_ufunc(
         _loo_pit,

--- a/arviz/stats/stats_utils.py
+++ b/arviz/stats/stats_utils.py
@@ -7,6 +7,7 @@ from copy import deepcopy as _deepcopy
 import numpy as np
 import pandas as pd
 from scipy.fftpack import next_fast_len
+from scipy.interpolate import CubicSpline
 from scipy.stats.mstats import mquantiles
 from xarray import apply_ufunc
 
@@ -554,3 +555,18 @@ def _circular_standard_deviation(samples, high=2 * np.pi, low=0, skipna=False, a
     c_c = np.cos(ang).mean(axis=axis)
     r_r = np.hypot(s_s, c_c)
     return ((high - low) / 2.0 / np.pi) * np.sqrt(-2 * np.log(r_r))
+
+
+def smooth_data(obs_vals, pp_vals):
+    """
+    Helper function to smooth discrete data in plot_pbv, loo_pit and plot_loo_pit.
+    """
+    x = np.linspace(0, 1, len(obs_vals))
+    csi = CubicSpline(x, obs_vals)
+    obs_vals = csi(np.linspace(0.01, 0.99, len(obs_vals)))
+
+    x = np.linspace(0, 1, pp_vals.shape[1])
+    csi = CubicSpline(x, pp_vals, axis=1)
+    pp_vals = csi(np.linspace(0.01, 0.99, pp_vals.shape[1]))
+
+    return obs_vals, pp_vals

--- a/arviz/stats/stats_utils.py
+++ b/arviz/stats/stats_utils.py
@@ -558,9 +558,7 @@ def _circular_standard_deviation(samples, high=2 * np.pi, low=0, skipna=False, a
 
 
 def smooth_data(obs_vals, pp_vals):
-    """
-    Helper function to smooth discrete data in plot_pbv, loo_pit and plot_loo_pit.
-    """
+    """Smooth data, helper function for discrete data in plot_pbv, loo_pit and plot_loo_pit."""
     x = np.linspace(0, 1, len(obs_vals))
     csi = CubicSpline(x, obs_vals)
     obs_vals = csi(np.linspace(0.01, 0.99, len(obs_vals)))


### PR DESCRIPTION
We recently introducing a smoothing step for discrete data in `plot_pbv`, this does the same but for loo_pit. See example below. I am omitting plot from `plot_pbv`, because they were part of a previous PR.

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [ ] New features are properly documented (with an example if appropriate)?
- [ ] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)


binomial well-calibrated old
![binomial_good_old](https://user-images.githubusercontent.com/1338958/104733613-b8248000-571d-11eb-8172-95fbb3709a7c.png)


binomial well-calibrated new
![binomial_good_new](https://user-images.githubusercontent.com/1338958/104733624-bd81ca80-571d-11eb-8c96-c0250e7cebff.png)


binomial bad-calibrated old
![binomial_bad_old](https://user-images.githubusercontent.com/1338958/104733360-56641600-571d-11eb-9071-32b4ef03acd1.png)

binomial bad-calibrated new
![binomial_bad_new](https://user-images.githubusercontent.com/1338958/104733646-c5416f00-571d-11eb-8176-c38a0e4b2ffe.png)


Poisson well-calibrated old
![poisson_good_old](https://user-images.githubusercontent.com/1338958/104733668-cd011380-571d-11eb-948c-6f3cb48613f4.png)


Poisson well-calibrated new
![poisson_good_new](https://user-images.githubusercontent.com/1338958/104733710-e013e380-571d-11eb-94f1-52e1b5f92e25.png)


poisson bad-calibrated old
![poisson_bad_old](https://user-images.githubusercontent.com/1338958/104733721-e609c480-571d-11eb-9e94-ddc87f92dc0d.png)


poisson bad-calibrated new
![poisson_bad_new](https://user-images.githubusercontent.com/1338958/104733742-ec983c00-571d-11eb-987c-9f45d1adab06.png)

