### PR TITLE
Fix stats.hdi for multimodal=True

### DIFF
--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -476,7 +476,7 @@ def hdi(
         "skipna": skipna,
         "out_shape": (max_modes, 2) if multimodal else (2,),
     }
-    kwargs.setdefault("output_core_dims", [["hdi", "mode"] if multimodal else ["hdi"]])
+    kwargs.setdefault("output_core_dims", [["mode", "hdi"] if multimodal else ["hdi"]])
     if not multimodal:
         func_kwargs["circular"] = circular
     else:

--- a/arviz/tests/base_tests/test_stats.py
+++ b/arviz/tests/base_tests/test_stats.py
@@ -121,6 +121,18 @@ def test_hdi_multimodal():
     intervals = hdi(normal_sample, multimodal=True)
     assert_array_almost_equal(intervals, [[-5.8, -2.2], [0.9, 3.1]], 1)
 
+def test_hdi_multimodal_multivars():
+    size = 2500000
+    var1 = np.concatenate((np.random.normal(-4, 1, size), np.random.normal(2, 0.5, size)))
+    var2 = np.random.normal(8, 1, size*2)
+    sample = Dataset(
+        {"var1": (("chain", "draw"), var1[np.newaxis, :]), "var2": (("chain", "draw"), var2[np.newaxis, :])},
+        coords={"chain": [0], "draw": np.arange(size * 2)},
+    )
+    intervals = hdi(sample, multimodal=True)
+    assert_array_almost_equal(intervals.var1, [[-5.8, -2.2], [0.9, 3.1]], 1)
+    assert_array_almost_equal(intervals.var2, [[6.1, 9.9], [np.nan, np.nan]], 1)
+
 
 def test_hdi_circular():
     normal_sample = np.random.vonmises(np.pi, 1, 5000000)

--- a/arviz/tests/base_tests/test_stats.py
+++ b/arviz/tests/base_tests/test_stats.py
@@ -121,12 +121,16 @@ def test_hdi_multimodal():
     intervals = hdi(normal_sample, multimodal=True)
     assert_array_almost_equal(intervals, [[-5.8, -2.2], [0.9, 3.1]], 1)
 
+
 def test_hdi_multimodal_multivars():
     size = 2500000
     var1 = np.concatenate((np.random.normal(-4, 1, size), np.random.normal(2, 0.5, size)))
-    var2 = np.random.normal(8, 1, size*2)
+    var2 = np.random.normal(8, 1, size * 2)
     sample = Dataset(
-        {"var1": (("chain", "draw"), var1[np.newaxis, :]), "var2": (("chain", "draw"), var2[np.newaxis, :])},
+        {
+            "var1": (("chain", "draw"), var1[np.newaxis, :]),
+            "var2": (("chain", "draw"), var2[np.newaxis, :]),
+        },
         coords={"chain": [0], "draw": np.arange(size * 2)},
     )
     intervals = hdi(sample, multimodal=True)


### PR DESCRIPTION
## Description

The dims for `hdi_data` are flipped, meaning the function errors when `multimodal=True` and `max_modes` is not used to restrict the number of modes.

Before this change:

```python
arviz.hdi(ads, hdi_prob=.9, multimodal=True)
```

results in

```python
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
/tmp/ipykernel_1840496/2310952448.py in <module>
----> 1 arviz.hdi(ads, hdi_prob=.9, multimodal=True)

~/mambaforge/envs/astro/lib/python3.9/site-packages/arviz/stats/stats.py in hdi(ary, hdi_prob, circular, multimodal, skipna, group, var_names, filter_vars, coords, max_modes, dask_kwargs, **kwargs)
    507 
    508     hdi_coord = xr.DataArray(["lower", "higher"], dims=["hdi"], attrs=dict(hdi_prob=hdi_prob))
--> 509     hdi_data = _wrap_xarray_ufunc(
    510         func, ary, func_kwargs=func_kwargs, dask_kwargs=dask_kwargs, **kwargs
    511     ).assign_coords({"hdi": hdi_coord})

~/mambaforge/envs/astro/lib/python3.9/site-packages/xarray/core/common.py in assign_coords(self, coords, **coords_kwargs)
    499         data = self.copy(deep=False)
    500         results = self._calc_assign_results(coords_kwargs)
--> 501         data.coords.update(results)
    502         return data
    503 

~/mambaforge/envs/astro/lib/python3.9/site-packages/xarray/core/coordinates.py in update(self, other)
    164             [self.variables, other_vars], priority_arg=1, indexes=self.xindexes
    165         )
--> 166         self._update_coords(coords, indexes)
    167 
    168     def _merge_raw(self, other, reflexive):

~/mambaforge/envs/astro/lib/python3.9/site-packages/xarray/core/coordinates.py in _update_coords(self, coords, indexes)
    279 
    280         # check for inconsistent state *before* modifying anything in-place
--> 281         dims = calculate_dimensions(variables)
    282         new_coord_names = set(coords)
    283         for dim, size in dims.items():

~/mambaforge/envs/astro/lib/python3.9/site-packages/xarray/core/dataset.py in calculate_dimensions(variables)
    206                 last_used[dim] = k
    207             elif dims[dim] != size:
--> 208                 raise ValueError(
    209                     f"conflicting sizes for dimension {dim!r}: "
    210                     f"length {size} on {k!r} and length {dims[dim]} on {last_used!r}"

ValueError: conflicting sizes for dimension 'hdi': length 2 on 'hdi' and length 10 on {'hdi': 'a', 'mode': 'a'}
```

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Code style  correct (follows pylint and black guidelines)