### PR TITLE
Added refernces in plot_kde

### DIFF
--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -82,26 +82,29 @@ def plot_kde(
         Figure size. If None it will be defined automatically.
     textsize: float
         Text size scaling factor for labels, titles and lines. If None it will be autoscaled based
-        on figsize. Not implemented for bokeh backend.
+        on ``figsize``. Not implemented for bokeh backend.
     plot_kwargs : dict
         Keywords passed to the pdf line of a 1D KDE. See :meth:`mpl:matplotlib.axes.Axes.plot`
-        or :meth:`bokeh:bokeh.plotting.figure.Figure.line` for a description of accepted values.
+        or :meth:`bokeh:bokeh.plotting.Figure.line` for a description of accepted values.
     fill_kwargs : dict
-        Keywords passed to the fill under the line (use fill_kwargs={'alpha': 0} to disable fill).
+        Keywords passed to the fill under the line (use ``fill_kwargs={'alpha': 0}`` to disable fill).
         Ignored for 2D KDE
     rug_kwargs : dict
-        Keywords passed to the rug plot. Ignored if rug=False or for 2D KDE
-        Use `space` keyword (float) to control the position of the rugplot. The larger this number
+        Keywords passed to the rug plot. Ignored if ``rug=False`` or for 2D KDE
+        Use ``space`` keyword (float) to control the position of the rugplot. The larger this number
         the lower the rugplot.
     contour_kwargs : dict
-        Keywords passed to ax.contour to draw contour lines. Ignored for 1D KDE.
+        Keywords passed to :meth:`mpl:matplotlib.axes.Axes.contour`
+        to draw contour lines. Ignored for 1D KDE.
     contourf_kwargs : dict
-        Keywords passed to ax.contourf to draw filled contours. Ignored for 1D KDE.
+        Keywords passed to :meth:`mpl:matplotlib.axes.Axes.contourf`
+        to draw filled contours. Ignored for 1D KDE.
     pcolormesh_kwargs : dict
-        Keywords passed to ax.pcolormesh. Ignored for 1D KDE.
+        Keywords passed to :meth:`mpl:matplotlib.axes.Axes.pcolormesh`
+        Ignored for 1D KDE.
     is_circular : {False, True, "radians", "degrees"}. Default False.
         Select input type {"radians", "degrees"} for circular histogram or KDE plot. If True,
-        default input type is "radians". When this argument is present, it interprets `values`
+        default input type is "radians". When this argument is present, it interprets ``values``
         is a circular variable measured in radians and a circular KDE is used. Inputs in
         "degrees" will undergo an internal conversion to radians.
     ax: axes, optional
@@ -111,7 +114,9 @@ def plot_kde(
     backend: str, optional
         Select plotting backend {"matplotlib","bokeh"}. Default "matplotlib".
     backend_kwargs: bool, optional
-        These are kwargs specific to the backend being used. For additional documentation
+        These are kwargs specific to the backend being used, passed to
+        :func:`matplotlib.pyplot.figure` or
+        :func:`bokeh.plotting.figure`. For additional documentation
         check the plotting method of the backend.
     show : bool, optional
         Call backend show function.
@@ -124,6 +129,11 @@ def plot_kde(
         Object containing the kde plot
     glyphs : list, optional
         Bokeh glyphs present in plot.  Only provided if ``return_glyph`` is True.
+
+    See Also
+    --------
+    kde : One dimensional density estimation.
+    plot_dist : Plot distribution as histogram or kernel density estimates.
 
     Examples
     --------
@@ -233,10 +243,6 @@ def plot_kde(
         :context: close-figs
 
         >>> az.plot_kde(mu_posterior, values2=tau_posterior, contour=False)
-
-    See Also
-    --------
-    kde : One dimensional density estimation.
 
     """
     if isinstance(values, xr.Dataset):

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -58,8 +58,8 @@ def plot_kde(
     bw: float or str, optional
         If numeric, indicates the bandwidth and must be positive.
         If str, indicates the method to estimate the bandwidth and must be
-        one of "scott", "silverman", "isj" or "experimental" when `is_circular` is False
-        and "taylor" (for now) when `is_circular` is True.
+        one of "scott", "silverman", "isj" or "experimental" when ``is_circular`` is False
+        and "taylor" (for now) when ``is_circular`` is True.
         Defaults to "default" which means "experimental" when variable is not circular
         and "taylor" when it is.
     adaptive: bool, optional.

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -118,7 +118,7 @@ def plot_kde(
         Select plotting backend {"matplotlib","bokeh"}. Default "matplotlib".
     backend_kwargs: bool, optional
         These are kwargs specific to the backend being used, passed to
-        :func:`matplotlib.pyplot.figure` or
+        :func:`matplotlib.pyplot.subplots` or
         :func:`bokeh.plotting.figure`. For additional documentation
         check the plotting method of the backend.
     show : bool, optional

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -87,20 +87,23 @@ def plot_kde(
         Keywords passed to the pdf line of a 1D KDE. See :meth:`mpl:matplotlib.axes.Axes.plot`
         or :meth:`bokeh:bokeh.plotting.Figure.line` for a description of accepted values.
     fill_kwargs : dict
-        Keywords passed to the fill under the line (use ``fill_kwargs={'alpha': 0}`` to disable fill).
-        Ignored for 2D KDE
+        Keywords passed to the fill under the line (use ``fill_kwargs={'alpha': 0}``
+        to disable fill). Ignored for 2D KDE. Passed to
+        :meth:`bokeh.plotting.Figure.patch`.
     rug_kwargs : dict
         Keywords passed to the rug plot. Ignored if ``rug=False`` or for 2D KDE
         Use ``space`` keyword (float) to control the position of the rugplot. The larger this number
-        the lower the rugplot.
+        the lower the rugplot. Passed to :class:`bokeh:bokeh.models.glyphs.Scatter`.
     contour_kwargs : dict
         Keywords passed to :meth:`mpl:matplotlib.axes.Axes.contour`
-        to draw contour lines. Ignored for 1D KDE.
+        to draw contour lines or :meth:`bokeh.plotting.Figure.patch`.
+        Ignored for 1D KDE.
     contourf_kwargs : dict
         Keywords passed to :meth:`mpl:matplotlib.axes.Axes.contourf`
         to draw filled contours. Ignored for 1D KDE.
     pcolormesh_kwargs : dict
-        Keywords passed to :meth:`mpl:matplotlib.axes.Axes.pcolormesh`
+        Keywords passed to :meth:`mpl:matplotlib.axes.Axes.pcolormesh` or
+        :meth:`bokeh.plotting.Figure.image`.
         Ignored for 1D KDE.
     is_circular : {False, True, "radians", "degrees"}. Default False.
         Select input type {"radians", "degrees"} for circular histogram or KDE plot. If True,


### PR DESCRIPTION
## Description
* Added references 
* Added backticks
* Added kwargs functions


Note: `fill_kwargs` are being passed to `fill_func` at a few [lines](https://github.com/arviz-devs/arviz/blob/main/arviz/plots/backends/matplotlib/kdeplot.py#L153), but I could not find it in matplotlib docs. 


Fixes: https://github.com/arviz-devs/arviz/issues/1853