### PR TITLE
improve codeautolink style, add edit and donate buttons

### DIFF
--- a/doc/_templates/donate.html
+++ b/doc/_templates/donate.html
@@ -1,0 +1,5 @@
+<div class="tocsection">
+    <a href="https://numfocus.org/donate-to-arviz">
+      <i class="far fa-heart"></i> {{ _("Support ArviZ") }}
+    </a>
+</div>

--- a/doc/_templates/donate.html
+++ b/doc/_templates/donate.html
@@ -1,4 +1,8 @@
-<div class="tocsection">
+{% if "generated" in sourcename %}
+<div class="tocsection editthispage">
+{% else %}
+<div class="tocsection supportbutton">
+{% endif %}
     <a href="https://numfocus.org/donate-to-arviz">
       <i class="far fa-heart"></i> {{ _("Support ArviZ") }}
     </a>

--- a/doc/_templates/edit-this-page.html
+++ b/doc/_templates/edit-this-page.html
@@ -1,0 +1,8 @@
+{% if sourcename is defined and theme_use_edit_page_button==true and page_source_suffix and "generated" not in sourcename %}
+{% set src = sourcename.split('.') %}
+<div class="tocsection editthispage">
+    <a href="{{ get_edit_url() }}">
+        <i class="fas fa-pencil-alt"></i> {{ _("Edit this page") }}
+    </a>
+</div>
+{% endif %}

--- a/doc/_templates/twitter.html
+++ b/doc/_templates/twitter.html
@@ -1,0 +1,1 @@
+<a class="twitter-timeline" data-width="300" data-height="500" data-dnt="true" href="https://twitter.com/arviz_devs?ref_src=twsrc%5Etfw">Tweets by arviz_devs</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -6,3 +6,7 @@
 .sphinx-codeautolink-a:hover{
     color: rgb(255, 139, 139);
 }
+
+.supportbutton a {
+ color: var(--pst-color-sidebar-link-active);
+}

--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -1,44 +1,8 @@
-div.body {
-  max-width: none;
+.sphinx-codeautolink-a{
+    border-bottom-color: rgb(0, 0, 0);
+    border-bottom-style: dotted;
+    border-bottom-width: 1px;
 }
-
-dt:target {
-  background-color: #E0FFFF;
-}
-
-a {
-  color: #12698A;
-}
-
-.navbar-brand img {
-  height: 150%;
-}
-
-h1, .h1 {
-  font-size: 40px
-}
-
-h2, .h2 {
-  font-size: 25px
-}
-
-h3, .h3 {
-  font-size: 20px
-}
-
-h4, .h4 {
-  font-size: 15px
-}
-
-h5, .h5 {
-  font-size: 10px
-}
-
-ul li p {
-	margin: 0 0 0 0;
-}
-
-.alert-info{
-  color: #555555;
-  background-color: #d1ecf1;
+.sphinx-codeautolink-a:hover{
+    color: rgb(255, 139, 139);
 }

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -99,10 +99,7 @@ codeautolink_custom_blocks = {
     # "ipython": ipython_directive_transform
 }
 codeautolink_autodoc_inject = False
-codeautolink_search_css_classes = [
-    "highlight-default notranslate",
-    "doctest highlight-default notranslate",
-]
+codeautolink_search_css_classes = ["highlight-default"]
 codeautolink_concat_default = True
 
 # ipython directive configuration

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -64,40 +64,7 @@ extensions = [
     "sphinx_codeautolink",
 ]
 
-from IPython.core.inputtransformer2 import TransformerManager
-import re
-
-
-def ipython_cell_transform(source):
-    out = TransformerManager().transform_cell(source)
-    return source, out
-
-
-def ipython_directive_transform(source):
-    """Convert ipython directive code (with initial 'In []:' or '...:') to valid code.
-
-    The current approach removes the "In []" and "...:" pieces and comments
-    all the lines that don't have either of those. This allows codeautolink/beautifulsoup
-    to correctly interpret the code as valid python code but codeautolink is then
-    unable to pair this "source" to the html output (at least for now) due to
-    the ammount of changes.
-    """
-    lines = []
-    for line in source.split("\n"):
-        (line, num_subs) = re.subn(r"^\s*(In\s*\[[0-9]+\]|\.{3,})\:\s", "", line)
-        if num_subs == 1:
-            lines.append(line)
-        else:
-            lines.append(f"# {line}")
-    return ipython_cell_transform("\n".join(lines))
-
-
 # codeautolink
-codeautolink_custom_blocks = {
-    "ipython3": ipython_cell_transform,
-    # ipython commented out because code and output are added in the same block and breaks autolink
-    # "ipython": ipython_directive_transform
-}
 codeautolink_autodoc_inject = False
 codeautolink_search_css_classes = ["highlight-default"]
 codeautolink_concat_default = True

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -67,20 +67,30 @@ extensions = [
 from IPython.core.inputtransformer2 import TransformerManager
 import re
 
+
 def ipython_cell_transform(source):
     out = TransformerManager().transform_cell(source)
     return source, out
 
+
 def ipython_directive_transform(source):
-    """Ignore lines starting with 'In[]:' or '...:'."""
+    """Convert ipython directive code (with initial 'In []:' or '...:') to valid code.
+
+    The current approach removes the "In []" and "...:" pieces and comments
+    all the lines that don't have either of those. This allows codeautolink/beautifulsoup
+    to correctly interpret the code as valid python code but codeautolink is then
+    unable to pair this "source" to the html output (at least for now) due to
+    the ammount of changes.
+    """
     lines = []
     for line in source.split("\n"):
         (line, num_subs) = re.subn(r"^\s*(In\s*\[[0-9]+\]|\.{3,})\:\s", "", line)
-        if num_subs==1:
+        if num_subs == 1:
             lines.append(line)
         else:
             lines.append(f"# {line}")
     return ipython_cell_transform("\n".join(lines))
+
 
 # codeautolink
 codeautolink_custom_blocks = {
@@ -89,7 +99,10 @@ codeautolink_custom_blocks = {
     # "ipython": ipython_directive_transform
 }
 codeautolink_autodoc_inject = False
-codeautolink_search_css_classes = ["highlight-default notranslate"]
+codeautolink_search_css_classes = [
+    "highlight-default notranslate",
+    "doctest highlight-default notranslate",
+]
 codeautolink_concat_default = True
 
 # ipython directive configuration
@@ -115,20 +128,10 @@ jupyter_execute_notebooks = "auto"
 execution_excludepatterns = ["*.ipynb"]
 myst_heading_anchors = 3
 panels_add_bootstrap_css = False
-myst_enable_extensions = [
-    "colon_fence",
-    "deflist",
-    "dollarmath",
-    "amsmath"
-]
+myst_enable_extensions = ["colon_fence", "deflist", "dollarmath", "amsmath"]
 
 
-myst_enable_extensions = [
-    "colon_fence",
-    "deflist",
-    "dollarmath",
-    "amsmath"
-]
+myst_enable_extensions = ["colon_fence", "deflist", "dollarmath", "amsmath"]
 
 # The base toctree document.
 master_doc = "index"
@@ -199,7 +202,8 @@ html_theme_options = {
         },
     ],
     "navbar_start": ["navbar-logo", "navbar-version"],
-    "use_edit_page_button": False,  # TODO: see how to skip of fix for generated pages
+    "page_sidebar_items": ["page-toc", "edit-this-page", "donate"],
+    "use_edit_page_button": True,
     "google_analytics_id": "G-W1G68W77YV",
 }
 html_context = {
@@ -208,13 +212,16 @@ html_context = {
     "github_version": "main",
     "doc_path": "doc/source/",
 }
-html_sidebars: Dict[str, Any] = {}
+html_sidebars: Dict[str, Any] = {
+    "community": ["search-field.html", "sidebar-nav-bs.html", "twitter.html", "sidebar-ethical-ads.html"]
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 # html_theme_path = sphinx_bootstrap_theme.get_html_theme_path()
 html_static_path = ["_static", thumb_directory]
+html_css_files = ["custom.css"]
 
 # use additional pages to add a 404 page
 html_additional_pages = {
@@ -325,12 +332,13 @@ intersphinx_mapping = {
     "diataxis": ("https://diataxis.fr/", None),
 }
 
+
 def setup(app):
     # this needs to be added so we can reference confval targets
     # in the doc contributing pages and explain what values we use and why
     app.add_object_type(
-        'confval',
-        'confval',
-        objname='configuration value',
-        indextemplate='pair: %s; configuration value'
+        "confval",
+        "confval",
+        objname="configuration value",
+        indextemplate="pair: %s; configuration value",
     )

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -12,4 +12,4 @@ sphinx-notfound-page
 sphinx-copybutton
 bokeh
 sphinx_design
-sphinx-codeautolink
+sphinx-codeautolink @ git+https://github.com/felix-hilden/sphinx-codeautolink


### PR DESCRIPTION
## Description
* ~fix codeautolink for code blocks generated from plot directive~ seemed to work locally doesn't seem to work here
* add custom style to code with links
* add edit this page button (but skip it for api as it wouldn't point to the right page)
* add donate button to right sidebar of all pages
* add twitter feed to community page left sidebar

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Does the PR follow [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format?
- [x] Is the documentation [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant?
- [ ] Is the fix listed in the [Documentation](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#documentation) section of the changelog?
