### PR TITLE
fix stacklevel of hdi warning

### DIFF
--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -495,6 +495,7 @@ def hdi(
             "hdi currently interprets 2d data as (draw, shape) but this will change in "
             "a future release to (chain, draw) for coherence with other functions",
             FutureWarning,
+            stacklevel=2,
         )
         ary = np.expand_dims(ary, 0)
 

--- a/arviz/tests/base_tests/test_stats.py
+++ b/arviz/tests/base_tests/test_stats.py
@@ -66,8 +66,8 @@ def test_hdp():
 def test_hdp_2darray():
     normal_sample = np.random.randn(12000, 5)
     msg = (
-        r'hdi currently interprets 2d data as \(draw, shape\) but this will '
-        r'change in a future release to \(chain, draw\) for coherence with other functions'
+        r"hdi currently interprets 2d data as \(draw, shape\) but this will "
+        r"change in a future release to \(chain, draw\) for coherence with other functions"
     )
     with pytest.warns(FutureWarning, match=msg):
         result = hdi(normal_sample)

--- a/arviz/tests/base_tests/test_stats.py
+++ b/arviz/tests/base_tests/test_stats.py
@@ -65,7 +65,12 @@ def test_hdp():
 
 def test_hdp_2darray():
     normal_sample = np.random.randn(12000, 5)
-    result = hdi(normal_sample)
+    msg = (
+        r'hdi currently interprets 2d data as \(draw, shape\) but this will '
+        r'change in a future release to \(chain, draw\) for coherence with other functions'
+    )
+    with pytest.warns(FutureWarning, match=msg):
+        result = hdi(normal_sample)
     assert result.shape == (5, 2)
 
 


### PR DESCRIPTION
## Description
<!--
Thank you so much for your PR! To help us review your contribution, please consider the following points:

- The PR title should summarize the changes, for example "Add new group argument for the pair plot".
  Avoid non-descriptive titles such as "Addresses issue #348".

- The description should provide at least 1-2 sentences describing the pull request in detail and
  link to any relevant issues.

- Please prefix the title of incomplete contributions with [WIP] (to indicate a work in
  progress). WIPs may be useful to (1) indicate you are working on something to avoid
  duplicated work, (2) request broad review of functionality or API, or (3) seek collaborators. -->

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [ ] New features are properly documented (with an example if appropriate)?
- [ ] Includes new or updated tests to cover the new feature
- [ ] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->

On main, this warning shows the line number from ArviZ code. On this branch, it'll show the line number from the user's code.

I wanted to add a test, but running
```
pytest arviz/tests/base_tests/test_stats.py -k test_hdp_2darray -W error
```
doesn't throw any errors, neither here nor on main - do the warnings get silenced somewhere during tests?

It shows the warning if I just execute the code:
```python
>>> import numpy as np
>>> import arviz
>>> arviz.hdi(np.random.randn(2, 2))
<stdin>:1: FutureWarning: hdi currently interprets 2d data as (draw, shape) but this will change in a future release to (chain, draw) for coherence with other functions
array([[-1.85791612,  1.28256026],
       [ 1.23431573,  1.91356814]])
>>> 
```