### PR TITLE
Coerce coords into np.array in numpy_to_data_array

### DIFF
--- a/arviz/data/base.py
+++ b/arviz/data/base.py
@@ -245,7 +245,7 @@ def numpy_to_data_array(
         coords["draw"] = np.arange(index_origin, n_samples + index_origin)
 
     # filter coords based on the dims
-    coords = {key: xr.IndexVariable((key,), data=coords[key]) for key in dims}
+    coords = {key: xr.IndexVariable((key,), data=np.asarray(coords[key])) for key in dims}
     return xr.DataArray(ary, coords=coords, dims=dims)
 
 

--- a/arviz/tests/base_tests/test_data.py
+++ b/arviz/tests/base_tests/test_data.py
@@ -921,6 +921,16 @@ def test_dict_to_dataset_event_dims_error():
         convert_to_dataset(datadict, coords=coords, dims={"a": ["b", "c"]})
 
 
+def test_dict_to_dataset_with_tuple_coord():
+    datadict = {"a": np.random.randn(100), "b": np.random.randn(1, 100, 10)}
+    dataset = convert_to_dataset(datadict, coords={"c": tuple(range(10))}, dims={"b": ["c"]})
+    assert set(dataset.data_vars) == {"a", "b"}
+    assert set(dataset.coords) == {"chain", "draw", "c"}
+
+    assert set(dataset.a.coords) == {"chain", "draw"}
+    assert set(dataset.b.coords) == {"chain", "draw", "c"}
+
+
 def test_convert_to_dataset_idempotent():
     first = convert_to_dataset(np.random.randn(100))
     second = convert_to_dataset(first)


### PR DESCRIPTION
## Description
Coerces the coords parameter of the numpy_to_data_array function into a numpy array using np.asarray.
This patch prevents the function from failing on tuple/list parameters.
Added a new unit test to cover the failing test.

Fixes #1451

## Checklist

- [X] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [X] Includes new or updated tests to cover the new feature
- [X] Code style  correct (follows pylint and black guidelines)
- [ ] Is the new feature listed in the [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md)?