### PR TITLE
Remove testing dependency on http download for radon dataset

### DIFF
--- a/arviz/tests/base_tests/test_stats.py
+++ b/arviz/tests/base_tests/test_stats.py
@@ -605,9 +605,16 @@ def test_loo_pit_multidim(multidim_models, args):
 
 
 def test_loo_pit_multi_lik():
-    idata = load_arviz_data("radon")
-    idata.log_likelihood["by_county"] = (
-        idata.log_likelihood["y"].groupby(idata.constant_data["county_idx"]).sum()
+    rng = np.random.default_rng(0)
+    post_pred = rng.standard_normal(size=(4, 100, 10))
+    obs = np.quantile(post_pred, np.linspace(0, 1, 10))
+    obs[0] *= 0.9
+    obs[-1] *= 1.1
+    idata = from_dict(
+        posterior={"a": np.random.randn(4, 100)},
+        posterior_predictive={"y": post_pred},
+        observed_data={"y": obs},
+        log_likelihood={"y": -(post_pred ** 2), "decoy": np.zeros_like(post_pred)},
     )
     loo_pit_data = loo_pit(idata, y="y")
     assert np.all((loo_pit_data >= 0) & (loo_pit_data <= 1))


### PR DESCRIPTION
## Description
Modified loo_pit tests to remove dependency on radon dataset. Using modified centered_eight instead.
Closes #1716 
<!--
Thank you so much for your PR! To help us review your contribution, please consider the following points:

- The PR title should summarize the changes, for example "Add new group argument for the pair plot".
  Avoid non-descriptive titles such as "Addresses issue #348".

- The description should provide at least 1-2 sentences describing the pull request in detail and
  link to any relevant issues.

- Please prefix the title of incomplete contributions with [WIP] (to indicate a work in
  progress). WIPs may be useful to (1) indicate you are working on something to avoid
  duplicated work, (2) request broad review of functionality or API, or (3) seek collaborators. -->

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [ ] New features are properly documented (with an example if appropriate)?
- [ ] Includes new or updated tests to cover the new feature
- [ ] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
