### PR TITLE
Fix pareto k threshold typo in reloo function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Maintenance and fixes
 * Enforced using coordinate values as default labels ([1201](https://github.com/arviz-devs/arviz/pull/1201))
 * Integrate `index_origin` with all the library ([1201](https://github.com/arviz-devs/arviz/pull/1201))
+* Fix pareto k threshold typo in reloo function ([1580](https://github.com/arviz-devs/arviz/pull/1580))
 
 ### Deprecation
 * Deprecated `index_origin` and `order` arguments in `az.summary` ([1201](https://github.com/arviz-devs/arviz/pull/1201))

--- a/arviz/stats/stats_refitting.py
+++ b/arviz/stats/stats_refitting.py
@@ -99,7 +99,7 @@ def reloo(wrapper, loo_orig=None, k_thresh=0.7, scale=None, verbose=True):
         warnings.warn("reloo is an experimental and untested feature", UserWarning)
 
     if np.any(khats > k_thresh):
-        for idx in np.argwhere(khats.values > 0.7):
+        for idx in np.argwhere(khats.values > k_thresh):
             if verbose:
                 _log.info("Refitting model excluding observation %d", idx)
             new_obs, excluded_obs = wrapper.sel_observations(idx)


### PR DESCRIPTION
## Description
I noticed that changing the `k_thresh` argument to the function `reloo` from the default value 0.7 had no effect. I think this is because the threshold is accidentally hard-coded as 0.7 inside the function.

This change fixes the apparent typo, replacing 0.7 with `k_thresh`.

## Checklist

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Includes new or updated tests to cover the new feature
This function is so far untested and I didn't think it made sense to write a whole test before fixing this bug.
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)