### PR TITLE
Removed repetitive variable names from forest plots of multivariate variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Maintenance and fixes
 * Fixed ovelapping titles and repeating warnings on circular traceplot ([1517](https://github.com/arviz-devs/arviz/pull/1517))
+* Removed repetitive variable names from forest plots of multivariate variables ([1527](https://github.com/arviz-devs/arviz/pull/1527))
+
 ### Deprecation
 
 ### Documentation

--- a/arviz/plots/backends/bokeh/forestplot.py
+++ b/arviz/plots/backends/bokeh/forestplot.py
@@ -572,9 +572,16 @@ class VarHandler:
                     skip_dims=skip_dims,
                     reverse_selections=True,
                 )
-                for _, selection, values in datum_iter:
+                datum_list = list(datum_iter)
+                for _, selection, values in datum_list:
                     selection_list.append(selection)
-                    label = make_label(self.var_name, selection, position="beside")
+                    if not selection:
+                        var_name = self.var_name
+                    elif len(selection_list)==len(datum_list):
+                        var_name = self.var_name + ':'
+                    else:
+                        var_name = ''
+                    label = make_label(var_name, selection, position="beside")
                     if label not in label_dict:
                         label_dict[label] = OrderedDict()
                     if name not in label_dict[label]:

--- a/arviz/plots/backends/bokeh/forestplot.py
+++ b/arviz/plots/backends/bokeh/forestplot.py
@@ -577,10 +577,10 @@ class VarHandler:
                     selection_list.append(selection)
                     if not selection:
                         var_name = self.var_name
-                    elif len(selection_list)==len(datum_list):
-                        var_name = self.var_name + ':'
+                    elif len(selection_list) == len(datum_list):
+                        var_name = self.var_name + ":"
                     else:
-                        var_name = ''
+                        var_name = ""
                     label = make_label(var_name, selection, position="beside")
                     if label not in label_dict:
                         label_dict[label] = OrderedDict()

--- a/arviz/plots/backends/matplotlib/forestplot.py
+++ b/arviz/plots/backends/matplotlib/forestplot.py
@@ -519,7 +519,7 @@ class VarHandler:
                     selection_list.append(selection)
                     if not selection:
                         var_name = self.var_name
-                    elif len(selection_list) == len(datum_list):
+                    elif not len(selection_list) % len(datum_list):
                         var_name = self.var_name + ":"
                     else:
                         var_name = ""

--- a/arviz/plots/backends/matplotlib/forestplot.py
+++ b/arviz/plots/backends/matplotlib/forestplot.py
@@ -519,10 +519,10 @@ class VarHandler:
                     selection_list.append(selection)
                     if not selection:
                         var_name = self.var_name
-                    elif len(selection_list)==len(datum_list):
-                        var_name = self.var_name + ':'
+                    elif len(selection_list) == len(datum_list):
+                        var_name = self.var_name + ":"
                     else:
-                        var_name = ''
+                        var_name = ""
                     label = make_label(var_name, selection, position="beside")
                     if label not in label_dict:
                         label_dict[label] = OrderedDict()

--- a/arviz/plots/backends/matplotlib/forestplot.py
+++ b/arviz/plots/backends/matplotlib/forestplot.py
@@ -529,7 +529,7 @@ class VarHandler:
                     if name not in label_dict[label]:
                         label_dict[label][name] = []
                     label_dict[label][name].append(values)
-                    
+
         y = self.y_start
         for idx, (label, model_data) in enumerate(label_dict.items()):
             for model_name, value_list in model_data.items():

--- a/arviz/plots/backends/matplotlib/forestplot.py
+++ b/arviz/plots/backends/matplotlib/forestplot.py
@@ -514,15 +514,22 @@ class VarHandler:
                     skip_dims=skip_dims,
                     reverse_selections=True,
                 )
-                for _, selection, values in datum_iter:
+                datum_list = list(datum_iter)
+                for _, selection, values in datum_list:
                     selection_list.append(selection)
-                    label = make_label(self.var_name, selection, position="beside")
+                    if not selection:
+                        var_name = self.var_name
+                    elif len(selection_list)==len(datum_list):
+                        var_name = self.var_name + ':'
+                    else:
+                        var_name = ''
+                    label = make_label(var_name, selection, position="beside")
                     if label not in label_dict:
                         label_dict[label] = OrderedDict()
                     if name not in label_dict[label]:
                         label_dict[label][name] = []
                     label_dict[label][name].append(values)
-
+                    
         y = self.y_start
         for idx, (label, model_data) in enumerate(label_dict.items()):
             for model_name, value_list in model_data.items():


### PR DESCRIPTION
Forest plots of multivariate variables currently prepend the variable name to each element label, which adds a lot of clutter to the plot. This removes the variable names from all but the first element.

Can add this feature to other plots as needed, either here or in a separate PR.

Not sure what sort of test would be relevant here, if any.

Closes #1524 