### PR TITLE
change error handling in get_coords

### DIFF
--- a/arviz/tests/base_tests/test_plot_utils.py
+++ b/arviz/tests/base_tests/test_plot_utils.py
@@ -137,23 +137,25 @@ def test_xarray_sel_data_array(sample_dataset):  # pylint: disable=invalid-name
 class TestCoordsExceptions:
     # test coord exceptions on datasets
     def test_invalid_coord_name(self, sample_dataset):  # pylint: disable=invalid-name
-        """Assert that nicer exception appears when user enters wrong coords name"""
+        """Assert that nicer exception appears when user enters wrong coords name.
+
+        TODO: remove test and delegate to xarray
+        """
         _, _, data = sample_dataset
         coords = {"NOT_A_COORD_NAME": [1]}
 
-        with pytest.raises(
-            ValueError, match="Coords {'NOT_A_COORD_NAME'} are invalid coordinate keys"
-        ):
+        with pytest.raises((ValueError, KeyError)):
             get_coords(data, coords)
 
     def test_invalid_coord_value(self, sample_dataset):  # pylint: disable=invalid-name
-        """Assert that nicer exception appears when user enters wrong coords value"""
+        """Assert that nicer exception appears when user enters wrong coords value.
+
+        TODO: remove test and delegate to xarray
+        """
         _, _, data = sample_dataset
         coords = {"draw": [1234567]}
 
-        with pytest.raises(
-            KeyError, match=r"Coords should follow mapping format {coord_name:\[dim1, dim2\]}"
-        ):
+        with pytest.raises(KeyError):
             get_coords(data, coords)
 
     def test_invalid_coord_structure(self, sample_dataset):  # pylint: disable=invalid-name

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -621,7 +621,11 @@ def get_coords(data, coords):
         xarray.DataSet or xarray.DataArray object, same type as input
     """
     if not isinstance(data, (list, tuple)):
-        if packaging.version.parse(xr.__version__) > packaging.version.parse("0.18.2"):
+        min_version = packaging.version.parse("0.18.2")
+        xr_version = packaging.version.parse(xr.__version__)
+        if (xr_version > min_version) or (
+            ("dev" in xr.__version__) and (xr_version == min_version)
+        ):
             return data.sel(**coords)
         else:
             # keep our tweaked improved errors for a while


### PR DESCRIPTION
## Description
I think this will fix CI for xarray preview. Also sets the path to end up delegating errors to
xarray instead of catching them to improve the error message. From a couple cases, it looks
like errors in xarray have now improved and are much more informative.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Does the PR follow [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist)
      PR format?
- [ ] Does the PR include new or updated tests to prevent issue recurrence (using [pytest fixture pattern](
      https://docs.pytest.org/en/latest/fixture.html#fixture))?
- [ ] Is the code style correct (follows pylint and black guidelines)?
- [ ] Is the fix listed in the [Maintenance and fixes](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#maintenance-and-fixes)
      section of the changelog?

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
