### PR TITLE
Fix credible interval  percentage in plot loo pit legend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * Fixed plot_kde to take labels with kwargs. ([1710](https://github.com/arviz-devs/arviz/pull/1710))
 * Fixed xarray related tests. ([1726](https://github.com/arviz-devs/arviz/pull/1726))
 * Fix Bokeh deprecation warnings ([1657](https://github.com/arviz-devs/arviz/pull/1657))
+* Fix credible inteval percentage in legend in `plot_loo_pit` ([1745](https://github.com/arviz-devs/arviz/pull/1745))
 
 ### Deprecation
 * Deprecated `index_origin` and `order` arguments in `az.summary` ([1201](https://github.com/arviz-devs/arviz/pull/1201))

--- a/arviz/plots/backends/bokeh/loopitplot.py
+++ b/arviz/plots/backends/bokeh/loopitplot.py
@@ -103,7 +103,9 @@ def plot_loo_pit(
             fill_kwargs.setdefault(
                 "step", "mid" if plot_kwargs["drawstyle"] == "steps-mid" else None
             )
-            fill_kwargs.setdefault("legend_label", "{:.3g}% credible interval".format(hdi_prob))
+            fill_kwargs.setdefault(
+                "legend_label", "{:.3g}% credible interval".format(hdi_prob * 100)
+            )
     elif use_hdi:
         if hdi_kwargs is None:
             hdi_kwargs = {}

--- a/arviz/plots/backends/matplotlib/loopitplot.py
+++ b/arviz/plots/backends/matplotlib/loopitplot.py
@@ -99,7 +99,7 @@ def plot_loo_pit(
             fill_kwargs.setdefault(
                 "step", "mid" if plot_kwargs["drawstyle"] == "steps-mid" else None
             )
-            fill_kwargs.setdefault("label", "{:.3g}% credible interval".format(hdi_prob))
+            fill_kwargs.setdefault("label", "{:.3g}% credible interval".format(hdi_prob * 100))
     elif use_hdi:
         if hdi_kwargs is None:
             hdi_kwargs = {}
@@ -137,7 +137,7 @@ def plot_loo_pit(
     ax.tick_params(labelsize=xt_labelsize)
     if legend:
         if not (use_hdi or (ecdf and ecdf_fill)):
-            label = "{:.3g}% credible interval".format(hdi_prob) if ecdf else "Uniform"
+            label = "{:.3g}% credible interval".format(hdi_prob * 100) if ecdf else "Uniform"
             ax.plot([], label=label, **plot_unif_kwargs)
         ax.legend()
 


### PR DESCRIPTION
## Description

Fix credible interval percentage in `plot_loo_pit` legend

Before:
![Screenshot from 2021-07-25 19-19-17](https://user-images.githubusercontent.com/40103387/126901516-e511c29f-9cfb-4f3a-9037-989195270939.png)

After:
![Screenshot from 2021-07-25 19-17-53](https://user-images.githubusercontent.com/40103387/126901525-d0b0b6f3-62e5-4d5f-8ef3-6b3aade37aa1.png)


<!--
Thank you so much for your PR! To help us review your contribution, please consider the following points:

- The PR title should summarize the changes, for example "Add new group argument for the pair plot".
  Avoid non-descriptive titles such as "Addresses issue #348".

- The description should provide at least 1-2 sentences describing the pull request in detail and
  link to any relevant issues.

- Please prefix the title of incomplete contributions with [WIP] (to indicate a work in
  progress). WIPs may be useful to (1) indicate you are working on something to avoid
  duplicated work, (2) request broad review of functionality or API, or (3) seek collaborators. -->

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
