### PR TITLE
Standardized error messaging in pairplot and parallelplot

### DIFF
--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -235,7 +235,7 @@ def plot_pair(
     numvars = len(flat_var_names)
 
     if numvars < 2:
-        raise Exception("Number of variables to be plotted must be 2 or greater.")
+        raise ValueError("Number of variables to be plotted must be 2 or greater.")
 
     pairplot_kwargs = dict(
         ax=ax,

--- a/arviz/plots/parallelplot.py
+++ b/arviz/plots/parallelplot.py
@@ -116,7 +116,7 @@ def plot_parallel(
         get_coords(posterior_data, coords), var_names=var_names, combined=True
     )
     if len(var_names) < 2:
-        raise ValueError("This plot needs at least two variables")
+        raise ValueError("Number of variables to be plotted must be 2 or greater.")
     if norm_method is not None:
         if norm_method == "normal":
             mean = np.mean(_posterior, axis=1)


### PR DESCRIPTION
## Description
This should solve "Make exception consistent between plot_pair and plot_parallel" issue #1507. Now, both plots should raise ValueError with the same error prompt if the number of variables is less than 2. Beginner, so please let me know what I missed. 
<!--
Thank you so much for your PR! To help us review your contribution, please consider the following points:

- The PR title should summarize the changes, for example "Add new group argument for the pair plot".
  Avoid non-descriptive titles such as "Addresses issue #348".

- The description should provide at least 1-2 sentences describing the pull request in detail and
  link to any relevant issues.

- Please prefix the title of incomplete contributions with [WIP] (to indicate a work in
  progress). WIPs may be useful to (1) indicate you are working on something to avoid
  duplicated work, (2) request broad review of functionality or API, or (3) seek collaborators. -->

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [ ] New features are properly documented (with an example if appropriate)?
- [ ] Includes new or updated tests to cover the new feature
- [ ] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/master/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
