### PR TITLE
Fix standard deviation code in density utils by replacing it with np.std.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### New features
 
 ### Maintenance and fixes
+* Fix standard deviation code in density utils by replacing it with `np.std`. ([1833](https://github.com/arviz-devs/arviz/pull/1833))
 
 ### Deprecation
 

--- a/arviz/stats/density_utils.py
+++ b/arviz/stats/density_utils.py
@@ -563,10 +563,9 @@ def _kde_linear(
         raise ValueError(f"`bw_fct` must be a positive number, not {bw_fct}.")
 
     # Preliminary calculations
-    x_len = len(x)
     x_min = x.min()
     x_max = x.max()
-    x_std = (((x ** 2).sum() / x_len) - (x.sum() / x_len) ** 2) ** 0.5
+    x_std = np.std(x)
     x_range = x_max - x_min
 
     # Determine grid


### PR DESCRIPTION
## Description

[Current formula for computing the standard deviation in `_kde_linear`](https://github.com/arviz-devs/arviz/blob/77a30bec94a3b88594edb6b272dad91039594f97/arviz/stats/density_utils.py#L569) is not numerically stable. Replace this  formula with `np.std`.

Solves https://github.com/arviz-devs/arviz/issues/1832



## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

