### PR TITLE
Add docs reference to plot_parallel docstring

### DIFF
--- a/arviz/plots/parallelplot.py
+++ b/arviz/plots/parallelplot.py
@@ -94,7 +94,7 @@ def plot_parallel(
     --------
     plot_pair : Plot a scatter, kde and/or hexbin matrix with (optional) marginals on the diagonal.
     plot_trace : Plot distribution (histogram or kernel density estimates) and sampled values
-    or rank plot
+                 or rank plot
 
     Examples
     --------


### PR DESCRIPTION
This closes #1886 

Following #1816 as guidance, I have:
* added links to the related arviz functions and classes in [arviz/plots/parallelplot.py](arviz/plots/parallelplot.py);
* included backquotes to identify code samples;
* added the "See Also" section;
* checked and added the functions which `backend_kwargs` are passed to.
 