### PR TITLE
Add init strategy to generate sample for ImproperUniform in NumPyro

### DIFF
--- a/arviz/data/io_numpyro.py
+++ b/arviz/data/io_numpyro.py
@@ -124,7 +124,9 @@ class NumPyroConverter:
 
         observations = {}
         if self.model is not None:
-            seeded_model = numpyro.handlers.seed(self.model, jax.random.PRNGKey(0))
+            seeded_model = numpyro.handlers.substitute(
+                numpyro.handlers.seed(self.model, jax.random.PRNGKey(0)),
+                substitute_fn=numpyro.infer.init_to_sample)
             trace = numpyro.handlers.trace(seeded_model).get_trace(*self._args, **self._kwargs)
             observations = {
                 name: site["value"]


### PR DESCRIPTION
## Description
Resolves #1704. Currently, we run the model to inspect observed variables. However, numpyro does not allow to sample from `ImproperUniform` distribution. As a workaround, I add an init_strategy method to draw a sample from transform_to_support(Uniform(-2, 2)).

## Checklist

- [ ] Includes new or updated tests to cover the new feature
- [ ] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)