### PR TITLE
Fix xlabels and ax argument in plot_elpd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Fix `from_numpyro` crash when importing model with `thinning=x` for `x > 1` ([1619](https://github.com/arviz-devs/arviz/pull/1619))
 * Upload updated mypy.ini in ci if mypy copilot fails ([1624](https://github.com/arviz-devs/arviz/pull/1624))
 * Added type checking to raise an error whenever `InferenceData` object is passed using `io_pymc3`'s `trace` argument ([1629](https://github.com/arviz-devs/arviz/pull/1629))
+* Fix `xlabels` in `plot_elpd` ([1601](https://github.com/arviz-devs/arviz/pull/1601))
 
 ### Deprecation
 * Deprecated `index_origin` and `order` arguments in `az.summary` ([1201](https://github.com/arviz-devs/arviz/pull/1201))

--- a/arviz/plots/backends/matplotlib/elpdplot.py
+++ b/arviz/plots/backends/matplotlib/elpdplot.py
@@ -141,7 +141,7 @@ def plot_elpd(
                 sharex="all",
             )
         else:
-            fig = ax.get_figure()
+            fig = ax.ravel()[0].get_figure()
 
         for i in range(0, numvars - 1):
             var1 = pointwise_data[i]
@@ -179,7 +179,8 @@ def plot_elpd(
                     "{} - {}".format(models[i], models[j + 1]), fontsize=titlesize, wrap=True
                 )
         if xlabels:
-            set_xticklabels(ax[-1, -1], coord_labels)
+            for i in range(len(ax)):
+                set_xticklabels(ax[-1, :][i], coord_labels)
             fig.autofmt_xdate()
             fig.tight_layout()
         if legend:

--- a/arviz/plots/backends/matplotlib/elpdplot.py
+++ b/arviz/plots/backends/matplotlib/elpdplot.py
@@ -138,7 +138,7 @@ def plot_elpd(
                 squeeze=False,
                 constrained_layout=not xlabels,
                 sharey="row",
-                sharex="all",
+                sharex="col",
             )
         else:
             fig = ax.ravel()[0].get_figure()
@@ -180,7 +180,7 @@ def plot_elpd(
                 )
         if xlabels:
             for i in range(len(ax)):
-                set_xticklabels(ax[-1, :][i], coord_labels)
+                set_xticklabels(ax[-1, i], coord_labels)
             fig.autofmt_xdate()
             fig.tight_layout()
         if legend:


### PR DESCRIPTION
## Description
Fix xlabels and ax argument in plot_elpd for numvars > 2. 

![elpd+2numvars](https://user-images.githubusercontent.com/8028618/110137536-bb4bfc00-7daf-11eb-9a0e-1298e6136fb8.png)

## Checklist
- [X] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [X] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [X] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
