### PR TITLE
Add sphinx.notfound extension (again)

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -59,7 +59,8 @@ extensions = [
     "IPython.sphinxext.ipython_console_highlighting",
     "gallery_generator",
     "myst_nb",
-    "sphinx_panels"
+    "sphinx_panels",
+    "notfound.extension"
 ]
 
 # ipython directive configuration

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -7,3 +7,4 @@ pydata_sphinx_theme
 myst-parser
 myst-nb
 sphinx-panels
+sphinx-notfound-page


### PR DESCRIPTION
## Description
I removed the extension because it does not work with the navbar, you click there and
the url somehow grows instead of going to the right page. I have then realized however
that even though it does not fix the paths and references in the navbar, it does fix the
references to the css style and makes the page look good.

Now notfound pages generally look like: 

![image](https://user-images.githubusercontent.com/23738400/107165637-cfb8f680-69b3-11eb-80e2-5db0baa1d57d.png)

instead of looking like:

![image](https://user-images.githubusercontent.com/23738400/107165715-13abfb80-69b4-11eb-8e34-a61bbb4298f8.png)



## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Does the PR follow [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format?
- [x] Is the documentation [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant?
- [ ] Is the fix listed in the [Documentation](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#documentation)
  section of the changelog?

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

- If you are contributing fixes to docstrings, please pay attention to
  https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#docstring-formatting.
  In particular, note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
