### PR TITLE
Fix ax argumentin plot_elpd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Fix pareto k threshold typo in reloo function ([1580](https://github.com/arviz-devs/arviz/pull/1580))
 * Preserve shape from Stan code in `from_cmdstanpy` ([1579](https://github.com/arviz-devs/arviz/pull/1579))
 * Correctly use chain index when constructing PyMC3 `DefaultTrace` in `from_pymc3` ([1590](https://github.com/arviz-devs/arviz/pull/1590))
+* Fix `ax` argument in `plot_elpd` ([1593](https://github.com/arviz-devs/arviz/pull/1593))
 
 ### Deprecation
 * Deprecated `index_origin` and `order` arguments in `az.summary` ([1201](https://github.com/arviz-devs/arviz/pull/1201))

--- a/arviz/plots/backends/matplotlib/elpdplot.py
+++ b/arviz/plots/backends/matplotlib/elpdplot.py
@@ -140,6 +140,8 @@ def plot_elpd(
                 sharey="row",
                 sharex="all",
             )
+        else:
+            fig = ax.get_figure()
 
         for i in range(0, numvars - 1):
             var1 = pointwise_data[i]

--- a/arviz/plots/backends/matplotlib/elpdplot.py
+++ b/arviz/plots/backends/matplotlib/elpdplot.py
@@ -74,7 +74,10 @@ def plot_elpd(
         backend_kwargs.setdefault("figsize", figsize)
         backend_kwargs["squeeze"] = True
         if ax is None:
-            fig, ax = create_axes_grid(1, backend_kwargs=backend_kwargs,)
+            fig, ax = create_axes_grid(
+                1,
+                backend_kwargs=backend_kwargs,
+            )
         else:
             fig = ax.get_figure()
 

--- a/arviz/plots/backends/matplotlib/elpdplot.py
+++ b/arviz/plots/backends/matplotlib/elpdplot.py
@@ -74,10 +74,9 @@ def plot_elpd(
         backend_kwargs.setdefault("figsize", figsize)
         backend_kwargs["squeeze"] = True
         if ax is None:
-            fig, ax = create_axes_grid(
-                1,
-                backend_kwargs=backend_kwargs,
-            )
+            fig, ax = create_axes_grid(1, backend_kwargs=backend_kwargs,)
+        else:
+            fig = ax.get_figure()
 
         ydata = pointwise_data[0] - pointwise_data[1]
         ax.scatter(xdata, ydata, **plot_kwargs)


### PR DESCRIPTION
## Description

`plot_elpd` can now take the `ax` argument. Naive example:

```
d1 = az.load_arviz_data("centered_eight")
d2 = az.load_arviz_data("non_centered_eight")

fig, ax = plt.subplots(1, 2, figsize=(10, 4))

az.plot_elpd({"Centered eight": d1, "Non centered eight": d2}, xlabels=True, ax=ax[0])
az.plot_elpd({"Centered eight": d1, "Non centered eight": d2}, xlabels=True, ax=ax[1])

```

![elpd](https://user-images.githubusercontent.com/8028618/109684099-b3e1e400-7b5e-11eb-8011-7ffa5fe8dd1a.png)

## Checklist
- [X] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [X] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)