### PR TITLE
add custom labellers section to label guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 * Deprecated `index_origin` and `order` arguments in `az.summary` ([1201](https://github.com/arviz-devs/arviz/pull/1201))
 
 ### Documentation
-* Added "Label guide" page and API section for `arviz.labels` module ([1201](https://github.com/arviz-devs/arviz/pull/1201))
+* Added "Label guide" page and API section for `arviz.labels` module ([1201](https://github.com/arviz-devs/arviz/pull/1201) and [1635](https://github.com/arviz-devs/arviz/pull/1635))
 * Add "Installation guide" page to the documentation ([1551](https://github.com/arviz-devs/arviz/pull/1551))
 * Improve documentation on experimental `SamplingWrapper` classes ([1582](https://github.com/arviz-devs/arviz/pull/1582))
 

--- a/doc/source/api/plot_utils.md
+++ b/doc/source/api/plot_utils.md
@@ -17,7 +17,7 @@ See also the {ref}`label_guide`
   DimIdxLabeller
   MapLabeller
   NoModelLabeller
-  NoRepeatLabeller
+  NoVarLabeller
 ```
 
 ## Labeling utils


### PR DESCRIPTION
## Description
Adds the missing section about writing custom labellers to the label guide.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Does the PR follow [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format?
- [x] Is the documentation [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant?
- [x] Is the fix listed in the [Documentation](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#documentation) section of the changelog?

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

- If you are contributing fixes to docstrings, please pay attention to
  https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#docstring-formatting.
  In particular, note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
