### PR TITLE
Check data type in `plot_ppc`

### DIFF
--- a/arviz/plots/backends/bokeh/ppcplot.py
+++ b/arviz/plots/backends/bokeh/ppcplot.py
@@ -89,6 +89,11 @@ def plot_ppc(
         dtype = predictive_dataset[pp_var_name].dtype.kind
         legend_it = []
 
+        if dtype not in ["i", "f"]:
+            raise ValueError(
+                f"The data type of the predictive data must be one of 'i' or 'f', but is '{dtype}'"
+            )
+
         # flatten non-specified dimensions
         obs_vals = obs_vals.flatten()
         pp_vals = pp_vals.reshape(total_pp_samples, -1)

--- a/arviz/plots/backends/matplotlib/ppcplot.py
+++ b/arviz/plots/backends/matplotlib/ppcplot.py
@@ -116,6 +116,11 @@ def plot_ppc(
         pp_var_name, _, _, pp_vals = pp_plotters[i]
         dtype = predictive_dataset[pp_var_name].dtype.kind
 
+        if dtype not in ["i", "f"]:
+            raise ValueError(
+                f"The data type of the predictive data must be one of 'i' or 'f', but is '{dtype}'"
+            )
+
         # flatten non-specified dimensions
         obs_vals = obs_vals.flatten()
         pp_vals = pp_vals.reshape(total_pp_samples, -1)


### PR DESCRIPTION
## Description

This PR adds a check for the type of predictive data in the `plot_ppc()` functions. I don't think it is common that people face the problem I faced (because I committed a mistake), but I think it is better to show them an appropriate error message in this case.

**This is what I tried to do**

```python
import arviz as az
import numpy as np
import pymc3 as pm

x = np.random.normal(size=100)
y = np.random.normal(size=100)

with pm.Model() as model:
    a = pm.Normal("a")
    b = pm.Normal("b")
    y = pm.Normal("obs", mu = a + b * x, observed = y)
    idata = pm.sample(return_inferencedata=True)


with model:
    ppc = pm.sample_posterior_predictive(idata)

idata.add_groups({"posterior_predictive": {"obs": ppc}})

az.plot_ppc(idata)
```

The traceback 

```
~/Desktop/Cosas/oss/arviz/arviz/plots/backends/matplotlib/ppcplot.py in plot_ppc(ax, length_plotters, rows, cols, figsize, animated, obs_plotters, pp_plotters, predictive_dataset, pp_sample_ix, kind, alpha, colors, textsize, mean, observed, jitter, total_pp_samples, legend, labeller, group, animation_kwargs, num_pp_samples, backend_kwargs, show)
    148                         linewidth=linewidth,
    149                         zorder=3,
--> 150                         drawstyle=plot_kwargs["drawstyle"],
    151                     )
    152 

KeyError: 'drawstyle'
```

which tells the plotting function is expecting a `"drawstyle"` value that is not there. Some minutes later I realized the problem was that `ppc` is a `dict`, and that I should have passed `ppc["obs"]` instead of just `ppc`:

![image](https://user-images.githubusercontent.com/25507629/137118555-89dc486c-86cb-4679-951b-be4d054afcde.png)


**After the changes in this PR**


```python
import arviz as az
import numpy as np
import pymc3 as pm

x = np.random.normal(size=100)
y = np.random.normal(size=100)

with pm.Model() as model:
    a = pm.Normal("a")
    b = pm.Normal("b")
    y = pm.Normal("obs", mu = a + b * x, observed = y)
    idata = pm.sample(return_inferencedata=True)


with model:
    ppc = pm.sample_posterior_predictive(idata)

idata.add_groups({"posterior_predictive": {"obs": ppc}})

az.plot_ppc(idata)
```

```
ValueError: The data type of the predictive data must be one of 'i' or 'f', but is 'O'
```

which is clearer about what is wrong.