### PR TITLE
Move observations to cpu in PyroConverter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Improve error messages in `stats.compare()`, and `var_name` parameter. ([1616](https://github.com/arviz-devs/arviz/pull/1616))
 
 ### Maintenance and fixes
+* Fixed conversion of Pyro output fit using GPUs ([1659](https://github.com/arviz-devs/arviz/pull/1659))
 * Enforced using coordinate values as default labels ([1201](https://github.com/arviz-devs/arviz/pull/1201))
 * Integrate `index_origin` with all the library ([1201](https://github.com/arviz-devs/arviz/pull/1201))
 * Fix pareto k threshold typo in reloo function ([1580](https://github.com/arviz-devs/arviz/pull/1580))

--- a/arviz/data/io_pyro.py
+++ b/arviz/data/io_pyro.py
@@ -110,7 +110,7 @@ class PyroConverter:
         if self.model is not None:
             trace = pyro.poutine.trace(self.model).get_trace(*self._args, **self._kwargs)
             observations = {
-                name: site["value"]
+                name: site["value"].cpu()
                 for name, site in trace.nodes.items()
                 if site["type"] == "sample" and site["is_observed"]
             }


### PR DESCRIPTION
Implements fix suggested in #1529 to allow traces on the GPU to be moved back to the CPU.

Closes #1529 