### PR TITLE
Fix bug in `levels` argument to `plot_kde` with Bokeh backend

### DIFF
--- a/arviz/plots/backends/bokeh/kdeplot.py
+++ b/arviz/plots/backends/bokeh/kdeplot.py
@@ -183,7 +183,7 @@ def plot_kde(
                 levels_scaled = np.linspace(0, 1, levels)
                 levels = _rescale_axis(levels_scaled, scaled_density_args)
             else:
-                levels_scaled_nonclip = _scale_axis(np.asarray(levels), scaled_density_args)
+                levels_scaled_nonclip, _, _ = _scale_axis(np.asarray(levels), scaled_density_args)
                 levels_scaled = np.clip(levels_scaled_nonclip, 0, 1)
 
             cmap = contourf_kwargs.pop("cmap", "viridis")
@@ -198,6 +198,7 @@ def plot_kde(
             contour_kwargs.setdefault("line_color", "black")
             contour_kwargs.setdefault("line_alpha", 0.25)
             contour_kwargs.setdefault("fill_alpha", 1)
+            contour_kwargs.pop("levels", None)
 
             for i, (level, level_upper, color) in enumerate(
                 zip(levels_scaled[:-1], levels_scaled[1:], colors[1:])

--- a/arviz/tests/base_tests/test_plots_bokeh.py
+++ b/arviz/tests/base_tests/test_plots_bokeh.py
@@ -266,6 +266,8 @@ def test_plot_kde_1d(continuous_model):
         {"contour": True, "contourf_kwargs": {"cmap": "plasma"}},
         {"contour": False},
         {"contour": False, "pcolormesh_kwargs": {"cmap": "plasma"}},
+        {"contour": True, "contourf_kwargs": {"levels": 3}},
+        {"contour": True, "contourf_kwargs": {"levels": [0.1, 0.2, 0.3]}},
     ],
 )
 def test_plot_kde_2d(continuous_model, kwargs):


### PR DESCRIPTION
## Description
<!--
Thank you so much for your PR! To help us review your contribution, please consider the following points:

- The PR title should summarize the changes, for example "Add new group argument for the pair plot".
  Avoid non-descriptive titles such as "Addresses issue #348".

- The description should provide at least 1-2 sentences describing the pull request in detail and
  link to any relevant issues.

- Please prefix the title of incomplete contributions with [WIP] (to indicate a work in
  progress). WIPs may be useful to (1) indicate you are working on something to avoid
  duplicated work, (2) request broad review of functionality or API, or (3) seek collaborators. -->

This pull request is aimed at tackling #1673, a bug in the handling of the `levels` argument in either `contour_kwargs` or `contourf_kwargs` for `plot_kde` with the Bokeh backend.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes new or updated tests to cover the new feature
- [x] Code style correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
