### PR TITLE
Updated Refitting PyStan (2.x) models with ArviZ (and xarray)

### DIFF
--- a/doc/source/user_guide/pystan2_refitting_xr_lik.ipynb
+++ b/doc/source/user_guide/pystan2_refitting_xr_lik.ipynb
@@ -217,7 +217,7 @@
    "source": [
     "This function should work for any shape of the input arrays as long as their shapes are compatible and can broadcast. There is no need to loop over each draw in order to calculate the pointwise log likelihood using scalars.\n",
     "\n",
-    "Therefore, we can use {func}`~xr:xarray.apply_ufunc` to handle the broadcasting and preserve the dimension names:"
+    "Therefore, we can use {func}`~xr:xarray.apply_ufunc` {func}`xr:xarray.apply_ufunc` {func}`xr.apply_ufunc <xarray.apply_ufunc>` to handle the broadcasting and preserve the dimension names:"
    ]
   },
   {

--- a/doc/source/user_guide/pystan2_refitting_xr_lik.ipynb
+++ b/doc/source/user_guide/pystan2_refitting_xr_lik.ipynb
@@ -195,9 +195,9 @@
    "source": [
     "We are now missing the `log_likelihood` group because we have not used the `log_likelihood` argument in `idata_kwargs`. We are doing this to ease the job of the sampling wrapper. Instead of going out of our way to get Stan to calculate the pointwise log likelihood values for each refit and for the excluded observation at every refit, we will compromise and manually write a function to calculate the pointwise log likelihood.\n",
     "\n",
-    "Even though it is not ideal to lose part of the straight out of the box capabilities of PyStan-ArviZ integration, this should generally not be a problem. We are basically moving the pointwise log likelihood calculation from the Stan code to the Python code, in both cases we need to manually write the function to calculate the pointwise log likelihood.\n",
+    "Even though it is not ideal to lose part of the straight out of the box capabilities of PyStan-ArviZ integration, this should generally not be a problem. We are basically moving the pointwise log likelihood calculation from the Stan code to the Python code, in both cases, we need to manually write the function to calculate the pointwise log likelihood.\n",
     "\n",
-    "Moreover, the Python computation could even be written to be compatible with Dask. Thus it will work even in cases where the large number of observations makes it impossible to store pointwise log likelihood values (with shape `n_samples * n_observations`) in memory."
+    "Moreover, the Python computation could even be written to be compatible with [Dask](https://docs.dask.org/en/latest/). Thus it will work even in cases where the large number of observations makes it impossible to store pointwise log likelihood values (with shape `n_samples * n_observations`) in memory."
    ]
   },
   {
@@ -280,7 +280,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you are still curious about the magic of xarray and {func}`~xarray:xarray.apply_ufunc`, you can also try to modify the `dims` used to generate the `InferenceData` a couple cells before:\n",
+    "If you are still curious about the magic of xarray and `apply_ufunc`, you can also try to modify the `dims` used to generate the `InferenceData` a couple of cells before:\n",
     "\n",
     "    dims = {\"y\": [\"time\"], \"x\": [\"time\"]}\n",
     "    \n",
@@ -3183,7 +3183,11 @@
    "source": [
     "We will create a subclass of {class}`~arviz.SamplingWrapper`. Therefore, instead of having to implement all functions required by {func}`~arviz.reloo` we only have to implement {func}`~arviz.SamplingWrapper.sel_observations` (we are cloning  {func}`~arviz.PyStanSamplingWrapper.sample` and {func}`~arviz.PyStanSamplingWrapper.get_inference_data` from the {class}`~arviz.PyStan2SamplingWrapper` in order to use `apply_ufunc` instead of assuming the log likelihood is calculated within Stan). \n",
     "\n",
-    "Note that of the 2 outputs of `sel_observations`, `data__i` is a dictionary because it is an argument of `sample` which will pass it as is to `model.sampling`, whereas `data_ex` is a list because it is an argument to `log_likelihood__i` which will pass it as `*data_ex` to  `apply_ufunc`. More on `data_ex` and `apply_ufunc` integration is given below."
+    "Let's check the 2 outputs of `sel_observations`.\n",
+    "1. `data__i` is a dictionary because it is an argument of `sample` which will pass it as is to `model.sampling`.\n",
+    "2. `data_ex` is a list because it is an argument to `log_likelihood__i` which will pass it as `*data_ex` to  `apply_ufunc`.\n"
+    "\n",
+    "More on `data_ex` and `apply_ufunc` integration is given below."
    ]
   },
   {
@@ -3267,7 +3271,7 @@
    "source": [
     "We initialize our sampling wrapper. Let's stop and analyze each of the arguments. \n",
     "\n",
-    "We then use the `log_lik_fun` and `posterior_vars` argument to tell the wrapper how to call {func}`~xarray:xarray.apply_ufunc`. `log_lik_fun` is the function to be called, which is then called with the following positional arguments:\n",
+    "We use the `log_lik_fun` and `posterior_vars` argument to tell the wrapper how to call {func}`~xarray:xarray.apply_ufunc`. `log_lik_fun` is the function to be called, which is then called with the following positional arguments:\n",
     "\n",
     "    log_lik_fun(*data_ex, *[idata__i.posterior[var_name] for var_name in posterior_vars]\n",
     "    \n",

--- a/doc/source/user_guide/pystan2_refitting_xr_lik.ipynb
+++ b/doc/source/user_guide/pystan2_refitting_xr_lik.ipynb
@@ -3185,7 +3185,7 @@
     "\n",
     "Let's check the 2 outputs of `sel_observations`.\n",
     "1. `data__i` is a dictionary because it is an argument of `sample` which will pass it as is to `model.sampling`.\n",
-    "2. `data_ex` is a list because it is an argument to `log_likelihood__i` which will pass it as `*data_ex` to  `apply_ufunc`.\n"
+    "2. `data_ex` is a list because it is an argument to `log_likelihood__i` which will pass it as `*data_ex` to  `apply_ufunc`.\n",
     "\n",
     "More on `data_ex` and `apply_ufunc` integration is given below."
    ]

--- a/doc/source/user_guide/pystan2_refitting_xr_lik.ipynb
+++ b/doc/source/user_guide/pystan2_refitting_xr_lik.ipynb
@@ -3181,7 +3181,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will create a subclass of {class}`~arviz.SamplingWrapper`. Therefore, instead of having to implement all functions required by {func}`~arviz.reloo` we only have to implement {func}`~arviz.SamplingWrapper.sel_observations` (we are cloning  {func}`~arviz.SamplingWrapper.sample` and {func}`~arviz.SamplingWrapper.get_inference_data` from the {class}`~arviz.PyStan2SamplingWrapper` in order to use `apply_ufunc` instead of assuming the log likelihood is calculated within Stan). \n",
+    "We will create a subclass of {class}`~arviz.SamplingWrapper`. Therefore, instead of having to implement all functions required by {func}`~arviz.reloo` we only have to implement {func}`~arviz.SamplingWrapper.sel_observations` (we are cloning  {func}`~arviz.SamplingWrapper.sample` and {func}`~arviz.SamplingWrapper.get_inference_data` from the {class}`~arviz.SamplingWrapper` in order to use `apply_ufunc` instead of assuming the log likelihood is calculated within Stan). \n",
     "\n",
     "Let's check the 2 outputs of `sel_observations`.\n",
     "1. `data__i` is a dictionary because it is an argument of `sample` which will pass it as is to `model.sampling`.\n",
@@ -3211,7 +3211,7 @@
     "        return fit\n",
     "\n",
     "    def get_inference_data(self, fit):\n",
-    "        # Cloned from PyStanSamplingWrapper.\n",
+    "        # Cloned from PyStan2SamplingWrapper.\n",
     "        idata = az.from_pystan(posterior=fit, **self.idata_kwargs)\n",
     "        return idata\n"
    ]

--- a/doc/source/user_guide/pystan2_refitting_xr_lik.ipynb
+++ b/doc/source/user_guide/pystan2_refitting_xr_lik.ipynb
@@ -35,7 +35,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For the example we will use linear regression."
+    "For the example, we will use a linear regression model."
    ]
   },
   {
@@ -3181,7 +3181,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will create a subclass of {class}`~arviz.SamplingWrapper`. Therefore, instead of having to implement all functions required by {func}`~arviz.reloo` we only have to implement {func}`~arviz.SamplingWrapper.sel_observations` (we are cloning  {func}`~arviz.PyStanSamplingWrapper.sample` and {func}`~arviz.PyStanSamplingWrapper.get_inference_data` from the {class}`~arviz.PyStan2SamplingWrapper` in order to use `apply_ufunc` instead of assuming the log likelihood is calculated within Stan). \n",
+    "We will create a subclass of {class}`~arviz.SamplingWrapper`. Therefore, instead of having to implement all functions required by {func}`~arviz.reloo` we only have to implement {func}`~arviz.SamplingWrapper.sel_observations` (we are cloning  {func}`~arviz.SamplingWrapper.sample` and {func}`~arviz.SamplingWrapper.get_inference_data` from the {class}`~arviz.PyStan2SamplingWrapper` in order to use `apply_ufunc` instead of assuming the log likelihood is calculated within Stan). \n",
     "\n",
     "Let's check the 2 outputs of `sel_observations`.\n",
     "1. `data__i` is a dictionary because it is an argument of `sample` which will pass it as is to `model.sampling`.\n",
@@ -3253,7 +3253,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this case, the Leave-One-Out Cross Validation (LOO-CV) approximation using [Pareto Smoothed Importance Sampling](https://mc-stan.org/loo/reference/psis.html) (PSIS) works for all observations, so we will use modify `loo_orig` in order to make {func}`~arviz.reloo` believe that PSIS failed for some observations. This will also serve as a validation of our wrapper, as the PSIS LOO-CV already returned the correct value."
+    "In this case, the Leave-One-Out Cross Validation (LOO-CV) approximation using [Pareto Smoothed Importance Sampling](https://arxiv.org/abs/1507.02646) (PSIS) works for all observations, so we will use modify `loo_orig` in order to make {func}`~arviz.reloo` believe that PSIS failed for some observations. This will also serve as a validation of our wrapper, as the PSIS LOO-CV already returned the correct value."
    ]
   },
   {

--- a/doc/source/user_guide/pystan2_refitting_xr_lik.ipynb
+++ b/doc/source/user_guide/pystan2_refitting_xr_lik.ipynb
@@ -14,7 +14,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Below there is one example of `SamplingWrapper` usage for PyStan (2.x)."
+    "Below there is an example of `SamplingWrapper` usage for PyStan (2.x)."
    ]
   },
   {
@@ -35,7 +35,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For the example we will use a linear regression."
+    "For the example we will use linear regression."
    ]
   },
   {
@@ -87,7 +87,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we will write the Stan code, keeping in mind only to include the array shapes as parameters."
+    "Now we will write the Stan code, keeping in mind to include only the array shapes as parameters."
    ]
   },
   {
@@ -217,7 +217,7 @@
    "source": [
     "This function should work for any shape of the input arrays as long as their shapes are compatible and can broadcast. There is no need to loop over each draw in order to calculate the pointwise log likelihood using scalars.\n",
     "\n",
-    "Therefore, we can use `xr.apply_ufunc` to handle the broadasting and preserve the dimension names:"
+    "Therefore, we can use {func}`~xr:xarray.apply_ufunc` to handle the broadcasting and preserve the dimension names:"
    ]
   },
   {
@@ -243,7 +243,7 @@
    "source": [
     "The first argument is the function, followed by as many positional arguments as needed by the function, 5 in our case. As this case does not have many different dimensions nor combinations of these, we do not need to use any extra kwargs passed to {func}`xarray:xarray.apply_ufunc`.\n",
     "\n",
-    "We are now passing the arguments to `calculate_log_lik` initially as {class}`xarray:xarray.DataArray`s. What is happening here behind the scenes is that {func}`~xarray:xarray.apply_ufunc` is broadcasting and aligning the dimensions of all the DataArrays involved and afterwards passing numpy arrays to `calculate_log_lik`. Everything works automagically. \n",
+    "We are now passing the arguments to `calculate_log_lik` initially as {class}`xarray:xarray.DataArray`s. What is happening here behind the scenes is that {func}`~xarray:xarray.apply_ufunc` is broadcasting and aligning the dimensions of all the DataArrays involved and afterwards passing NumPy arrays to `calculate_log_lik`. Everything works automagically. \n",
     "\n",
     "Now let's see what happens if we were to pass the arrays directly to `calculate_log_lik` instead:"
    ]
@@ -280,7 +280,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you are still curious about the magic of xarray and {func}`~xarray:xarray.apply_ufunc`, you can also try to modify the `dims` used to generate the InferenceData a couple cells before:\n",
+    "If you are still curious about the magic of xarray and {func}`~xarray:xarray.apply_ufunc`, you can also try to modify the `dims` used to generate the `InferenceData` a couple cells before:\n",
     "\n",
     "    dims = {\"y\": [\"time\"], \"x\": [\"time\"]}\n",
     "    \n",
@@ -3181,9 +3181,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will create a subclass of {class}`~arviz.SamplingWrapper`. Therefore, instead of having to implement all functions required by {func}`~arviz.reloo` we only have to implement `sel_observations` (we are cloning `sample` and `get_inference_data` from the `PyStan2SamplingWrapper` in order to use `apply_ufunc` instead of assuming the log likelihood is calculated within Stan). \n",
+    "We will create a subclass of {class}`~arviz.SamplingWrapper`. Therefore, instead of having to implement all functions required by {func}`~arviz.reloo` we only have to implement {func}`~arviz.SamplingWrapper.sel_observations` (we are cloning  {func}`~arviz.PyStanSamplingWrapper.sample` and {func}`~arviz.PyStanSamplingWrapper.get_inference_data` from the {class}`~arviz.PyStan2SamplingWrapper` in order to use `apply_ufunc` instead of assuming the log likelihood is calculated within Stan). \n",
     "\n",
-    "Note that of the 2 outputs of `sel_observations`, `data__i` is a dictionary because it is an argument of `sample` which will pass it as is to `model.sampling`, whereas `data_ex` is a list because it is an argument to `log_likelihood__i` which will pass it as `*data_ex` to  `apply_ufunc`. More on `data_ex` and `apply_ufunc` integration below."
+    "Note that of the 2 outputs of `sel_observations`, `data__i` is a dictionary because it is an argument of `sample` which will pass it as is to `model.sampling`, whereas `data_ex` is a list because it is an argument to `log_likelihood__i` which will pass it as `*data_ex` to  `apply_ufunc`. More on `data_ex` and `apply_ufunc` integration is given below."
    ]
   },
   {
@@ -3249,7 +3249,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this case, the Leave-One-Out Cross Validation (LOO-CV) approximation using Pareto Smoothed Importance Sampling (PSIS) works for all observations, so we will use modify `loo_orig` in order to make {func}`~arviz.reloo` believe that PSIS failed for some observations. This will also serve as a validation of our wrapper, as the PSIS LOO-CV already returned the correct value."
+    "In this case, the Leave-One-Out Cross Validation (LOO-CV) approximation using [Pareto Smoothed Importance Sampling](https://mc-stan.org/loo/reference/psis.html) (PSIS) works for all observations, so we will use modify `loo_orig` in order to make {func}`~arviz.reloo` believe that PSIS failed for some observations. This will also serve as a validation of our wrapper, as the PSIS LOO-CV already returned the correct value."
    ]
   },
   {
@@ -3271,11 +3271,11 @@
     "\n",
     "    log_lik_fun(*data_ex, *[idata__i.posterior[var_name] for var_name in posterior_vars]\n",
     "    \n",
-    "where `data_ex` is the second element returned by `sel_observations` and `idata__i` is the InferenceData object result of `get_inference_data` which contains the fit on the subsetted data. We have generated `data_ex` to be a tuple of DataArrays so it plays nicely with this call signature.\n",
+    "where `data_ex` is the second element returned by `sel_observations` and `idata__i` is the `InferenceData` object result of `get_inference_data` which contains the fit on the subsetted data. We have generated `data_ex` to be a tuple of DataArrays so it plays nicely with this call signature.\n",
     "\n",
     "We use `idata_orig` as a starting point, and mostly as a source of observed and constant data which is then subsetted in `sel_observations`.\n",
     "\n",
-    "Finally, `sample_kwargs` and `idata_kwargs` are used to make sure all refits and corresponding InferenceData are generated with the same properties."
+    "Finally, `sample_kwargs` and `idata_kwargs` are used to make sure all refits and corresponding `InferenceData` are generated with the same properties."
    ]
   },
   {

--- a/doc/source/user_guide/pystan2_refitting_xr_lik.ipynb
+++ b/doc/source/user_guide/pystan2_refitting_xr_lik.ipynb
@@ -217,7 +217,7 @@
    "source": [
     "This function should work for any shape of the input arrays as long as their shapes are compatible and can broadcast. There is no need to loop over each draw in order to calculate the pointwise log likelihood using scalars.\n",
     "\n",
-    "Therefore, we can use {func}`~xr:xarray.apply_ufunc` {func}`xr:xarray.apply_ufunc` {func}`xr.apply_ufunc <xarray.apply_ufunc>` to handle the broadcasting and preserve the dimension names:"
+    "Therefore, we can use {func}`xr.apply_ufunc <xarray.apply_ufunc>` to handle the broadcasting and preserve the dimension names:"
    ]
   },
   {
@@ -241,7 +241,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The first argument is the function, followed by as many positional arguments as needed by the function, 5 in our case. As this case does not have many different dimensions nor combinations of these, we do not need to use any extra kwargs passed to {func}`xarray:xarray.apply_ufunc`.\n",
+    "The first argument is the function, followed by as many positional arguments as needed by the function, 5 in our case. As this case does not have many different dimensions nor combinations of these, we do not need to use any extra kwargs passed to `xarray.apply_ufunc`.\n",
     "\n",
     "We are now passing the arguments to `calculate_log_lik` initially as {class}`xarray:xarray.DataArray`s. What is happening here behind the scenes is that {func}`~xarray:xarray.apply_ufunc` is broadcasting and aligning the dimensions of all the DataArrays involved and afterwards passing NumPy arrays to `calculate_log_lik`. Everything works automagically. \n",
     "\n",


### PR DESCRIPTION
**Description:** 
Updated [Refitting PyStan (2.x) models with ArviZ (and xarray)](https://arviz-devs.github.io/arviz/user_guide/pystan2_refitting_xr_lik.html#) part.

* Added links to the ArviZ functions and classes using [Cross-referencing with Sphinx](https://docs.readthedocs.io/en/stable/guides/cross-referencing-with-sphinx.html).
* Added links to the xarray functions and classes using [Intersphinx](https://docs.readthedocs.io/en/stable/guides/intersphinx.html).
* Added the rest of the external links using the simple syntax `[]()`.