### PR TITLE
Fixed the link of netCDF

### DIFF
--- a/doc/source/getting_started/Introduction.ipynb
+++ b/doc/source/getting_started/Introduction.ipynb
@@ -6299,7 +6299,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Again, converting to `InferenceData` (a [NetCDF](https://arviz-devs.github.io/arviz/getting_started/XarrayforArviZ.html#netcdf) datastore that loads data into `xarray` datasets), we can get much richer labelling and mixing of data. Here is a plot showing where the Hamiltonian sampler had divergences:"
+    "Again, converting to `InferenceData` (a {ref}`netCDF <netcdf>` datastore that loads data into `xarray` datasets), we can get much richer labelling and mixing of data. Here is a plot showing where the Hamiltonian sampler had divergences:"
    ]
   },
   {


### PR DESCRIPTION
**Description:**
Fixed the reference to netCDf in the [quick-start](https://arviz-devs.github.io/arviz/getting_started/Introduction.html#plotting-with-pystan-objects) section. 