### PR TITLE
autocorrelation plot add ci band and remove hline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v0.x.x Unreleased
 ### New features
+* add confidence interval band to auto-correlation plot ([1535](https://github.com/arviz-devs/arviz/pull/1535))
+
+https://github.com/arviz-devs/arviz/pull/1535
 
 ### Maintenance and fixes
 * Fixed ovelapping titles and repeating warnings on circular traceplot ([1517](https://github.com/arviz-devs/arviz/pull/1517))

--- a/arviz/plots/backends/bokeh/autocorrplot.py
+++ b/arviz/plots/backends/bokeh/autocorrplot.py
@@ -1,7 +1,8 @@
 """Bokeh Autocorrplot."""
 import numpy as np
-from bokeh.models import DataRange1d
+from bokeh.models import DataRange1d, BoxAnnotation
 from bokeh.models.annotations import Title
+
 
 from ....stats import autocorr
 from ...plot_utils import _scale_fig_size, make_label
@@ -74,8 +75,10 @@ def plot_autocorr(
         x_prime = x
         if combined:
             x_prime = x.flatten()
+        c_i = 1.96 / x_prime.size ** 0.5
         y = autocorr(x_prime)
 
+        ax.add_layout(BoxAnnotation(bottom=-c_i, top=c_i, fill_color="gray"))
         ax.segment(
             x0=np.arange(len(y)),
             y0=0,
@@ -84,7 +87,6 @@ def plot_autocorr(
             line_width=line_width,
             line_color="black",
         )
-        ax.line([0, 0], [0, max_lag], line_color="steelblue")
 
         title = Title()
         title.text = make_label(var_name, selection)

--- a/arviz/plots/backends/matplotlib/autocorrplot.py
+++ b/arviz/plots/backends/matplotlib/autocorrplot.py
@@ -49,9 +49,12 @@ def plot_autocorr(
         x_prime = x
         if combined:
             x_prime = x.flatten()
+        c_i = 1.96 / x_prime.size ** 0.5
         y = autocorr(x_prime)
+
+        ax.fill_between([0, max_lag], -c_i, c_i, color="0.75")
         ax.vlines(x=np.arange(0, max_lag), ymin=0, ymax=y[0:max_lag], lw=linewidth)
-        ax.hlines(0, 0, max_lag, "steelblue")
+
         ax.set_title(make_label(var_name, selection), fontsize=titlesize, wrap=True)
         ax.tick_params(labelsize=xt_labelsize)
 


### PR DESCRIPTION
Add confidence interval to auto correlation plot. It also remove the horizontal line at 0 (which color was "steeelblue", for historical reasons.)

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [x] New features are properly documented (with an example if appropriate)?
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

old version 
![autocorrelation_plot_old](https://user-images.githubusercontent.com/1338958/107090696-5b2d5e80-67df-11eb-8ec8-66ce75e8cc3b.png)

new version
![autocorrelation_plot_new](https://user-images.githubusercontent.com/1338958/107090721-641e3000-67df-11eb-9f52-59672da843b7.png)

