### PR TITLE
Add a possible type hint to the @requires decorator.

### DIFF
--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -214,10 +214,13 @@ class PyMC3Converter:  # pylint: disable=too-many-instance-attributes
             log_like_val = np.where(mask, np.nan, log_like_val)
         return log_like_val
 
-    @requires("trace")
-    @requires("model")
     def _extract_log_likelihood(self, trace):
         """Compute log likelihood of each observation."""
+        if self.trace is None:
+            return None
+        if self.model is None:
+            return None
+
         # If we have predictions, then we have a thinned trace which does not
         # support extracting a log likelihood.
         if self.log_likelihood is True:


### PR DESCRIPTION
## Description
This PR type-hints the `@requires` decorator, which seems to be used in over 100 places in the repository at the moment. Since decorators are a bit tricky to type-hint correctly, and still have some unsolved edge cases with regard to type-hinting (https://github.com/python/mypy/issues/3157 comes to mind), I wanted to open this PR as an example of the available options and to provide a bit more context for #1498 where we were discussing whether to use `@requires` or not. Also tangentially related to #1496.

The gist of the still-open `mypy` [issue](https://github.com/python/mypy/issues/3157) is that there's no great way to type-hint decorators that work on functions with arbitrary type signatures but change the input function's type signature in some way. The `@requires` decorator falls in this category because it works over functions with arbitrary inputs and outputs, and simply wraps the function's return type in an `Optional`.

This limitation leaves us with two options.

* Option 1 (implemented in this PR): allow `@requires` to work on arbitrary functions, but make the resulting decorated function's input argument signature appear to be `f(*args, **kwargs)`.

This is an excerpt of what that looks like:
```python
RequiresReturnTypeT = TypeVar("RequiresReturnTypeT")

def __call__(
    self, func: Callable[..., RequiresReturnTypeT]
) -> Callable[..., Optional[RequiresReturnTypeT]]:
```

The `Callable[..., Foo]` syntax means "this function allows any positional and keyword arguments". The equivalent way to define a function with such a signature in Python would be this:
```python
def foo(*args: Any, **kwargs: Any) -> Foo:
    ...
```

Pro: `@requires` can be used with arbitrary functions
Con: Functions decorated with `@requires` thus lose their type signatures, and `mypy` is no longer able to statically check their call sites since they appear callable with any input arguments.

* Option 2 (viable alternative, but limits `@requires` functionality): only allow `@requires` to be used on functions with one positional argument (i.e. ones that look like `def foo(self) -> Foo`), then preserve the function signature through the decoration process.

I didn't want to implement this option without asking for approval first, since it does limit what `@requires` can do and I'm not sure if it is always used with only a single argument. However, if this option seems reasonable to all the maintainers, it is definitely preferable from a `mypy` perspective since it preserves the ability for `mypy` to type-check call sites of functions decorated with `@requires`.

This is what that would look like, as an excerpt:

```python
ArgTypeT = TypeVar("ArgTypeT")
RequiresReturnTypeT = TypeVar("RequiresReturnTypeT")

def __call__(
    self, func: Callable[[ArgTypeT], RequiresReturnTypeT] 
) -> Callable[[ArgTypeT], Optional[RequiresReturnTypeT]]:
    ...
```

The pro/con here are essentially the reverse of Option 1's ones above. You can see that the decorated function has a specific type signature including the function's argument types, and the generics (the `TypeVar` values) allow us to express the "same type as in the input function" type relationships between the function being decorated and the final produced function. This allows `mypy` to perform type-checking of calls to the decorated function, at the cost of only allowing a single argument to the function.

In principle, similar variants of this decorator could be written for 2-argument or arbitrary k-argument versions of the same functionality. I admit that's not the most elegant option, but until the relevant portion of https://github.com/python/mypy/issues/3157 is resolved, this is the best we can do.

I'd be happy to implement either of these options, based on whatever the maintainers decide is the best way forward for this project.

## Checklist
- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Code style  correct (follows pylint and black guidelines)