### PR TITLE
Change order of regularization in psislw (#1941)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ## v0.11.3 (2021 Oct 1)
 ### New features
-* Change order of regularization in psislw ([1943](https://github.com/arviz-devs/arviz/pull/1943))
+* Change order of regularization in `psislw` ([1943](https://github.com/arviz-devs/arviz/pull/1943))
 * Added `labeller` argument to enable label customization in plots and summary ([1201](https://github.com/arviz-devs/arviz/pull/1201))
 * Added `arviz.labels` module with classes and utilities ([1201](https://github.com/arviz-devs/arviz/pull/1201) and [1605](https://github.com/arviz-devs/arviz/pull/1605))
 * Added probability estimate within ROPE in `plot_posterior` ([1570](https://github.com/arviz-devs/arviz/pull/1570))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ## v0.11.3 (2021 Oct 1)
 ### New features
+* Change order of regularization in psislw ([1943](https://github.com/arviz-devs/arviz/pull/1943))
 * Added `labeller` argument to enable label customization in plots and summary ([1201](https://github.com/arviz-devs/arviz/pull/1201))
 * Added `arviz.labels` module with classes and utilities ([1201](https://github.com/arviz-devs/arviz/pull/1201) and [1605](https://github.com/arviz-devs/arviz/pull/1605))
 * Added probability estimate within ROPE in `plot_posterior` ([1570](https://github.com/arviz-devs/arviz/pull/1570))

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -952,8 +952,8 @@ def _gpdfit(ary):
     # estimate for k
     k_post = np.log1p(-b_post * ary).mean()  # pylint: disable=invalid-unary-operand-type,no-member
     # add prior for k_post
-    k_post = (n * k_post + prior_k * 0.5) / (n + prior_k)
     sigma = -k_post / b_post
+    k_post = (n * k_post + prior_k * 0.5) / (n + prior_k)
 
     return k_post, sigma
 


### PR DESCRIPTION
## Description
Resolves #1941. Changed the order of regularization of the shape parameter of the generalized Pareto distribution and estimation of scale parameter.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

