### PR TITLE
Fix CI PyMC3 github install to v3

### DIFF
--- a/.azure-pipelines/azure-pipelines-external.yml
+++ b/.azure-pipelines/azure-pipelines-external.yml
@@ -86,7 +86,7 @@ jobs:
       fi
 
       if [ "$(pymc3.version)" = "github" ]; then
-           python -m pip --no-cache-dir --log log.txt install git+https://github.com/pymc-devs/pymc3
+           python -m pip --no-cache-dir --log log.txt install git+https://github.com/pymc-devs/pymc3@v3
            cat log.txt
       else
           python -m pip --no-cache-dir install pymc3


### PR DESCRIPTION
Fixing PyMC3 github source test to the PyMC3 branch in pymc3

This means PyMC (not 3) is not being tested right now so that'll have to get added later