### PR TITLE
Avoid overwriting a variable with value of different type.

### DIFF
--- a/arviz/plots/traceplot.py
+++ b/arviz/plots/traceplot.py
@@ -172,19 +172,21 @@ def plot_trace(
     else:
         divergence_data = False
 
-    data = get_coords(convert_to_dataset(data, group="posterior"), coords)
+    coords_data = get_coords(convert_to_dataset(data, group="posterior"), coords)
 
     if transform is not None:
-        data = transform(data)
+        coords_data = transform(coords_data)
 
-    var_names = _var_names(var_names, data, filter_vars)
+    var_names = _var_names(var_names, coords_data, filter_vars)
 
     if compact:
-        skip_dims = set(data.dims) - {"chain", "draw"}
+        skip_dims = set(coords_data.dims) - {"chain", "draw"}
     else:
         skip_dims = set()
 
-    plotters = list(xarray_var_iter(data, var_names=var_names, combined=True, skip_dims=skip_dims))
+    plotters = list(
+        xarray_var_iter(coords_data, var_names=var_names, combined=True, skip_dims=skip_dims)
+    )
     max_plots = rcParams["plot.max_subplots"]
     max_plots = len(plotters) if max_plots is None else max(max_plots // 2, 1)
     if len(plotters) > max_plots:
@@ -199,7 +201,7 @@ def plot_trace(
     # TODO: Check if this can be further simplified
     trace_plot_args = dict(
         # User Kwargs
-        data=data,
+        data=coords_data,
         var_names=var_names,
         # coords = coords,
         divergences=divergences,


### PR DESCRIPTION
## Description
Avoids the following `mypy` error:
```
arviz/plots/traceplot.py:183: error: "InferenceData" has no attribute "dims"  [attr-defined]
```
Part of #1496.

The error was happening because the `data` variable was initially of type `InferenceData` but was later overwritten with a value of different type on the line:
```python
data = get_coords(convert_to_dataset(data, group="posterior"), coords)
```
In general, assigning a value of a completely different type to an existing variable will cause both `mypy` and `pylint` to complain about the assignment itself. In this case, the `get_coords()` function itself was not type-hinted, i.e. its return type was considered to be `Any`. This led `mypy` to incorrectly deduce that the return type must have preserved the existing type of `data`, because not doing so would have been an immediate error.

Renaming the assignment on that line to a new variable name avoids the current error as well as the possible future `mypy` or `pylint` errors arising when and if `get_coords()` gets a type hint for its return type.

## Checklist
- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Code style  correct (follows pylint and black guidelines)