### PR TITLE
Updated text in PyStan schema example to match PyMC3 example

### DIFF
--- a/doc/source/schema/PyStan_schema_example.ipynb
+++ b/doc/source/schema/PyStan_schema_example.ipynb
@@ -361,10 +361,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-     "In this example, each variable for its dimension has a combination of the following three: `chain`, `draw` and `developer`. Moreover, each dimension has specific coordinate values.\n",
-     "\n",
-     "* In the case of `chain` and `draw` it is an integer identifier starting at `0`.\n",
-     "* In the case of `developer` dimension, its coordinate values are the following strings: `[\"Alice\", \"Bob\", \"Cole\", \"Danielle\", \"Erika\"]`."
+    "In this example, each variable for its dimension has a combination of the following three: `chain`, `draw` and `developer`. Moreover, each dimension has specific coordinate values.\n",
+    "\n",
+    "* In the case of `chain` and `draw` it is an integer identifier starting at `0`.\n",
+    "* In the case of `developer` dimension, its coordinate values are the following strings: `[\"Alice\", \"Bob\", \"Cole\", \"Danielle\", \"Erika\"]`."
    ]
   },
   {

--- a/doc/source/schema/PyStan_schema_example.ipynb
+++ b/doc/source/schema/PyStan_schema_example.ipynb
@@ -361,7 +361,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this example, each variable has as dimension a combination of the following 3: `chain`, `draw` and `developer`. Moreover, each dimension has specific coordinate values. In the case of `chain` and `draw` it is an integer identifier starting at `0`; in the case of `developer` dimension, its coordinate values are the following strings: `[\"Alice\", \"Bob\", \"Cole\", \"Danielle\", \"Erika\"]`."
+     "In this example, each variable for its dimension has a combination of the following three: `chain`, `draw` and `developer`. Moreover, each dimension has specific coordinate values.\n",
+     "\n",
+     "* In the case of `chain` and `draw` it is an integer identifier starting at `0`.\n",
+     "* In the case of `developer` dimension, its coordinate values are the following strings: `[\"Alice\", \"Bob\", \"Cole\", \"Danielle\", \"Erika\"]`."
    ]
   },
   {

--- a/doc/source/schema/PyStan_schema_example.ipynb
+++ b/doc/source/schema/PyStan_schema_example.ipynb
@@ -361,7 +361,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this example, each variable for its dimension has a combination of the following three: `chain`, `draw` and `developer`. Moreover, each dimension has specific coordinate values.\n",
+    "In this example, each variable has as dimensions a combination of the following three: `chain`, `draw` and `developer`. Moreover, each dimension has specific coordinate values.\n",
     "\n",
     "* In the case of `chain` and `draw` it is an integer identifier starting at `0`.\n",
     "* In the case of `developer` dimension, its coordinate values are the following strings: `[\"Alice\", \"Bob\", \"Cole\", \"Danielle\", \"Erika\"]`."


### PR DESCRIPTION
Documentation update.
- Updated text in notebook as requested in "Update doc-Example of InferenceData schema in PyStan" https://github.com/arviz-devs/arviz/issues/1799 
Looked at PR that updated pymc3 example https://github.com/arviz-devs/arviz/pull/1790 as reference


