### PR TITLE
use chain serial rather than logical index with _DefaultTrace.insert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Integrate `index_origin` with all the library ([1201](https://github.com/arviz-devs/arviz/pull/1201))
 * Fix pareto k threshold typo in reloo function ([1580](https://github.com/arviz-devs/arviz/pull/1580))
 * Preserve shape from Stan code in `from_cmdstanpy` ([1579](https://github.com/arviz-devs/arviz/pull/1579))
+* Correctly use chain index when constructing PyMC3 `DefaultTrace` in `from_pymc3` ([1590](https://github.com/arviz-devs/arviz/pull/1590))
 
 ### Deprecation
 * Deprecated `index_origin` and `order` arguments in `az.summary` ([1201](https://github.com/arviz-devs/arviz/pull/1201))

--- a/arviz/data/io_pymc3.py
+++ b/arviz/data/io_pymc3.py
@@ -243,12 +243,12 @@ class PyMC3Converter:  # pylint: disable=too-many-instance-attributes
                 "`pip install pymc3>=3.8` or `conda install -c conda-forge pymc3>=3.8`."
             ) from err
         for var, log_like_fun in cached:
-            for chain in trace.chains:
+            for k, chain in enumerate(trace.chains):
                 log_like_chain = [
                     self.log_likelihood_vals_point(point, var, log_like_fun)
                     for point in trace.points([chain])
                 ]
-                log_likelihood_dict.insert(var.name, np.stack(log_like_chain), chain)
+                log_likelihood_dict.insert(var.name, np.stack(log_like_chain), k)
         return log_likelihood_dict.trace_dict
 
     @requires("trace")


### PR DESCRIPTION
This is part of a fix for an issue in PyMC3: https://github.com/pymc-devs/pymc3/issues/4469 . A trace could have chains that are not necessarily indexed 0, 1, .... However, `_DefaultTrace.insert` *does* take an index 0, 1, ... So, the index argument into `insert` should be zero-based. This PR decouples the `chain` index (which refers to a logical chain index, possibly starting at 1 or whatever) from the index passed to `_DefaultTrace.insert`.