### PR TITLE
Removed extra line

### DIFF
--- a/doc/source/getting_started/index.md
+++ b/doc/source/getting_started/index.md
@@ -1,4 +1,3 @@
-(getting_started)=
 
 # Getting Started
 


### PR DESCRIPTION
There was an extra line at the start of `index.md`. It seemed to be there by mistake. 
