### PR TITLE
Update setup.py to require python >= 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
     long_description=get_long_description(),
     long_description_content_type="text/markdown",
     include_package_data=True,
+    python_requires='>=3.6',
     classifiers=[
         "Development Status :: 4 - Beta",
         "Framework :: Matplotlib",

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     long_description=get_long_description(),
     long_description_content_type="text/markdown",
     include_package_data=True,
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     classifiers=[
         "Development Status :: 4 - Beta",
         "Framework :: Matplotlib",


### PR DESCRIPTION
Arxviz due to its requirement on xarray>=0.16.1 (and possibly for internal reasons as well) in practice has a hard requirement on the python version of >=3.6. However, it is not declared at the moment in the setup.py so the package resolution doesn't notice this through pypi until attempting to satisfy the xarray requirement.