### PR TITLE
Fix smooth_data axis loo_pit

### DIFF
--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -1569,8 +1569,6 @@ def loo_pit(idata=None, *, y=None, y_hat=None, log_weights=None):
                 "all 3 y, y_hat and log_weights must be array or DataArray when idata is None "
                 f"but they are of types {[type(arg) for arg in (y, y_hat, log_weights)]}"
             )
-        if isinstance(y, xr.DataArray):
-            y = y.values
 
     else:
         if y_hat is None and isinstance(y, str):
@@ -1580,8 +1578,6 @@ def loo_pit(idata=None, *, y=None, y_hat=None, log_weights=None):
         if isinstance(y, str):
             y_str = y
             y = idata.observed_data[y].values
-        elif isinstance(y, xr.DataArray):
-            y = y.values
         elif not isinstance(y, (np.ndarray, xr.DataArray)):
             raise ValueError(f"y must be of types array, DataArray or str, not {type(y)}")
         if isinstance(y_hat, str):
@@ -1631,17 +1627,34 @@ def loo_pit(idata=None, *, y=None, y_hat=None, log_weights=None):
             f"{y_hat.shape,} and {log_weights.shape}"
         )
 
-    if y.ndim == 2:
-        y = y.T[None, :]
-    y_hat = y_hat.T
+    kwargs = {
+        "input_core_dims": [[], ["__sample__"], ["__sample__"]],
+        "output_core_dims": [[]],
+        "join": "left",
+    }
+    ufunc_kwargs = {"n_dims": 1}
+
     if y.dtype.kind == "i" or y_hat.dtype.kind == "i":
-        y, y_hat = smooth_data(y, y_hat)
+        y, y_hat = smooth_data(y, y_hat, axis=0)
 
-    mlw = np.max(log_weights)
-    pits = np.exp(mlw + np.log(np.sum(np.exp(log_weights.T - mlw) * (y_hat <= y), axis=0)))
-    pits = np.minimum(1, pits)
+    return _wrap_xarray_ufunc(
+        _loo_pit,
+        y,
+        y_hat,
+        log_weights,
+        ufunc_kwargs=ufunc_kwargs,
+        **kwargs,
+    )
 
-    return pits
+
+def _loo_pit(y, y_hat, log_weights):
+    """Compute LOO-PIT values."""
+    sel = y_hat <= y
+    if np.sum(sel) > 0:
+        value = np.exp(_logsumexp(log_weights[sel]))
+        return min(1, value)
+    else:
+        return 0
 
 
 def apply_test_function(

--- a/arviz/stats/stats_utils.py
+++ b/arviz/stats/stats_utils.py
@@ -561,14 +561,14 @@ def _circular_standard_deviation(samples, high=2 * np.pi, low=0, skipna=False, a
     return ((high - low) / 2.0 / np.pi) * np.sqrt(-2 * np.log(r_r))
 
 
-def smooth_data(obs_vals, pp_vals):
+def smooth_data(obs_vals, pp_vals, axis=1):
     """Smooth data, helper function for discrete data in plot_pbv, loo_pit and plot_loo_pit."""
     x = np.linspace(0, 1, len(obs_vals))
     csi = CubicSpline(x, obs_vals)
     obs_vals = csi(np.linspace(0.01, 0.99, len(obs_vals)))
 
-    x = np.linspace(0, 1, pp_vals.shape[1])
-    csi = CubicSpline(x, pp_vals, axis=1)
-    pp_vals = csi(np.linspace(0.01, 0.99, pp_vals.shape[1]))
+    x = np.linspace(0, 1, pp_vals.shape[axis])
+    csi = CubicSpline(x, pp_vals, axis=axis)
+    pp_vals = csi(np.linspace(0.01, 0.99, pp_vals.shape[axis]))
 
     return obs_vals, pp_vals


### PR DESCRIPTION
This PR computed loo-pit using a numpy vectorized version, instead of the wrapped _loo_pit function. Not necessary in favor of keeping this version, just pointing that the current version may be failing for some corner cases. Below, blue current version, black numpy version, gray `az.plot_bpv()`

For these two there is a large difference (both are logistic regressions)
![logistic](https://user-images.githubusercontent.com/1338958/121135515-f6285a80-c80a-11eb-8ef4-19d117cc1d4b.png)
![test_loo_pit](https://user-images.githubusercontent.com/1338958/121135593-0a6c5780-c80b-11eb-81d9-5217cae6bea2.png)

For the rest the blue curve is hidden behind the black one (current and numpy versions agree)
![miss_normal](https://user-images.githubusercontent.com/1338958/121135632-1526ec80-c80b-11eb-8518-3f6f7cfa5841.png). 
![radon](https://user-images.githubusercontent.com/1338958/121135613-11936580-c80b-11eb-8e4f-5322814b1233.png)
![non_centered_eight](https://user-images.githubusercontent.com/1338958/121135615-122bfc00-c80b-11eb-8947-7cdde43ba8d4.png)

