### PR TITLE
Remove varname from legend in plotppc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Maintenance and fixes
 * Updated `from_cmdstan` and `from_numpyro` converter to follow schema convention ([1541](https://github.com/arviz-devs/arviz/pull/1541) and [1525](https://github.com/arviz-devs/arviz/pull/1525))
 * Fix calculation of mode as point estimate ([1552](https://github.com/arviz-devs/arviz/pull/1552))
+* Remove variable name from legend in posterior predictive plot ([1559](https://github.com/arviz-devs/arviz/pull/1559))
 
 ### Deprecation
 * Removed Geweke diagnostic ([1545](https://github.com/arviz-devs/arviz/pull/1545))

--- a/arviz/plots/backends/matplotlib/ppcplot.py
+++ b/arviz/plots/backends/matplotlib/ppcplot.py
@@ -124,14 +124,12 @@ def plot_ppc(
             plot_kwargs = {"color": color, "alpha": alpha, "linewidth": 0.5 * linewidth}
             if dtype == "i":
                 plot_kwargs["drawstyle"] = "steps-pre"
-            ax_i.plot(
-                [], color=color, label="{} predictive {}".format(group.capitalize(), pp_var_name)
-            )
+            ax_i.plot([], color=color, label="{} predictive".format(group.capitalize()))
             if observed:
                 if dtype == "f":
                     plot_kde(
                         obs_vals,
-                        label="Observed {}".format(var_name),
+                        label="Observed",
                         plot_kwargs={"color": "k", "linewidth": linewidth, "zorder": 3},
                         fill_kwargs={"alpha": 0},
                         ax=ax_i,
@@ -144,7 +142,7 @@ def plot_ppc(
                     ax_i.plot(
                         bin_edges,
                         hist,
-                        label="Observed {}".format(var_name),
+                        label="Observed",
                         color="k",
                         linewidth=linewidth,
                         zorder=3,
@@ -179,7 +177,7 @@ def plot_ppc(
                         ax_i.plot(x_s, y_s, **plot_kwargs)
 
             if mean:
-                label = "{} predictive mean {}".format(group.capitalize(), pp_var_name)
+                label = "{} predictive mean".format(group.capitalize())
                 if dtype == "f":
                     rep = len(pp_densities)
                     len_density = len(pp_densities[0])
@@ -224,7 +222,7 @@ def plot_ppc(
                     *_empirical_cdf(obs_vals),
                     color="k",
                     linewidth=linewidth,
-                    label="Observed {}".format(var_name),
+                    label="Observed",
                     drawstyle=drawstyle,
                     zorder=3
                 )
@@ -253,7 +251,7 @@ def plot_ppc(
                     drawstyle=drawstyle,
                     linewidth=linewidth
                 )
-            ax_i.plot([], color=color, label="Posterior predictive {}".format(pp_var_name))
+            ax_i.plot([], color=color, label="Posterior predictive")
             if mean:
                 ax_i.plot(
                     *_empirical_cdf(pp_vals.flatten()),
@@ -261,7 +259,7 @@ def plot_ppc(
                     linestyle="--",
                     linewidth=linewidth * 1.5,
                     drawstyle=drawstyle,
-                    label="Posterior predictive mean {}".format(pp_var_name)
+                    label="Posterior predictive mean"
                 )
             ax_i.set_yticks([0, 0.5, 1])
 
@@ -276,7 +274,7 @@ def plot_ppc(
                             "linewidth": linewidth * 1.5,
                             "zorder": 3,
                         },
-                        label="Posterior predictive mean {}".format(pp_var_name),
+                        label="Posterior predictive mean",
                         ax=ax_i,
                         legend=legend,
                     )
@@ -290,7 +288,7 @@ def plot_ppc(
                         hist,
                         color=color,
                         linewidth=linewidth * 1.5,
-                        label="Posterior predictive mean {}".format(pp_var_name),
+                        label="Posterior predictive mean",
                         zorder=3,
                         linestyle="--",
                         drawstyle="steps-pre",
@@ -316,7 +314,7 @@ def plot_ppc(
                     color="k",
                     markersize=markersize,
                     alpha=alpha,
-                    label="Observed {}".format(var_name),
+                    label="Observed",
                     zorder=4,
                 )
 
@@ -340,9 +338,7 @@ def plot_ppc(
                         vals, yvals, "o", zorder=2, color=color, markersize=markersize, alpha=alpha
                     )
 
-            ax_i.plot(
-                [], color=color, marker="o", label="Posterior predictive {}".format(pp_var_name)
-            )
+            ax_i.plot([], color=color, marker="o", label="Posterior predictive")
 
             ax_i.set_yticks([])
 

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -794,6 +794,14 @@ def test_plot_ppc_bad_ax(models, fig_ax):
         plot_ppc(models.model_1, ax=ax2)
 
 
+def test_plot_legend(models):
+    axes = plot_ppc(models.model_1)
+    legend_texts = axes.get_legend().get_texts()
+    result = [i.get_text() for i in legend_texts]
+    expected = ["Posterior predictive", "Observed", "Posterior predictive mean"]
+    assert result == expected
+
+
 @pytest.mark.parametrize("var_names", (None, "mu", ["mu", "tau"]))
 def test_plot_violin(models, var_names):
     axes = plot_violin(models.model_1, var_names=var_names)


### PR DESCRIPTION
closes #1540

## Description
<!--
Thank you so much for your PR! To help us review your contribution, please consider the following points:

- The PR title should summarize the changes, for example "Add new group argument for the pair plot".
  Avoid non-descriptive titles such as "Addresses issue #348".

- The description should provide at least 1-2 sentences describing the pull request in detail and
  link to any relevant issues.

- Please prefix the title of incomplete contributions with [WIP] (to indicate a work in
  progress). WIPs may be useful to (1) indicate you are working on something to avoid
  duplicated work, (2) request broad review of functionality or API, or (3) seek collaborators. -->

Remove varname from legend in plotppc. Motivation is:
- it's already the label of the x-axis
- if the case of multiple plots, then a single legend is still valid

xref https://github.com/arviz-devs/arviz/issues/1540#issuecomment-774667864

> Of course the current behavior is problematic, because we have one legend that is supposed to work for both plots but is referring only to the first. So I suggest to have as default one legend and remove from the legend the name of the variable.

Here's what the output from `examples/matplotlib/mpl_plot_ppc.py` would now look like - note how `obs` only appears as the label of the x-axis, rather than being repeated in the legend


![image](https://user-images.githubusercontent.com/33491632/107851528-97c21100-6e02-11eb-8312-cde4abb02175.png)



## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [x] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->