### PR TITLE
add upper bound to bokeh version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Maintenance and fixes
 * Drop Python 3.6 support ([1430](https://github.com/arviz-devs/arviz/pull/1430))
 * Bokeh 3 compatibility. ([1919](https://github.com/arviz-devs/arviz/pull/1919))
+* Pin to bokeh<3 version ([1954](https://github.com/arviz-devs/arviz/pull/1954))
 
 ### Deprecation
 

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,5 +1,5 @@
 numba
-bokeh>=1.4.0
+bokeh>=1.4.0,<3.0
 ujson
 dask[distributed]
 zarr>=2.5.0


### PR DESCRIPTION
## Description
Follow up from https://github.com/arviz-devs/arviz/pull/1953, set an upper bound to bokeh version
for now until making the change, updating the code and requiring version 3.


## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Does the PR follow [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format?
- [x] Is the code style correct (follows pylint and black guidelines)?
- [ ] Is the fix listed in the [Maintenance and fixes](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#maintenance-and-fixes) section of the changelog?

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
