### PR TITLE
#1855: Added docs references to plot_mcse docstring

### DIFF
--- a/arviz/plots/mcseplot.py
+++ b/arviz/plots/mcseplot.py
@@ -79,13 +79,13 @@ def plot_mcse(
         its own array of plot areas (and return it).
     rug_kwargs: dict
         kwargs passed to rug plot in
-        :meth:`mpl:matplotlib.axes.Axes.plot` or :class:`bokeh:bokeh.models.glyphs.Scatter`
+        :meth:`mpl:matplotlib.axes.Axes.plot` or :class:`bokeh:bokeh.models.glyphs.Scatter`.
     extra_kwargs: dict, optional
         kwargs passed as extra method lines in
         :meth:`mpl:matplotlib.axes.Axes.axhline` or :class:`bokeh:bokeh.models.Span`
     text_kwargs: dict, optional
         kwargs passed to :meth:`mpl:matplotlib.axes.Axes.annotate` for extra methods lines labels.
-        It accepts the additional key ``x`` to set ``xy=(text_kwargs["x"], mcse)``. 
+        It accepts the additional key ``x`` to set ``xy=(text_kwargs["x"], mcse)``.
         text_kwargs are ignored for the bokeh plotting backend.
     backend: str, optional
         Select plotting backend {"matplotlib","bokeh"}. Default "matplotlib".


### PR DESCRIPTION
## Description
This commit resolves [#1855](https://github.com/arviz-devs/arviz/issues/1855) by adding doc references to plot_mcse docstring as described in the issue.

Also added this resolution in the [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

## Checklist
- [X] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [X] Code style  correct (follows pylint and black guidelines)
- [X] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)