### PR TITLE
Unpin typing_extensions

### DIFF
--- a/arviz/tests/base_tests/test_data_zarr.py
+++ b/arviz/tests/base_tests/test_data_zarr.py
@@ -2,6 +2,7 @@
 import os
 import shutil
 from collections.abc import MutableMapping
+from typing import Mapping
 
 import numpy as np
 import pytest
@@ -26,7 +27,8 @@ class TestDataZarr:
         class Data:
             # fake 8-school output
             obj = {}
-            for key, shape in {"mu": [], "tau": [], "eta": [8], "theta": [8]}.items():
+            shapes: Mapping[str, list] = {"mu": [], "tau": [], "eta": [8], "theta": [8]}
+            for key, shape in shapes.items():
                 obj[key] = np.random.randn(chains, draws, *shape)
 
         return Data

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ packaging
 pandas>=0.23
 xarray>=0.16.1
 netcdf4
-typing_extensions>=3.7.4.3,<4
+typing_extensions>=3.7.4.3


### PR DESCRIPTION
Fixes #1947. I also had some trouble installing some `requirements-external.txt`, but I didn't include those in the change so far. 

I'll tag @obi1kenobi who originally added this pin, I think it was just defensive against the next major version, but if the mypy checks pass, I think we can merge.