### PR TITLE
[docs] Tabs for example gallery!

### DIFF
--- a/.azure-pipelines/azure-pipelines-docs.yml
+++ b/.azure-pipelines/azure-pipelines-docs.yml
@@ -53,7 +53,6 @@ jobs:
       # install emcee
       python -m pip install emcee
       python -m pip install .
-      conda install -y geckodriver firefox --channel conda-forge
     displayName: 'Install requirements'
 
   - script: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Deprecation
 
 ### Documentation
+* Use tabs in ArviZ example gallery ([1521](https://github.com/arviz-devs/arviz/pull/1521))
 
 ## v0.11.0 (2021 Dec 17)
 ### New features

--- a/doc/_templates/404.html
+++ b/doc/_templates/404.html
@@ -9,10 +9,12 @@
         <main>
           <div class="col d-flex">
             <div class="card" style="width: 30rem;">
-              <img class="card-img-top" src="_static/404.png" alt="">
+              <img class="card-img-top" src="https://raw.githubusercontent.com/arviz-devs/arviz/master/doc/source/_static/404.png" alt="">
               <div class="card-body">
                 <h5 class="card-title">Page not found</h5>
+                <p class="card-text">Sorry, it looks like your sampler ventured to an undefined region of the documentation space.</p>
                 <p class="card-text">The page you are looking for could not be found.</p>
+                <p class="card-text">Click on the link below to go back to home page (the navbar links are probably not working either).</p>
                 <a href="https://arviz-devs.github.io/arviz/" class="card-link">Back to Home Page</a>
               </div>
             </div>

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -59,7 +59,7 @@ extensions = [
     "IPython.sphinxext.ipython_console_highlighting",
     "gallery_generator",
     "myst_nb",
-    'notfound.extension',
+    "sphinx_panels"
 ]
 
 # ipython directive configuration
@@ -83,6 +83,7 @@ templates_path = ["../_templates"]
 # MyST related params
 jupyter_execute_notebooks = "off"
 myst_heading_anchors = 3
+panels_add_bootstrap_css = False
 
 
 # The base toctree document.
@@ -154,9 +155,6 @@ html_static_path = ["_static", thumb_directory]
 html_additional_pages = {
     '404': '404.html',
 }
-# configure notfound extension to not add any prefix to the urls
-notfound_urls_prefix = "/arviz/"
-
 
 # -- Options for HTMLHelp output ------------------------------------------
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -101,90 +101,90 @@ If you use ArviZ and want to **cite** it please use |JOSS|. Here is the citation
       <div class="container">
         <div class="row">
             <div class="col">
-            <a href="examples/matplotlib/mpl_plot_pair.html">
+            <a href="examples/plot_pair.html">
             <div class="img-thumbnail">
-                <img src="_static/mpl_plot_pair_thumb.png">
+                <img src="_static/plot_pair_thumb.png">
             </div>
             </a>
             </div>
             <div class="col">
-            <a href="examples/matplotlib/mpl_plot_forest.html">
+            <a href="examples/plot_forest.html">
             <div class="img-thumbnail">
-                <img src="_static/mpl_plot_forest_thumb.png">
+                <img src="_static/plot_forest_thumb.png">
             </div>
             </a>
             </div>
             <div class="col">
-            <a href="examples/matplotlib/mpl_plot_density.html">
+            <a href="examples/plot_density.html">
             <div class="img-thumbnail">
-                <img src="_static/mpl_plot_density_thumb.png">
+                <img src="_static/plot_density_thumb.png">
             </div>
             </a>
             </div>
             <div class="col">
-            <a href="examples/matplotlib/mpl_plot_energy.html">
+            <a href="examples/plot_energy.html">
             <div class="img-thumbnail">
-                <img src="_static/mpl_plot_energy_thumb.png">
-            </div>
-            </a>
-            </div>
-        </div>
-        <div class="row">
-            <div class="col">
-            <a href="examples/matplotlib/mpl_plot_posterior.html">
-            <div class="img-thumbnail">
-                <img src="_static/mpl_plot_posterior_thumb.png">
-            </div>
-            </a>
-            </div>
-            <div class="col">
-            <a href="examples/matplotlib/mpl_plot_kde_2d.html">
-            <div class="img-thumbnail">
-                <img src="_static/mpl_plot_kde_2d_thumb.png">
-            </div>
-            </a>
-            </div>
-            <div class="col">
-            <a href="examples/matplotlib/mpl_plot_forest_ridge.html">
-            <div class="img-thumbnail">
-                <img src="_static/mpl_plot_forest_ridge_thumb.png">
-            </div>
-            </a>
-            </div>
-            <div class="col">
-            <a href="examples/matplotlib/mpl_plot_parallel.html">
-            <div class="img-thumbnail">
-                <img src="_static/mpl_plot_parallel_thumb.png">
+                <img src="_static/plot_energy_thumb.png">
             </div>
             </a>
             </div>
         </div>
         <div class="row">
             <div class="col">
-            <a href="examples/matplotlib/mpl_plot_trace.html">
+            <a href="examples/plot_posterior.html">
             <div class="img-thumbnail">
-                <img src="_static/mpl_plot_trace_thumb.png">
+                <img src="_static/plot_posterior_thumb.png">
             </div>
             </a>
             </div>
             <div class="col">
-            <a href="examples/matplotlib/mpl_plot_joint.html">
+            <a href="examples/plot_kde_2d.html">
             <div class="img-thumbnail">
-                <img src="_static/mpl_plot_joint_thumb.png">
+                <img src="_static/plot_kde_2d_thumb.png">
             </div>
             </a>
             </div>
             <div class="col">
-            <a href="examples/matplotlib/mpl_plot_ppc.html">
+            <a href="examples/plot_forest_ridge.html">
             <div class="img-thumbnail">
-                <img src="_static/mpl_plot_ppc_thumb.png">
+                <img src="_static/plot_forest_ridge_thumb.png">
             </div>
             </a>
             </div>
             <div class="col">
-            <a href="examples/matplotlib/mpl_plot_autocorr.html">
+            <a href="examples/plot_parallel.html">
             <div class="img-thumbnail">
-                <img src="_static/mpl_plot_autocorr_thumb.png">
+                <img src="_static/plot_parallel_thumb.png">
+            </div>
+            </a>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col">
+            <a href="examples/plot_trace.html">
+            <div class="img-thumbnail">
+                <img src="_static/plot_trace_thumb.png">
+            </div>
+            </a>
+            </div>
+            <div class="col">
+            <a href="examples/plot_joint.html">
+            <div class="img-thumbnail">
+                <img src="_static/plot_joint_thumb.png">
+            </div>
+            </a>
+            </div>
+            <div class="col">
+            <a href="examples/plot_ppc.html">
+            <div class="img-thumbnail">
+                <img src="_static/plot_ppc_thumb.png">
+            </div>
+            </a>
+            </div>
+            <div class="col">
+            <a href="examples/plot_autocorr.html">
+            <div class="img-thumbnail">
+                <img src="_static/plot_autocorr_thumb.png">
             </div>
             </a>
             </div>

--- a/doc/sphinxext/gallery_generator.py
+++ b/doc/sphinxext/gallery_generator.py
@@ -375,7 +375,7 @@ class ExampleGenerator:
                     exec(code_text)
 
     def toctree_entry(self):
-        return "   ./%s\n\n" % op.join(op.splitext(self.htmlfilename)[0])
+        return "   ./{}\n\n".format(op.join(op.splitext(self.htmlfilename)[0]))
 
     def contents_entry(self) -> str:
         return CONTENTS_ENTRY_TEMPLATE.format(
@@ -425,7 +425,6 @@ def main(app):
             "image_dir": image_dir,
         }
 
-    toctrees_contents = ""
     toctree = "\n\n.. toctree::\n   :hidden:\n\n"
     contents = "\n\n"
 
@@ -466,7 +465,7 @@ def main(app):
         toctree += ex.toctree_entry()
         contents += ex.contents_entry()
 
-    toctrees_contents += "\n".join((toctree, contents))
+    toctrees_contents = "\n".join((toctree, contents))
     toctrees_contents += """.. raw:: html\n\n    <div style="clear: both"></div>"""
 
     # write index file

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -7,4 +7,4 @@ pydata_sphinx_theme
 selenium
 myst-parser
 myst-nb
-sphinx-notfound-page
+sphinx-panels

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -4,7 +4,6 @@ numpydoc
 pydocstyle
 Sphinx>=1.8.3
 pydata_sphinx_theme
-selenium
 myst-parser
 myst-nb
 sphinx-panels


### PR DESCRIPTION
## Description
As proposed in #1484, this PR modifies the example gallery to have a single page per type of plot.
Each page has then one tab per backend to ease comparison between backends.

You can see the preview at https://oriolabril.github.io/arviz/examples/index.html, let me know what you think about it.

Also, side note, now only one thumb per example is required, therefore, we can use matplotlib to generate thumbs and forget about exporting bokeh plots as png files and the extra dependencies it requires which I believe will simplify building docs locally.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Does the PR follow [official](https://github.com/arviz-devs/arviz/blob/master/CONTRIBUTING.md#pull-request-checklist)
      PR format?
- [x] Is the documentation [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant?
- [x] Is the fix listed in the [Documentation](https://github.com/arviz-devs/arviz/blob/master/CHANGELOG.md#documentation)
      section of the changelog?
