### PR TITLE
Progressively updated doc references (WIP)

### DIFF
--- a/arviz/plots/hdiplot.py
+++ b/arviz/plots/hdiplot.py
@@ -71,7 +71,8 @@ def plot_hdi(
     backend : {"matplotlib","bokeh"}, optional
         Select plotting backend.
     backend_kwargs : bool, optional
-        These are kwargs specific to the backend being used, passed to :meth:`mpl:matplotlib.axes.Axes.plot` or
+        These are kwargs specific to the backend being used, passed to 
+        :meth:`mpl:matplotlib.axes.Axes.plot` or
         :meth:`bokeh:bokeh.plotting.figure.Figure.patch`.
     show : bool, optional
         Call backend show function.

--- a/arviz/plots/hdiplot.py
+++ b/arviz/plots/hdiplot.py
@@ -71,7 +71,7 @@ def plot_hdi(
     backend : {"matplotlib","bokeh"}, optional
         Select plotting backend.
     backend_kwargs : bool, optional
-        These are kwargs specific to the backend being used, passed to 
+        These are kwargs specific to the backend being used, passed to
         :meth:`mpl:matplotlib.axes.Axes.plot` or
         :meth:`bokeh:bokeh.plotting.figure.Figure.patch`.
     show : bool, optional

--- a/arviz/plots/hdiplot.py
+++ b/arviz/plots/hdiplot.py
@@ -71,7 +71,8 @@ def plot_hdi(
     backend : {"matplotlib","bokeh"}, optional
         Select plotting backend.
     backend_kwargs : bool, optional
-        These are kwargs specific to the backend being used. Passed to ::``
+        These are kwargs specific to the backend being used, passed to :meth:`mpl:matplotlib.axes.Axes.plot` or
+        :meth:`bokeh:bokeh.plotting.figure.Figure.patch`.
     show : bool, optional
         Call backend show function.
 

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -160,8 +160,9 @@ def compare(
 
     References
     ----------
-    .. [1] Using Advanced Plot Types in Kaluza: Comparison Plots for Visualization of the TCR V
-        Beta Repertoire, see https://www.beckman.com/flow-cytometry/software/kaluza/learning-center/comparison-plot
+    .. [1] Vehtari, A., Gelman, A. & Gabry, J. Practical Bayesian model evaluation using
+        leave-one-out cross-validation and WAIC. Stat Comput 27, 1413–1432 (2017)
+        see https://doi.org/10.1007/s11222-016-9696-4
 
     """
     names = list(dataset_dict.keys())

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -156,6 +156,13 @@ def compare(
     --------
     loo : Compute the Pareto Smoothed importance sampling Leave One Out cross-validation.
     waic : Compute the widely applicable information criterion.
+    plot_compare : Summary plot for model comparison.
+
+    References
+    ----------
+    .. [1] Using Advanced Plot Types in Kaluza: Comparison Plots for Visualization of the TCR V
+        Beta Repertoire, see https://www.beckman.com/flow-cytometry/software/kaluza/learning-center/comparison-plot
+
     """
     names = list(dataset_dict.keys())
     if scale is not None:


### PR DESCRIPTION
## Description
> Resolves #1188. The external reference for backend_kwargs in plot_hdi has been added. Additionally, the see also section has been extended in compare with an addition of references. The work is still in progress for the other functions.
> ## Checklist
> * [x]  plot_hdi: nearly finished, only external references for `backend_kwargs` are missing.
> * [x]  compare: extend see also section, maybe use references too? plot_separation is a good example on how to format references in docstrings
