### PR TITLE
Added floating margins for get_bins

### DIFF
--- a/arviz/stats/density_utils.py
+++ b/arviz/stats/density_utils.py
@@ -8,7 +8,6 @@ from scipy.optimize import brentq
 from scipy.signal import convolve, convolve2d, gaussian  # pylint: disable=no-name-in-module
 from scipy.sparse import coo_matrix
 from scipy.special import ive  # pylint: disable=no-name-in-module
-from numpy import histogram_bin_edges
 
 from ..utils import _cov, _dot, _stack, conditional_jit
 
@@ -954,11 +953,9 @@ def get_bins(values):
     # Sturges histogram bin estimator
     bins_sturges = (x_max - x_min) / (np.log2(values.size) + 1)
 
-        # The Freedman-Diaconis histogram bin estimator.
-        iqr = np.subtract(
-            *np.percentile(values, [75, 25])
-        )  # pylint: disable=assignment-from-no-return
-        bins_fd = 2 * iqr * values.size ** (-1 / 3)
+    # The Freedman-Diaconis histogram bin estimator.
+    iqr = np.subtract(*np.percentile(values, [75, 25]))  # pylint: disable=assignment-from-no-return
+    bins_fd = 2 * iqr * values.size ** (-1 / 3)
 
     width = np.round(np.max([1, bins_sturges, bins_fd])).astype(int)
 

--- a/arviz/stats/density_utils.py
+++ b/arviz/stats/density_utils.py
@@ -8,6 +8,7 @@ from scipy.optimize import brentq
 from scipy.signal import convolve, convolve2d, gaussian  # pylint: disable=no-name-in-module
 from scipy.sparse import coo_matrix
 from scipy.special import ive  # pylint: disable=no-name-in-module
+from numpy import histogram_bin_edges
 
 from ..utils import _cov, _dot, _stack, conditional_jit
 
@@ -953,9 +954,9 @@ def get_bins(values):
     # Sturges histogram bin estimator
     bins_sturges = (x_max - x_min) / (np.log2(values.size) + 1)
 
-    # The Freedman-Diaconis histogram bin estimator.
-    iqr = np.subtract(*np.percentile(values, [75, 25]))  # pylint: disable=assignment-from-no-return
-    bins_fd = 2 * iqr * values.size ** (-1 / 3)
+        # The Freedman-Diaconis histogram bin estimator.
+        iqr = np.subtract(*np.percentile(values, [75, 25]))  # pylint: disable=assignment-from-no-return
+        bins_fd = 2 * iqr * values.size ** (-1 / 3)
 
     width = np.round(np.max([1, bins_sturges, bins_fd])).astype(int)
 

--- a/arviz/stats/density_utils.py
+++ b/arviz/stats/density_utils.py
@@ -955,7 +955,9 @@ def get_bins(values):
     bins_sturges = (x_max - x_min) / (np.log2(values.size) + 1)
 
         # The Freedman-Diaconis histogram bin estimator.
-        iqr = np.subtract(*np.percentile(values, [75, 25]))  # pylint: disable=assignment-from-no-return
+        iqr = np.subtract(
+            *np.percentile(values, [75, 25])
+        )  # pylint: disable=assignment-from-no-return
         bins_fd = 2 * iqr * values.size ** (-1 / 3)
 
     width = np.round(np.max([1, bins_sturges, bins_fd])).astype(int)


### PR DESCRIPTION
## Description

Added ability to calculate float margins with get_bins. This addresses issue #1639 .

The code distinguishes between dtype of the values array. If int32, previously defined code is used. If not int32, numpy [histogram_bin_edges ](https://numpy.org/doc/stable/reference/generated/numpy.histogram_bin_edges.html) function is used with bins='auto' and default arguments. 

Open to feedback and revisions to suit codebase.

<!--
Thank you so much for your PR! To help us review your contribution, please consider the following points:

- The PR title should summarize the changes, for example "Add new group argument for the pair plot".
  Avoid non-descriptive titles such as "Addresses issue #348".

- The description should provide at least 1-2 sentences describing the pull request in detail and
  link to any relevant issues.

- Please prefix the title of incomplete contributions with [WIP] (to indicate a work in
  progress). WIPs may be useful to (1) indicate you are working on something to avoid
  duplicated work, (2) request broad review of functionality or API, or (3) seek collaborators. -->

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [ ] New features are properly documented (with an example if appropriate)?
- [ ] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
