### PR TITLE
Fix circular traceplot warnings and title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### New features
 
 ### Maintenance and fixes
-
+* Fixed ovelapping titles and repeating warnings on circular traceplot ([1517](https://github.com/arviz-devs/arviz/pull/1517))
 ### Deprecation
 
 ### Documentation

--- a/arviz/plots/backends/matplotlib/kdeplot.py
+++ b/arviz/plots/backends/matplotlib/kdeplot.py
@@ -2,6 +2,7 @@
 import numpy as np
 from matplotlib import pyplot as plt
 from matplotlib import _pylab_helpers
+import matplotlib.ticker as mticker
 
 
 from ...plot_utils import _scale_fig_size
@@ -101,6 +102,8 @@ def plot_kde(
                     f"{-np.pi/4:.2f}",
                 ]
 
+                ticks_loc = ax.get_xticks()
+                ax.xaxis.set_major_locator(mticker.FixedLocator(ticks_loc))
                 ax.set_xticklabels(labels)
 
             x = np.linspace(-np.pi, np.pi, len(density))

--- a/arviz/plots/backends/matplotlib/traceplot.py
+++ b/arviz/plots/backends/matplotlib/traceplot.py
@@ -319,11 +319,11 @@ def plot_trace(
             if value[0].dtype.kind == "i" and idy == 0:
                 xticks = get_bins(value)
                 ax.set_xticks(xticks[:-1])
+            y = 1 / textsize
             if not idy:
                 ax.set_yticks([])
-                y = 0.13 if selection else 0.12
-            else:
-                y = 1 / textsize
+                if circular:
+                    y = 0.13 if selection else 0.12
             ax.set_title(
                 make_label(var_name, selection), fontsize=titlesize, wrap=True, y=textsize * y
             )

--- a/arviz/plots/backends/matplotlib/traceplot.py
+++ b/arviz/plots/backends/matplotlib/traceplot.py
@@ -6,6 +6,7 @@ import matplotlib.gridspec as gridspec
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.lines import Line2D
+import matplotlib.ticker as mticker
 
 from ....stats.density_utils import get_bins
 from ...distplot import plot_dist
@@ -320,7 +321,12 @@ def plot_trace(
                 ax.set_xticks(xticks[:-1])
             if not idy:
                 ax.set_yticks([])
-            ax.set_title(make_label(var_name, selection), fontsize=titlesize, wrap=True, y=1)
+                y = 0.13 if selection else 0.12
+            else:
+                y = 1 / textsize
+            ax.set_title(
+                make_label(var_name, selection), fontsize=titlesize, wrap=True, y=textsize * y
+            )
             ax.tick_params(labelsize=xt_labelsize)
 
             xlims = ax.get_xlim()
@@ -471,6 +477,7 @@ def _plot_chains_mpl(
                 if circ_units_trace == "degrees":
                     y_tick_locs = axes.get_yticks()
                     y_tick_labels = [i + 2 * 180 if i < 0 else i for i in np.rad2deg(y_tick_locs)]
+                    axes.yaxis.set_major_locator(mticker.FixedLocator(y_tick_locs))
                     axes.set_yticklabels([f"{i:.0f}°" for i in y_tick_labels])
 
         if not combined:


### PR DESCRIPTION
## Description

When plotting circular variables with `plot_trace` the circular subplot title overlaps with the x tick labels. I also fixed repeating warnings derived from changing of tick locations.

On master:
![trace_plot_master](https://user-images.githubusercontent.com/8028618/105483862-3c7c8300-5c89-11eb-9847-c5e1c6bac11e.png)

This PR:
![trace_plot](https://user-images.githubusercontent.com/8028618/105483877-42726400-5c89-11eb-9a4b-af60133cdc51.png)


## Checklist
- [X] Follows [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist) PR format
- [X] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [X] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#v0xx-unreleased)