### PR TITLE
Fix `az.from_numpyro` crash when running MCMC with `thinning > 1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Fix `c` argument in `plot_khat` ([1592](https://github.com/arviz-devs/arviz/pull/1592))
 * Fix `ax` argument in `plot_elpd` ([1593](https://github.com/arviz-devs/arviz/pull/1593))
 * Remove warning in `stats.py` compare function ([1607](https://github.com/arviz-devs/arviz/pull/1607))
+* Fix `from_numpyro` crash when importing model with `thinning=x` for `x > 1` ([]())
 
 ### Deprecation
 * Deprecated `index_origin` and `order` arguments in `az.summary` ([1201](https://github.com/arviz-devs/arviz/pull/1201))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 * Fix `c` argument in `plot_khat` ([1592](https://github.com/arviz-devs/arviz/pull/1592))
 * Fix `ax` argument in `plot_elpd` ([1593](https://github.com/arviz-devs/arviz/pull/1593))
 * Remove warning in `stats.py` compare function ([1607](https://github.com/arviz-devs/arviz/pull/1607))
-* Fix `from_numpyro` crash when importing model with `thinning=x` for `x > 1` ([]())
+* Fix `from_numpyro` crash when importing model with `thinning=x` for `x > 1` ([1619](https://github.com/arviz-devs/arviz/pull/1619))
 
 ### Deprecation
 * Deprecated `index_origin` and `order` arguments in `az.summary` ([1201](https://github.com/arviz-devs/arviz/pull/1201))

--- a/arviz/data/io_numpyro.py
+++ b/arviz/data/io_numpyro.py
@@ -92,7 +92,11 @@ class NumPyroConverter:
                     for i, v in enumerate(tree_flatten_samples)
                 }
             self._samples = samples
-            self.nchains, self.ndraws, self.nthinning = posterior.num_chains, posterior.num_samples, posterior.thinning
+            self.nchains, self.ndraws, self.nthinning = (
+                posterior.num_chains,
+                posterior.num_samples,
+                posterior.thinning,
+            )
             self.ndraws //= self.nthinning
             self.model = self.posterior.sampler.model
             # model arguments and keyword arguments

--- a/arviz/data/io_numpyro.py
+++ b/arviz/data/io_numpyro.py
@@ -19,7 +19,6 @@ class NumPyroConverter:
     model = None  # type: Optional[Callable]
     nchains = None  # type: int
     ndraws = None  # type: int
-    nthinning = None  # type: int
 
     def __init__(
         self,
@@ -92,12 +91,10 @@ class NumPyroConverter:
                     for i, v in enumerate(tree_flatten_samples)
                 }
             self._samples = samples
-            self.nchains, self.ndraws, self.nthinning = (
+            self.nchains, self.ndraws = (
                 posterior.num_chains,
-                posterior.num_samples,
-                posterior.thinning,
+                posterior.num_samples // posterior.thinning,
             )
-            self.ndraws //= self.nthinning
             self.model = self.posterior.sampler.model
             # model arguments and keyword arguments
             self._args = self.posterior._args  # pylint: disable=protected-access

--- a/arviz/data/io_numpyro.py
+++ b/arviz/data/io_numpyro.py
@@ -19,6 +19,7 @@ class NumPyroConverter:
     model = None  # type: Optional[Callable]
     nchains = None  # type: int
     ndraws = None  # type: int
+    nthinning = None  # type: int
 
     def __init__(
         self,
@@ -91,7 +92,8 @@ class NumPyroConverter:
                     for i, v in enumerate(tree_flatten_samples)
                 }
             self._samples = samples
-            self.nchains, self.ndraws = posterior.num_chains, posterior.num_samples
+            self.nchains, self.ndraws, self.nthinning = posterior.num_chains, posterior.num_samples, posterior.thinning
+            self.ndraws //= self.nthinning
             self.model = self.posterior.sampler.model
             # model arguments and keyword arguments
             self._args = self.posterior._args  # pylint: disable=protected-access

--- a/arviz/tests/external_tests/test_data_numpyro.py
+++ b/arviz/tests/external_tests/test_data_numpyro.py
@@ -235,7 +235,7 @@ class TestDataNumPyro:
 
         x = np.random.normal(10, 3, size=100)
 
-        def model_with_thinning(x):
+        def model(x):
             numpyro.sample(
                 "x",
                 dist.Normal(
@@ -245,7 +245,7 @@ class TestDataNumPyro:
                 obs=x,
             )
 
-        nuts_kernel = NUTS(model_with_thinning)
+        nuts_kernel = NUTS(model)
         mcmc = MCMC(nuts_kernel, num_samples=10, num_warmup=2, thinning=2)
         mcmc.run(PRNGKey(0), x=x)
 

--- a/arviz/tests/external_tests/test_data_numpyro.py
+++ b/arviz/tests/external_tests/test_data_numpyro.py
@@ -228,8 +228,9 @@ class TestDataNumPyro:
         nchains = inference_data.predictions.dims["chain"]
         assert nchains == chains
 
+    @pytest.mark.parametrize("nchains", [1, 2])
     @pytest.mark.parametrize("thin", [1, 2, 3, 5, 10])
-    def test_mcmc_with_thinning(self, thin):
+    def test_mcmc_with_thinning(self, nchains, thin):
         import numpyro
         import numpyro.distributions as dist
         from numpyro.infer import MCMC, NUTS
@@ -247,8 +248,8 @@ class TestDataNumPyro:
             )
 
         nuts_kernel = NUTS(model)
-        mcmc = MCMC(nuts_kernel, num_warmup=100, num_samples=400, num_chains=2, thinning=thin)
+        mcmc = MCMC(nuts_kernel, num_warmup=100, num_samples=400, num_chains=nchains, thinning=thin)
         mcmc.run(PRNGKey(0), x=x)
 
         inference_data = from_numpyro(mcmc)
-        assert inference_data.posterior["loc"].shape == (2, 400 // thin)
+        assert inference_data.posterior["loc"].shape == (nchains, 400 // thin)

--- a/arviz/tests/external_tests/test_data_numpyro.py
+++ b/arviz/tests/external_tests/test_data_numpyro.py
@@ -251,4 +251,4 @@ class TestDataNumPyro:
         mcmc.run(PRNGKey(0), x=x)
 
         inference_data = from_numpyro(mcmc)
-        assert not hasattr(inference_data.sample_stats, "log_likelihood")
+        assert inference_data.posterior["loc"].shape == (2, 400 // thin)

--- a/arviz/tests/external_tests/test_data_numpyro.py
+++ b/arviz/tests/external_tests/test_data_numpyro.py
@@ -228,7 +228,8 @@ class TestDataNumPyro:
         nchains = inference_data.predictions.dims["chain"]
         assert nchains == chains
 
-    def test_mcmc_with_thinning(self):
+    @pytest.mark.parametrize("thin", [1, 2, 3, 5, 10])
+    def test_mcmc_with_thinning(self, thin):
         import numpyro
         import numpyro.distributions as dist
         from numpyro.infer import MCMC, NUTS
@@ -246,7 +247,7 @@ class TestDataNumPyro:
             )
 
         nuts_kernel = NUTS(model)
-        mcmc = MCMC(nuts_kernel, num_samples=10, num_warmup=2, thinning=2)
+        mcmc = MCMC(nuts_kernel, num_warmup=100, num_samples=400, num_chains=2, thinning=thin)
         mcmc.run(PRNGKey(0), x=x)
 
         inference_data = from_numpyro(mcmc)


### PR DESCRIPTION
## Description
This PR fixes the crash observed when running the following code:
```python
import arviz as az
import numpy as np
import numpyro
import numpyro.distributions as dist
from jax import random
from numpyro.infer import MCMC, NUTS


data = np.random.normal(10, 3, size=100)

def model(data):
    numpyro.sample(
        'x',
        dist.Normal(
            numpyro.sample('loc', dist.Uniform(0, 20)),
            numpyro.sample('scale', dist.Uniform(0, 20)),
        ),
        obs=data,
    )


kernel = NUTS(model)
mcmc = MCMC(NUTS(model), 100, 200, thinning=2)

mcmc.run(random.PRNGKey(0), data=data)
mcmc.print_summary()

az.from_numpyro(mcmc)  # crash
```

Fixes #1618 (line edited by @OriolAbril to use [github issue closing keywords](https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords#about-issue-references))

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [X] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [X] Includes new or updated tests to cover the new feature
- [X] Code style  correct (follows pylint and black guidelines)
- [X] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)
