### PR TITLE
Fix typo in `Forestplot`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Deprecation
 
 ### Documentation
+* Fixed typo in `Forestplot` documentation
 
 
 ## v0.11.4 (2021 Oct 3)

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -137,7 +137,7 @@ def plot_forest(
 
     Examples
     --------
-    Forestpĺot
+    Forestplot
 
     .. plot::
         :context: close-figs
@@ -167,7 +167,7 @@ def plot_forest(
         >>>                            figsize=(9, 7))
         >>> axes[0].set_title('Estimated theta for 8 schools models')
 
-    Forestpĺot with ropes
+    Forestplot with ropes
 
     .. plot::
         :context: close-figs


### PR DESCRIPTION
## Description
- This PR fixes a type where `Forestplot` was written as `Forestpĺot` in comments, which showed up in online documentation.

## Checklist

- [X] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

