### PR TITLE
fixed plot_kde to take labels with kwargs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
 * Renamed `sample` dim to `__sample__` when stacking `chain` and `draw` to avoid dimension collision ([1647](https://github.com/arviz-devs/arviz/pull/1647))
 * Removed the `circular` argument in `plot_dist` in favor of `is_circular` ([1681](https://github.com/arviz-devs/arviz/pull/1681))
 * Fix `legend` argument in `plot_separation` ([1701](https://github.com/arviz-devs/arviz/pull/1701))
+* Removed testing dependency on http download for radon dataset ([1717](https://github.com/arviz-devs/arviz/pull/1717))
+* Fixed plot_kde to take labels with kwargs. ([1710](https://github.com/arviz-devs/arviz/pull/1710))
 
 ### Deprecation
 * Deprecated `index_origin` and `order` arguments in `az.summary` ([1201](https://github.com/arviz-devs/arviz/pull/1201))

--- a/arviz/plots/backends/bokeh/kdeplot.py
+++ b/arviz/plots/backends/bokeh/kdeplot.py
@@ -147,6 +147,8 @@ def plot_kde(
                     patch = ax.patch(patch_y, patch_x, **fill_kwargs)
                 glyphs.append(patch)
 
+            if label is not None:
+                plot_kwargs.setdefault("legend_label", label)
             if not rotated:
                 line = ax.line(x, density, **plot_kwargs)
             else:

--- a/arviz/plots/backends/matplotlib/kdeplot.py
+++ b/arviz/plots/backends/matplotlib/kdeplot.py
@@ -144,11 +144,13 @@ def plot_kde(
         else:
             fill_kwargs.setdefault("alpha", 0)
             if fill_kwargs.get("alpha") == 0:
-                ax.plot(x, density, label=label, **plot_kwargs)
+                label = plot_kwargs.setdefault("label", label)
+                ax.plot(x, density, **plot_kwargs)
                 fill_func(fill_x, fill_y, **fill_kwargs)
             else:
+                label = fill_kwargs.setdefault("label", label)
                 ax.plot(x, density, **plot_kwargs)
-                fill_func(fill_x, fill_y, label=label, **fill_kwargs)
+                fill_func(fill_x, fill_y, **fill_kwargs)
         if legend and label:
             ax.legend()
     else:

--- a/arviz/tests/base_tests/test_plots_bokeh.py
+++ b/arviz/tests/base_tests/test_plots_bokeh.py
@@ -992,7 +992,7 @@ def test_plot_ppc_ax(models, kind):
         {"point_estimate": "mode"},
         {"point_estimate": "median"},
         {"point_estimate": None},
-        {"hdi_prob": "hide"},
+        {"hdi_prob": "hide", "legend_label": ""},
         {"ref_val": 0},
         {"ref_val": None},
         {"ref_val": {"mu": [{"ref_val": 1}]}},

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -927,7 +927,7 @@ def test_plot_rank(models, kwargs):
         {"rope": {"mu": [{"rope": (-2, 2)}], "theta": [{"school": "Choate", "rope": (2, 4)}]}},
         {"point_estimate": "mode"},
         {"point_estimate": "median"},
-        {"hdi_prob": "hide"},
+        {"hdi_prob": "hide", "label": ""},
         {"point_estimate": None},
         {"ref_val": 0},
         {"ref_val": None},


### PR DESCRIPTION
## Description
This pr solves the conflict that arises when `label` is passed as a kwarg. It conflicted with the argument `label`. 
Added `set_default` to the required args. 
Added relevant kwargs in the test module.
Also, now user can use plot_posterior to use plot multiple distributions and have a legend.

closes #1703

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [ ] New features are properly documented (with an example if appropriate)?
- [x] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
