### PR TITLE
fix plot_pair labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Maintenance and fixes
 * Fixed ovelapping titles and repeating warnings on circular traceplot ([1517](https://github.com/arviz-devs/arviz/pull/1517))
 * Removed repetitive variable names from forest plots of multivariate variables ([1527](https://github.com/arviz-devs/arviz/pull/1527))
+* Fixed regression in `plot_pair` labels that prevented coord names to be shown when necessary ([1533](https://github.com/arviz-devs/arviz/pull/1533))
 
 ### Deprecation
 

--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -10,8 +10,8 @@ from ..utils import _var_names, get_coords
 from .plot_utils import (
     get_plotting_function,
     xarray_to_ndarray,
-    filter_plotters_list,
     xarray_var_iter,
+    make_label,
 )
 
 
@@ -194,11 +194,10 @@ def plot_pair(
     # Get posterior draws and combine chains
     dataset = convert_to_dataset(data, group=group)
     var_names = _var_names(var_names, dataset, filter_vars)
-    plotters = filter_plotters_list(
-        list(xarray_var_iter(get_coords(dataset, coords), var_names=var_names, combined=True)),
-        "plot_pair",
+    plotters = list(
+        xarray_var_iter(get_coords(dataset, coords), var_names=var_names, combined=True)
     )
-    flat_var_names = [plotter[0] for plotter in plotters]
+    flat_var_names = [make_label(var_name, selection) for var_name, selection, _ in plotters]
 
     divergent_data = None
     diverging_mask = None


### PR DESCRIPTION
## Description
Fixes #1531. This PR makes only a couple minor changes to plot_pair. The first one is to
fix the generation of the plot labels and the second is to avoid calling filter twice. As
plot_pair generates a half grid of plots, its interpretation of `max_subplots` is not done on
the number of variables like with most other plots but on the actual number of subplots, may not be
ideal but the filtering is currently implemented at the backend level.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Does the PR follow [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist)
      PR format?
- [x] Is the code style correct (follows pylint and black guidelines)?
- [x] Is the fix listed in the [Maintenance and fixes](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#maintenance-and-fixes)
      section of the changelog?

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
