### PR TITLE
Suppress false positive missing method mypy errors.

### DIFF
--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -1297,14 +1297,16 @@ class InferenceData(Mapping[str, xr.Dataset]):
     load = _extend_xr_method(xr.Dataset.load)
     compute = _extend_xr_method(xr.Dataset.compute)
     persist = _extend_xr_method(xr.Dataset.persist)
-
-    mean = _extend_xr_method(xr.Dataset.mean, see_also="median")
-    median = _extend_xr_method(xr.Dataset.median, see_also="mean")
-    min = _extend_xr_method(xr.Dataset.min, see_also=["max", "sum"])
-    max = _extend_xr_method(xr.Dataset.max, see_also=["min", "sum"])
-    cumsum = _extend_xr_method(xr.Dataset.cumsum, see_also="sum")
-    sum = _extend_xr_method(xr.Dataset.sum, see_also="cumsum")
     quantile = _extend_xr_method(xr.Dataset.quantile)
+
+    # The following lines use methods on xr.Dataset that are dynamically defined and attached.
+    # As a result mypy cannot see them, so we have to suppress the resulting mypy errors.
+    mean = _extend_xr_method(xr.Dataset.mean, see_also="median")  # type: ignore[attr-defined]
+    median = _extend_xr_method(xr.Dataset.median, see_also="mean")  # type: ignore[attr-defined]
+    min = _extend_xr_method(xr.Dataset.min, see_also=["max", "sum"])  # type: ignore[attr-defined]
+    max = _extend_xr_method(xr.Dataset.max, see_also=["min", "sum"])  # type: ignore[attr-defined]
+    cumsum = _extend_xr_method(xr.Dataset.cumsum, see_also="sum")  # type: ignore[attr-defined]
+    sum = _extend_xr_method(xr.Dataset.sum, see_also="cumsum")  # type: ignore[attr-defined]
 
     def _group_names(
         self,


### PR DESCRIPTION
## Description
Suppress the following false positive `mypy` type errors, without affecting any of the underlying functionality. Working toward #1496.
```
arviz/data/inference_data.py:1301: error: "Type[Dataset]" has no attribute "mean"  [attr-defined]
arviz/data/inference_data.py:1302: error: "Type[Dataset]" has no attribute "median"  [attr-defined]
arviz/data/inference_data.py:1303: error: "Type[Dataset]" has no attribute "min"  [attr-defined]
arviz/data/inference_data.py:1304: error: "Type[Dataset]" has no attribute "max"  [attr-defined]
arviz/data/inference_data.py:1305: error: "Type[Dataset]" has no attribute "cumsum"  [attr-defined]
arviz/data/inference_data.py:1306: error: "Type[Dataset]" has no attribute "sum"  [attr-defined]
```

These errors arise from the fact that the `Dataset` type has some [dynamically-defined methods](https://github.com/pydata/xarray/blob/master/xarray/core/dataset.py#L6858). Since those methods are not visible to mypy, it assumes they don't exist and therefore their use results in a false-positive type error.

## Checklist
- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Code style  correct (follows pylint and black guidelines)