### PR TITLE
extend 'right' join bug fix

### DIFF
--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -1358,9 +1358,15 @@ class InferenceData(Mapping[str, xr.Dataset]):
             if dataset:
                 setattr(self, group, dataset)
                 if group.startswith(WARMUP_TAG):
-                    supported_order = [key for key in SUPPORTED_GROUPS_ALL if key in self._groups_warmup]
+                    supported_order = [
+                        key for key in SUPPORTED_GROUPS_ALL if key in self._groups_warmup
+                    ]
                     if (supported_order == self._groups_warmup) and (group in SUPPORTED_GROUPS_ALL):
-                        group_order = [key for key in SUPPORTED_GROUPS_ALL if key in self._groups_warmup + [group]]
+                        group_order = [
+                            key
+                            for key in SUPPORTED_GROUPS_ALL
+                            if key in self._groups_warmup + [group]
+                        ]
                         group_idx = group_order.index(group)
                         self._groups_warmup.insert(group_idx, group)
                     else:
@@ -1368,7 +1374,9 @@ class InferenceData(Mapping[str, xr.Dataset]):
                 else:
                     supported_order = [key for key in SUPPORTED_GROUPS_ALL if key in self._groups]
                     if (supported_order == self._groups) and (group in SUPPORTED_GROUPS_ALL):
-                        group_order = [key for key in SUPPORTED_GROUPS_ALL if key in self._groups + [group]]
+                        group_order = [
+                            key for key in SUPPORTED_GROUPS_ALL if key in self._groups + [group]
+                        ]
                         group_idx = group_order.index(group)
                         self._groups.insert(group_idx, group)
                     else:
@@ -1408,9 +1416,15 @@ class InferenceData(Mapping[str, xr.Dataset]):
             setattr(self, group, dataset)
             if group.startswith(WARMUP_TAG):
                 if group not in self._groups_warmup:
-                    supported_order = [key for key in SUPPORTED_GROUPS_ALL if key in self._groups_warmup]
+                    supported_order = [
+                        key for key in SUPPORTED_GROUPS_ALL if key in self._groups_warmup
+                    ]
                     if (supported_order == self._groups_warmup) and (group in SUPPORTED_GROUPS_ALL):
-                        group_order = [key for key in SUPPORTED_GROUPS_ALL if key in self._groups_warmup + [group]]
+                        group_order = [
+                            key
+                            for key in SUPPORTED_GROUPS_ALL
+                            if key in self._groups_warmup + [group]
+                        ]
                         group_idx = group_order.index(group)
                         self._groups_warmup.insert(group_idx, group)
                     else:
@@ -1419,7 +1433,9 @@ class InferenceData(Mapping[str, xr.Dataset]):
                 if group not in self._groups:
                     supported_order = [key for key in SUPPORTED_GROUPS_ALL if key in self._groups]
                     if (supported_order == self._groups) and (group in SUPPORTED_GROUPS_ALL):
-                        group_order = [key for key in SUPPORTED_GROUPS_ALL if key in self._groups + [group]]
+                        group_order = [
+                            key for key in SUPPORTED_GROUPS_ALL if key in self._groups + [group]
+                        ]
                         group_idx = group_order.index(group)
                         self._groups.insert(group_idx, group)
                     else:

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -1394,10 +1394,11 @@ class InferenceData(Mapping[str, xr.Dataset]):
                 )
             dataset = getattr(other, group)
             setattr(self, group, dataset)
-            if group.startswith(WARMUP_TAG):
-                self._groups_warmup.append(group)
-            else:
-                self._groups.append(group)
+            if not hasattr(self, group):
+                if group.startswith(WARMUP_TAG):
+                    self._groups_warmup.append(group)
+                else:
+                    self._groups.append(group)
 
     set_index = _extend_xr_method(xr.Dataset.set_index, see_also="reset_index")
     get_index = _extend_xr_method(xr.Dataset.get_index)

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -1394,7 +1394,7 @@ class InferenceData(Mapping[str, xr.Dataset]):
                 )
             dataset = getattr(other, group)
             setattr(self, group, dataset)
-            if not hasattr(self, group):
+            if group not in self._groups and self._groups_warmup:
                 if group.startswith(WARMUP_TAG):
                     self._groups_warmup.append(group)
                 else:

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -1394,10 +1394,11 @@ class InferenceData(Mapping[str, xr.Dataset]):
                 )
             dataset = getattr(other, group)
             setattr(self, group, dataset)
-            if group not in self._groups and self._groups_warmup:
-                if group.startswith(WARMUP_TAG):
+            if group.startswith(WARMUP_TAG):
+                if group not in self._groups_warmup:
                     self._groups_warmup.append(group)
-                else:
+            else:
+                if group not in self._groups:
                     self._groups.append(group)
 
     set_index = _extend_xr_method(xr.Dataset.set_index, see_also="reset_index")

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -1396,10 +1396,22 @@ class InferenceData(Mapping[str, xr.Dataset]):
             setattr(self, group, dataset)
             if group.startswith(WARMUP_TAG):
                 if group not in self._groups_warmup:
-                    self._groups_warmup.append(group)
+                    supported_order = [key for key in SUPPORTED_GROUPS_ALL if key in self._groups_warmup]
+                    if (supported_order == self._groups_warmup) and (group in SUPPORTED_GROUPS_ALL):
+                        group_order = [key for key in SUPPORTED_GROUPS_ALL if key in self._groups_warmup + [group]]
+                        group_idx = group_order.index(group)
+                        self._groups_warmup.insert(group_idx, group)
+                    else:
+                        self._groups_warmup.append(group)
             else:
                 if group not in self._groups:
-                    self._groups.append(group)
+                    supported_order = [key for key in SUPPORTED_GROUPS_ALL if key in self._groups]
+                    if (supported_order == self._groups) and (group in SUPPORTED_GROUPS_ALL):
+                        group_order = [key for key in SUPPORTED_GROUPS_ALL if key in self._groups + [group]]
+                        group_idx = group_order.index(group)
+                        self._groups.insert(group_idx, group)
+                    else:
+                        self._groups.append(group)
 
     set_index = _extend_xr_method(xr.Dataset.set_index, see_also="reset_index")
     get_index = _extend_xr_method(xr.Dataset.get_index)

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -1358,9 +1358,21 @@ class InferenceData(Mapping[str, xr.Dataset]):
             if dataset:
                 setattr(self, group, dataset)
                 if group.startswith(WARMUP_TAG):
-                    self._groups_warmup.append(group)
+                    supported_order = [key for key in SUPPORTED_GROUPS_ALL if key in self._groups_warmup]
+                    if (supported_order == self._groups_warmup) and (group in SUPPORTED_GROUPS_ALL):
+                        group_order = [key for key in SUPPORTED_GROUPS_ALL if key in self._groups_warmup + [group]]
+                        group_idx = group_order.index(group)
+                        self._groups_warmup.insert(group_idx, group)
+                    else:
+                        self._groups_warmup.append(group)
                 else:
-                    self._groups.append(group)
+                    supported_order = [key for key in SUPPORTED_GROUPS_ALL if key in self._groups]
+                    if (supported_order == self._groups) and (group in SUPPORTED_GROUPS_ALL):
+                        group_order = [key for key in SUPPORTED_GROUPS_ALL if key in self._groups + [group]]
+                        group_idx = group_order.index(group)
+                        self._groups.insert(group_idx, group)
+                    else:
+                        self._groups.append(group)
 
     def extend(self, other, join="left"):
         """Extend InferenceData with groups from another InferenceData.


### PR DESCRIPTION
Bug: 

idata.extend(another_idata, join='right') returns two copies of every group  - i.e. posterior, prior 

![image](https://user-images.githubusercontent.com/55153708/121037665-41bc1380-c7cd-11eb-9aa9-95e5b768733a.png)


Bug cause:
append should only happen if group not in self
<img width="284" alt="image" src="https://user-images.githubusercontent.com/55153708/121037728-500a2f80-c7cd-11eb-8e2e-fc61d42952d0.png">

Possible fix - (thanks @OriolAbril )
<img width="378" alt="image" src="https://user-images.githubusercontent.com/55153708/121037876-7334df00-c7cd-11eb-8386-d305c800af83.png">


Note: extend(join='left') works just fine.

Feel free to suggest better fixes or tests or anything needed