### PR TITLE
Added "functions used" one-liner before every code tab in ArviZ QuickStart

### DIFF
--- a/doc/source/getting_started/Introduction.ipynb
+++ b/doc/source/getting_started/Introduction.ipynb
@@ -54,7 +54,9 @@
    "source": [
     "## Get started with plotting\n",
     "\n",
-    "ArviZ is designed to be used with libraries like [PyStan](https://pystan.readthedocs.io) and [PyMC3](https://docs.pymc.io), but works fine with raw NumPy arrays."
+    "ArviZ is designed to be used with libraries like [PyStan](https://pystan.readthedocs.io) and [PyMC3](https://docs.pymc.io), but works fine with raw NumPy arrays.\n",
+    "\n",
+    "**Functions used:** {func}`arviz.plot_posterior`"
    ]
   },
   {
@@ -81,7 +83,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Plotting a dictionary of arrays, ArviZ will interpret each key as the name of a different random variable. Each row of an array is treated as an independent series of draws from the variable, called a _chain_. Below, we have 10 chains of 50 draws, each for four different distributions."
+    "Plotting a dictionary of arrays, ArviZ will interpret each key as the name of a different random variable. Each row of an array is treated as an independent series of draws from the variable, called a _chain_. Below, we have 10 chains of 50 draws, each for four different distributions.\n",
+    "\n",
+    "**Functions used:** {func}`arviz.plot_posterior`"
    ]
   },
   {
@@ -257,7 +261,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Most ArviZ functions work fine with `trace` objects from PyMC3:"
+    "Most ArviZ functions work fine with `trace` objects from PyMC3:\n",
+    "\n",
+    "**Functions used:** {func}`arviz.plot_autocorr`"
    ]
   },
   {
@@ -296,7 +302,9 @@
     "\n",
     "For much more powerful querying, analysis and plotting, we can use built-in ArviZ utilities to convert PyMC3 objects to xarray datasets. Note we are also giving some information about labelling.\n",
     "\n",
-    "ArviZ is built to work with {ref}`InferenceData <creating_InferenceData>`. The more *groups* it has access to, the more powerful analyses it can perform. You can check the `InferenceData` structure specification {ref}`here <schema>`. Given below is a plot of the trace, which is common in PyMC3 workflows. Don't forget to note the intelligent labels."
+    "ArviZ is built to work with {ref}`InferenceData <creating_InferenceData>`. The more *groups* it has access to, the more powerful analyses it can perform. You can check the `InferenceData` structure specification {ref}`here <schema>`. Given below is a plot of the trace, which is common in PyMC3 workflows. Don't forget to note the intelligent labels.\n",
+    "\n",
+    "**Functions used:** {func}`arviz.from_pymc3`, {func}`arviz.plot_trace`"
    ]
   },
   {
@@ -6276,6 +6284,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Functions used: {func}`arviz.plot_density`"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {},
@@ -6299,7 +6314,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Again, converting to `InferenceData` (a {ref}`netCDF <netcdf>` datastore that loads data into `xarray` datasets), we can get much richer labelling and mixing of data. Here is a plot showing where the Hamiltonian sampler had divergences:"
+    "Again, converting to `InferenceData` (a {ref}`netCDF <netcdf>` datastore that loads data into `xarray` datasets), we can get much richer labelling and mixing of data. Here is a plot showing where the Hamiltonian sampler had divergences:\n",
+    "\n",
+    "**Functions used:** {func}`arviz.from_pystan`, {func}`arviz.plot_pair`"
    ]
   },
   {


### PR DESCRIPTION
**Description:**
Added one-liner "functions used" before every code tab in [Arviz quickStart](https://arviz-devs.github.io/arviz/getting_started/Introduction.html). The one-liner will consist of links to all the functions used in the below code tab. The aim is to make it easy for beginners to understand the ArviZ code.  