### PR TITLE
remove manual setting of 2d kde lims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Maintenance and fixes
 * Drop Python 3.6 support ([1430](https://github.com/arviz-devs/arviz/pull/1430))
 * Bokeh 3 compatibility. ([1919](https://github.com/arviz-devs/arviz/pull/1919))
+* Remove manual setting of 2d KDE limits ([1939](https://github.com/arviz-devs/arviz/pull/1939))
 
 ### Deprecation
 

--- a/arviz/plots/backends/bokeh/distplot.py
+++ b/arviz/plots/backends/bokeh/distplot.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from ....stats.density_utils import get_bins, histogram
 from ...kdeplot import plot_kde
-from ...plot_utils import _scale_fig_size, set_bokeh_circular_ticks_labels, vectorized_to_hex
+from ...plot_utils import _scale_fig_size, set_bokeh_circular_ticks_labels, vectorized_to_hex, _init_kwargs_dict
 from .. import show_layout
 from . import backend_kwarg_defaults, create_axes_grid
 
@@ -37,8 +37,7 @@ def plot_dist(
     show,
 ):
     """Bokeh distplot."""
-    if backend_kwargs is None:
-        backend_kwargs = {}
+    backend_kwargs = _init_kwargs_dict(backend_kwargs)
 
     backend_kwargs = {
         **backend_kwarg_defaults(),
@@ -49,7 +48,7 @@ def plot_dist(
 
     color = vectorized_to_hex(color)
 
-    hist_kwargs = {} if hist_kwargs is None else hist_kwargs
+    hist_kwargs = _init_kwargs_dict(hist_kwargs)
     if kind == "hist":
         hist_kwargs.setdefault("cumulative", cumulative)
         hist_kwargs.setdefault("fill_color", color)
@@ -80,8 +79,7 @@ def plot_dist(
             is_circular=is_circular,
         )
     elif kind == "kde":
-        if plot_kwargs is None:
-            plot_kwargs = {}
+        plot_kwargs = _init_kwargs_dict(plot_kwargs)
         if color is None:
             color = plt.rcParams["axes.prop_cycle"].by_key()["color"][0]
         plot_kwargs.setdefault("line_color", color)

--- a/arviz/plots/backends/bokeh/distplot.py
+++ b/arviz/plots/backends/bokeh/distplot.py
@@ -4,7 +4,12 @@ import numpy as np
 
 from ....stats.density_utils import get_bins, histogram
 from ...kdeplot import plot_kde
-from ...plot_utils import _scale_fig_size, set_bokeh_circular_ticks_labels, vectorized_to_hex, _init_kwargs_dict
+from ...plot_utils import (
+    _scale_fig_size,
+    set_bokeh_circular_ticks_labels,
+    vectorized_to_hex,
+    _init_kwargs_dict,
+)
 from .. import show_layout
 from . import backend_kwarg_defaults, create_axes_grid
 

--- a/arviz/plots/backends/bokeh/kdeplot.py
+++ b/arviz/plots/backends/bokeh/kdeplot.py
@@ -11,7 +11,7 @@ from matplotlib.cm import get_cmap
 from matplotlib.colors import rgb2hex
 from matplotlib.pyplot import rcParams as mpl_rcParams
 
-from ...plot_utils import _scale_fig_size
+from ...plot_utils import _scale_fig_size, _init
 from .. import show_layout
 from . import backend_kwarg_defaults, create_axes_grid
 
@@ -224,8 +224,8 @@ def plot_kde(
             ax.xgrid.grid_line_color = None
             ax.ygrid.grid_line_color = None
 
-            ax.x_range = Range1d(xmin, xmax)
-            ax.y_range = Range1d(ymin, ymax)
+            # ax.x_range = Range1d(xmin, xmax)
+            # ax.y_range = Range1d(ymin, ymax)
 
         else:
 

--- a/arviz/plots/backends/bokeh/kdeplot.py
+++ b/arviz/plots/backends/bokeh/kdeplot.py
@@ -11,7 +11,7 @@ from matplotlib.cm import get_cmap
 from matplotlib.colors import rgb2hex
 from matplotlib.pyplot import rcParams as mpl_rcParams
 
-from ...plot_utils import _scale_fig_size, _init
+from ...plot_utils import _scale_fig_size, _init_kwargs_dict
 from .. import show_layout
 from . import backend_kwarg_defaults, create_axes_grid
 
@@ -50,8 +50,7 @@ def plot_kde(
     return_glyph,
 ):
     """Bokeh kde plot."""
-    if backend_kwargs is None:
-        backend_kwargs = {}
+    backend_kwargs = _init_kwargs_dict(backend_kwargs)
 
     backend_kwargs = {
         **backend_kwarg_defaults(),
@@ -70,20 +69,15 @@ def plot_kde(
 
     glyphs = []
     if values2 is None:
-        if plot_kwargs is None:
-            plot_kwargs = {}
+        plot_kwargs = _init_kwargs_dict(plot_kwargs)
         plot_kwargs.setdefault("line_color", mpl_rcParams["axes.prop_cycle"].by_key()["color"][0])
 
-        if fill_kwargs is None:
-            fill_kwargs = {}
-
+        fill_kwargs = _init_kwargs_dict(fill_kwargs)
         fill_kwargs.setdefault("fill_color", mpl_rcParams["axes.prop_cycle"].by_key()["color"][0])
 
         if rug:
-            if rug_kwargs is None:
-                rug_kwargs = {}
+            rug_kwargs = _init_kwargs_dict(rug_kwargs)
 
-            rug_kwargs = rug_kwargs.copy()
             if "cds" in rug_kwargs:
                 cds_rug = rug_kwargs.pop("cds")
                 rug_varname = rug_kwargs.pop("y", "y")
@@ -157,12 +151,9 @@ def plot_kde(
             glyphs.append(line)
 
     else:
-        if contour_kwargs is None:
-            contour_kwargs = {}
-        if contourf_kwargs is None:
-            contourf_kwargs = {}
-        if pcolormesh_kwargs is None:
-            pcolormesh_kwargs = {}
+        contour_kwargs = _init_kwargs_dict(contour_kwargs)
+        contourf_kwargs = _init_kwargs_dict(contourf_kwargs)
+        pcolormesh_kwargs = _init_kwargs_dict(pcolormesh_kwargs)
 
         g_s = complex(gridsize[0])
         x_x, y_y = np.mgrid[xmin:xmax:g_s, ymin:ymax:g_s]
@@ -223,9 +214,6 @@ def plot_kde(
 
             ax.xgrid.grid_line_color = None
             ax.ygrid.grid_line_color = None
-
-            # ax.x_range = Range1d(xmin, xmax)
-            # ax.y_range = Range1d(ymin, ymax)
 
         else:
 

--- a/arviz/plots/backends/bokeh/kdeplot.py
+++ b/arviz/plots/backends/bokeh/kdeplot.py
@@ -5,7 +5,7 @@ from numbers import Integral
 
 from matplotlib import _contour
 import numpy as np
-from bokeh.models import ColumnDataSource, Range1d
+from bokeh.models import ColumnDataSource
 from bokeh.models.glyphs import Scatter
 from matplotlib.cm import get_cmap
 from matplotlib.colors import rgb2hex

--- a/arviz/plots/backends/bokeh/pairplot.py
+++ b/arviz/plots/backends/bokeh/pairplot.py
@@ -10,7 +10,12 @@ from bokeh.models import CDSView, ColumnDataSource, GroupFilter, Span
 from ....rcparams import rcParams
 from ...distplot import plot_dist
 from ...kdeplot import plot_kde
-from ...plot_utils import _scale_fig_size, calculate_point_estimate, vectorized_to_hex, _init_kwargs_dict
+from ...plot_utils import (
+    _scale_fig_size,
+    calculate_point_estimate,
+    vectorized_to_hex,
+    _init_kwargs_dict,
+)
 from .. import show_layout
 from . import backend_kwarg_defaults
 
@@ -50,7 +55,6 @@ def plot_pair(
         ),
         **backend_kwargs,
     }
-
 
     hexbin_kwargs = _init_kwargs_dict(hexbin_kwargs)
     hexbin_kwargs.setdefault("size", 0.5)

--- a/arviz/plots/backends/bokeh/pairplot.py
+++ b/arviz/plots/backends/bokeh/pairplot.py
@@ -10,7 +10,7 @@ from bokeh.models import CDSView, ColumnDataSource, GroupFilter, Span
 from ....rcparams import rcParams
 from ...distplot import plot_dist
 from ...kdeplot import plot_kde
-from ...plot_utils import _scale_fig_size, calculate_point_estimate, vectorized_to_hex
+from ...plot_utils import _scale_fig_size, calculate_point_estimate, vectorized_to_hex, _init_kwargs_dict
 from .. import show_layout
 from . import backend_kwarg_defaults
 
@@ -42,8 +42,7 @@ def plot_pair(
     reference_values_kwargs,
 ):
     """Bokeh pair plot."""
-    if backend_kwargs is None:
-        backend_kwargs = {}
+    backend_kwargs = _init_kwargs_dict(backend_kwargs)
 
     backend_kwargs = {
         **backend_kwarg_defaults(
@@ -52,18 +51,13 @@ def plot_pair(
         **backend_kwargs,
     }
 
-    if hexbin_kwargs is None:
-        hexbin_kwargs = {}
+
+    hexbin_kwargs = _init_kwargs_dict(hexbin_kwargs)
     hexbin_kwargs.setdefault("size", 0.5)
 
-    if marginal_kwargs is None:
-        marginal_kwargs = {}
-
-    if point_estimate_kwargs is None:
-        point_estimate_kwargs = {}
-
-    if kde_kwargs is None:
-        kde_kwargs = {}
+    marginal_kwargs = _init_kwargs_dict(marginal_kwargs)
+    point_estimate_kwargs = _init_kwargs_dict(point_estimate_kwargs)
+    kde_kwargs = _init_kwargs_dict(kde_kwargs)
 
     if kind != "kde":
         kde_kwargs.setdefault("contourf_kwargs", {})
@@ -121,16 +115,13 @@ def plot_pair(
                 UserWarning,
             )
 
-    if reference_values_kwargs is None:
-        reference_values_kwargs = {}
-
+    reference_values_kwargs = _init_kwargs_dict(reference_values_kwargs)
     reference_values_kwargs.setdefault("line_color", "black")
     reference_values_kwargs.setdefault("fill_color", vectorized_to_hex("C2"))
     reference_values_kwargs.setdefault("line_width", 1)
     reference_values_kwargs.setdefault("size", 10)
 
-    if divergences_kwargs is None:
-        divergences_kwargs = {}
+    divergences_kwargs = _init_kwargs_dict(divergences_kwargs)
     divergences_kwargs.setdefault("line_color", "black")
     divergences_kwargs.setdefault("fill_color", vectorized_to_hex("C1"))
     divergences_kwargs.setdefault("line_width", 1)
@@ -158,9 +149,7 @@ def plot_pair(
         figsize, textsize, numvars - offset, numvars - offset
     )
 
-    if point_estimate_marker_kwargs is None:
-        point_estimate_marker_kwargs = {}
-
+    point_estimate_marker_kwargs = _init_kwargs_dict(point_estimate_marker_kwargs)
     point_estimate_marker_kwargs.setdefault("size", markersize)
     point_estimate_marker_kwargs.setdefault("color", "black")
     point_estimate_kwargs.setdefault("line_color", "black")

--- a/arviz/plots/backends/matplotlib/distplot.py
+++ b/arviz/plots/backends/matplotlib/distplot.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from ....stats.density_utils import get_bins
 from ...kdeplot import plot_kde
-from ...plot_utils import _scale_fig_size
+from ...plot_utils import _scale_fig_size, _init_kwargs_dict
 from . import backend_kwarg_defaults, backend_show, create_axes_grid, matplotlib_kwarg_dealiaser
 
 
@@ -37,8 +37,7 @@ def plot_dist(
     show,
 ):
     """Matplotlib distplot."""
-    if backend_kwargs is None:
-        backend_kwargs = {}
+    backend_kwargs = _init_kwargs_dict(backend_kwargs)
 
     backend_kwargs = {
         **backend_kwarg_defaults(),

--- a/arviz/plots/backends/matplotlib/kdeplot.py
+++ b/arviz/plots/backends/matplotlib/kdeplot.py
@@ -5,7 +5,7 @@ from matplotlib import _pylab_helpers
 import matplotlib.ticker as mticker
 
 
-from ...plot_utils import _scale_fig_size
+from ...plot_utils import _scale_fig_size, _init_kwargs_dict
 from . import backend_kwarg_defaults, backend_show, create_axes_grid, matplotlib_kwarg_dealiaser
 
 
@@ -43,8 +43,7 @@ def plot_kde(
     return_glyph,  # pylint: disable=unused-argument
 ):
     """Matplotlib kde plot."""
-    if backend_kwargs is None:
-        backend_kwargs = {}
+    backend_kwargs = _init_kwargs_dict(backend_kwargs)
 
     backend_kwargs = {
         **backend_kwarg_defaults(),

--- a/arviz/plots/backends/matplotlib/kdeplot.py
+++ b/arviz/plots/backends/matplotlib/kdeplot.py
@@ -164,8 +164,6 @@ def plot_kde(
         x_x, y_y = np.mgrid[xmin:xmax:g_s, ymin:ymax:g_s]
 
         ax.grid(False)
-        ax.set_xlim(xmin, xmax)
-        ax.set_ylim(ymin, ymax)
         if contour:
             qcfs = ax.contourf(x_x, y_y, density, antialiased=True, **contourf_kwargs)
             qcs = ax.contour(x_x, y_y, density, **contour_kwargs)

--- a/arviz/plots/backends/matplotlib/pairplot.py
+++ b/arviz/plots/backends/matplotlib/pairplot.py
@@ -10,7 +10,7 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 from ....rcparams import rcParams
 from ...distplot import plot_dist
 from ...kdeplot import plot_kde
-from ...plot_utils import _scale_fig_size, calculate_point_estimate
+from ...plot_utils import _scale_fig_size, calculate_point_estimate, _init_kwargs_dict
 from . import backend_kwarg_defaults, backend_show, matplotlib_kwarg_dealiaser
 
 
@@ -41,9 +41,7 @@ def plot_pair(
     reference_values_kwargs,
 ):
     """Matplotlib pairplot."""
-    if backend_kwargs is None:
-        backend_kwargs = {}
-
+    backend_kwargs = _init_kwargs_dict(backend_kwargs)
     backend_kwargs = {
         **backend_kwarg_defaults(),
         **backend_kwargs,
@@ -56,11 +54,9 @@ def plot_pair(
     # Sets the default zorder higher than zorder of grid, which is 0.5
     scatter_kwargs.setdefault("zorder", 0.6)
 
-    if kde_kwargs is None:
-        kde_kwargs = {}
+    kde_kwargs = _init_kwargs_dict(kde_kwargs)
 
-    if hexbin_kwargs is None:
-        hexbin_kwargs = {}
+    hexbin_kwargs = matplotlib_kwarg_dealiaser(hexbin_kwargs, "hexbin")
     hexbin_kwargs.setdefault("mincnt", 1)
 
     divergences_kwargs = matplotlib_kwarg_dealiaser(divergences_kwargs, "plot")
@@ -69,8 +65,7 @@ def plot_pair(
     divergences_kwargs.setdefault("color", "C1")
     divergences_kwargs.setdefault("lw", 0)
 
-    if marginal_kwargs is None:
-        marginal_kwargs = {}
+    marginal_kwargs = _init_kwargs_dict(marginal_kwargs)
 
     point_estimate_kwargs = matplotlib_kwarg_dealiaser(point_estimate_kwargs, "fill_between")
     point_estimate_kwargs.setdefault("color", "k")

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -595,3 +595,19 @@ def compute_ranks(ary):
     ranks = rankdata(ary, method="average").reshape(ary.shape)
 
     return ranks
+
+def _init_kwargs_dict(kwargs):
+    """Initialize kwargs dict.
+
+    If the input is a dictionary, it returns
+    a copy of the dictionary, otherwise it
+    returns an empty dictionary.
+
+    Parameters
+    ----------
+    kwargs : dict or None
+        kwargs dict to initialize
+    """
+    if kwargs is None:
+        return {}
+    return kwargs.copy()

--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -596,6 +596,7 @@ def compute_ranks(ary):
 
     return ranks
 
+
 def _init_kwargs_dict(kwargs):
     """Initialize kwargs dict.
 


### PR DESCRIPTION
## Description
A few lines above we set `x_x` and `y_y` using the min and max along each dimension, so this has no visual effect on the plot, _as long as you are plotting models independently_. I think it is important to remove in order to allow using the kde mode of plot_pair to compare models. Otherwise only the last kde to be plotted is guaranteed to be seen complete, the rest are generally cut or lay completely outside the limits.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Does the PR follow [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format?
- [ ] Does the PR include new or updated tests to prevent issue recurrence (using [pytest fixture pattern](https://docs.pytest.org/en/latest/fixture.html#fixture))? No, could think of adding one, not sure if necessary
- [x] Is the code style correct (follows pylint and black guidelines)?
- [ ] Is the fix listed in the [Maintenance and fixes](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#maintenance-and-fixes) section of the changelog?
