### PR TITLE
Using color maps in plot_khat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Fix pareto k threshold typo in reloo function ([1580](https://github.com/arviz-devs/arviz/pull/1580))
 * Preserve shape from Stan code in `from_cmdstanpy` ([1579](https://github.com/arviz-devs/arviz/pull/1579))
 * Correctly use chain index when constructing PyMC3 `DefaultTrace` in `from_pymc3` ([1590](https://github.com/arviz-devs/arviz/pull/1590))
+* Fix `c` argument in `plot_khat` ([1592](https://github.com/arviz-devs/arviz/pull/1592))
 
 ### Deprecation
 * Deprecated `index_origin` and `order` arguments in `az.summary` ([1201](https://github.com/arviz-devs/arviz/pull/1201))

--- a/arviz/plots/backends/matplotlib/khatplot.py
+++ b/arviz/plots/backends/matplotlib/khatplot.py
@@ -76,31 +76,35 @@ def plot_khat(
     kwargs = matplotlib_kwarg_dealiaser(kwargs, "scatter")
     kwargs.setdefault("s", markersize)
     kwargs.setdefault("marker", "+")
-    color_mapping = None
-    cmap = None
-    if isinstance(color, str):
-        if color in dims:
-            colors, color_mapping = color_from_dim(khats, color)
-            cmap_name = kwargs.get("cmap", plt.rcParams["image.cmap"])
-            cmap = getattr(cm, cmap_name)
-            rgba_c = cmap(colors)
+
+    c_kwarg = kwargs.get("c", None)
+
+    if c_kwarg is None:
+        color_mapping = None
+        cmap = None
+        if isinstance(color, str):
+            if color in dims:
+                colors, color_mapping = color_from_dim(khats, color)
+                cmap_name = kwargs.get("cmap", plt.rcParams["image.cmap"])
+                cmap = getattr(cm, cmap_name)
+                rgba_c = cmap(colors)
+            else:
+                legend = False
+                rgba_c = to_rgba_array(np.full(n_data_points, color))
         else:
             legend = False
-            rgba_c = to_rgba_array(np.full(n_data_points, color))
-    else:
-        legend = False
-        try:
-            rgba_c = to_rgba_array(color)
-        except ValueError:
-            cmap_name = kwargs.get("cmap", plt.rcParams["image.cmap"])
-            cmap = getattr(cm, cmap_name)
-            rgba_c = cmap(color)
+            try:
+                rgba_c = to_rgba_array(color)
+            except ValueError:
+                cmap_name = kwargs.get("cmap", plt.rcParams["image.cmap"])
+                cmap = getattr(cm, cmap_name)
+                rgba_c = cmap(color)
 
-    khats = khats if isinstance(khats, np.ndarray) else khats.values.flatten()
-    alphas = 0.5 + 0.2 * (khats > 0.5) + 0.3 * (khats > 1)
-    rgba_c[:, 3] = alphas
-    rgba_c = vectorized_to_hex(rgba_c)
-    kwargs.setdefault("c", rgba_c)
+        khats = khats if isinstance(khats, np.ndarray) else khats.values.flatten()
+        alphas = 0.5 + 0.2 * (khats > 0.5) + 0.3 * (khats > 1)
+        rgba_c[:, 3] = alphas
+        rgba_c = vectorized_to_hex(rgba_c)
+        kwargs["c"] = rgba_c
 
     if ax is None:
         fig, ax = create_axes_grid(

--- a/arviz/plots/backends/matplotlib/khatplot.py
+++ b/arviz/plots/backends/matplotlib/khatplot.py
@@ -93,6 +93,7 @@ def plot_khat(
                 rgba_c = to_rgba_array(np.full(n_data_points, color))
         else:
             legend = False
+            color = (color - color.min()) / (color.max() - color.min())
             try:
                 rgba_c = to_rgba_array(color)
             except ValueError:
@@ -105,6 +106,14 @@ def plot_khat(
         rgba_c[:, 3] = alphas
         rgba_c = vectorized_to_hex(rgba_c)
         kwargs["c"] = rgba_c
+    else:
+        if isinstance(c_kwarg, str):
+            if c_kwarg in dims:
+                colors, color_mapping = color_from_dim(khats, c_kwarg)
+            else:
+                legend = False
+        else:
+            legend = False
 
     if ax is None:
         fig, ax = create_axes_grid(
@@ -162,6 +171,7 @@ def plot_khat(
         fig.autofmt_xdate()
         fig.tight_layout()
     if legend:
+        kwargs.pop("c")
         ncols = len(color_mapping) // 6 + 1
         for label, float_color in color_mapping.items():
             ax.scatter([], [], c=[cmap(float_color)], label=label, **kwargs)

--- a/arviz/plots/backends/matplotlib/khatplot.py
+++ b/arviz/plots/backends/matplotlib/khatplot.py
@@ -100,16 +100,14 @@ def plot_khat(
     alphas = 0.5 + 0.2 * (khats > 0.5) + 0.3 * (khats > 1)
     rgba_c[:, 3] = alphas
     rgba_c = vectorized_to_hex(rgba_c)
+    kwargs.setdefault("c", rgba_c)
 
     if ax is None:
-        fig, ax = create_axes_grid(
-            1,
-            backend_kwargs=backend_kwargs,
-        )
+        fig, ax = create_axes_grid(1, backend_kwargs=backend_kwargs,)
     else:
         fig = ax.get_figure()
 
-    sc_plot = ax.scatter(xdata, khats, c=rgba_c, **kwargs)
+    sc_plot = ax.scatter(xdata, khats, **kwargs)
 
     if threshold is not None:
         idxs = xdata[khats > threshold]

--- a/arviz/plots/backends/matplotlib/khatplot.py
+++ b/arviz/plots/backends/matplotlib/khatplot.py
@@ -103,7 +103,10 @@ def plot_khat(
     kwargs.setdefault("c", rgba_c)
 
     if ax is None:
-        fig, ax = create_axes_grid(1, backend_kwargs=backend_kwargs,)
+        fig, ax = create_axes_grid(
+            1,
+            backend_kwargs=backend_kwargs,
+        )
     else:
         fig = ax.get_figure()
 

--- a/arviz/plots/backends/matplotlib/khatplot.py
+++ b/arviz/plots/backends/matplotlib/khatplot.py
@@ -93,13 +93,13 @@ def plot_khat(
                 rgba_c = to_rgba_array(np.full(n_data_points, color))
         else:
             legend = False
-            color = (color - color.min()) / (color.max() - color.min())
             try:
                 rgba_c = to_rgba_array(color)
             except ValueError:
                 cmap_name = kwargs.get("cmap", plt.rcParams["image.cmap"])
                 cmap = getattr(cm, cmap_name)
-                rgba_c = cmap(color)
+                norm_fun = kwargs.get("norm", mpl.colors.Normalize(color.min(), color.max()))
+                rgba_c = cmap(norm_fun(color))
 
         khats = khats if isinstance(khats, np.ndarray) else khats.values.flatten()
         alphas = 0.5 + 0.2 * (khats > 0.5) + 0.3 * (khats > 1)

--- a/arviz/plots/khatplot.py
+++ b/arviz/plots/khatplot.py
@@ -47,7 +47,8 @@ def plot_khat(
         have the same color, if it is the size of the observations,
         each dot will have the specified color, otherwise, it will be
         interpreted as a list of the dims to be used for the color
-        code
+        code. If Matplotlib c argument is passed, it will override
+        the color argument
     xlabels : bool, optional
         Use coords as xticklabels
     show_hlines : bool, optional


### PR DESCRIPTION
## Description
`plot_khat` can take a `c` argument to use with a color map

![cmaps_khat](https://user-images.githubusercontent.com/8028618/109677172-2b604500-7b58-11eb-86c6-5f4a4790b7aa.png)


## Checklist
- [X] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [X] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)
