### PR TITLE
Add support for JSON format

### DIFF
--- a/arviz/data/io_cmdstan.py
+++ b/arviz/data/io_cmdstan.py
@@ -1,5 +1,6 @@
 # pylint: disable=too-many-lines
 """CmdStan-specific conversion code."""
+import json
 import logging
 import os
 import re
@@ -838,7 +839,7 @@ def _process_data_var(string):
 
 
 def _read_data(path):
-    """Read Rdump output to dictionary.
+    """Read Rdump or JSON output to dictionary.
 
     Parameters
     ----------
@@ -847,10 +848,12 @@ def _read_data(path):
     Returns
     -------
     Dict
-        key, values pairs from Rdump formatted data.
+        key, values pairs from Rdump/JSON formatted data.
     """
     data = {}
     with open(path, "r") as f_obj:
+        if path.lower().endswith(".json"):
+            return json.load(f_obj)
         var = ""
         for line in f_obj:
             if "<-" in line:
@@ -944,18 +947,18 @@ def from_cmdstan(
     prior_predictive : str or list of str, optional
         Prior predictive samples for the fit. If endswith ".csv" assumes file.
     observed_data : str, optional
-        Observed data used in the sampling. Path to data file in Rdump format.
+        Observed data used in the sampling. Path to data file in Rdump or JSON format.
     observed_data_var : str or list of str, optional
         Variable(s) used for slicing observed_data. If not defined, all
         data variables are imported.
     constant_data : str, optional
-        Constant data used in the sampling. Path to data file in Rdump format.
+        Constant data used in the sampling. Path to data file in Rdump or JSON format.
     constant_data_var : str or list of str, optional
         Variable(s) used for slicing constant_data. If not defined, all
         data variables are imported.
     predictions_constant_data : str, optional
         Constant data for predictions used in the sampling.
-        Path to data file in Rdump format.
+        Path to data file in Rdump or JSON format.
     predictions_constant_data_var : str or list of str, optional
         Variable(s) used for slicing predictions_constant_data.
         If not defined, all data variables are imported.
@@ -967,7 +970,7 @@ def from_cmdstan(
     coords : dict of {str: array_like}, optional
         A dictionary containing the values that are used as index. The key
         is the name of the dimension, the values are the index values.
-    dims : dict of {str: list of str, optional
+    dims : dict of {str: list of str}, optional
         A mapping from variables to a list of coordinate names for the variable.
     disable_glob : bool
         Don't use glob for string input. This means that all string input is


### PR DESCRIPTION
This small change adds support to read Stan's JSON data in addition to Rdump. This was requested in #1466 and I've needed it myself. It updates `_read_data()` to parse as JSON any input files with `.json` extension, defaulting to Rdump otherwise.
Hence `observed_data`, `constant_data`, and `predictions_constant_data` all accept JSON inputs now.
I've run `black` and `pylint` on the changes.

Also added a missing bracket in a docstring.