### PR TITLE
Allow kwargs to customize appearance of the mean in `plot_lm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.x.x Unreleased
 ### New features
 * [experimental] Enable dask chunking information to be passed to `InferenceData.from_netcdf` with regex support ([1749](https://github.com/arviz-devs/arviz/pull/1749))
+* Allow kwargs to customize appearance of the mean in `plot_lm`
 
 ### Maintenance and fixes
 * Drop Python 3.6 support ([1430](https://github.com/arviz-devs/arviz/pull/1430))

--- a/arviz/plots/backends/bokeh/lmplot.py
+++ b/arviz/plots/backends/bokeh/lmplot.py
@@ -72,6 +72,11 @@ def plot_lm(
         y_model_fill_kwargs = {}
     y_model_fill_kwargs.setdefault("color", "black")
     y_model_fill_kwargs.setdefault("alpha", 0.5)
+    
+    if y_model_mean_kwargs is None:
+        y_model_mean_kwargs = {}
+    y_model_mean_kwargs.setdefault("line_color", "yellow")
+    y_model_mean_kwargs.setdefault("line_width", 2)
 
     for i, ax_i in enumerate((item for item in axes.flatten() if item is not None)):
 
@@ -130,7 +135,7 @@ def plot_lm(
                 x_plotters_edge = [min(x_plotters), max(x_plotters)]
                 y_model_mean_edge = [min(y_model_mean), max(y_model_mean)]
                 mean_legend = ax_i.line(
-                    x_plotters_edge, y_model_mean_edge, line_color="yellow", line_width=2
+                    x_plotters_edge, y_model_mean_edge, **y_model_mean_kwargs
                 )
                 legend_it.append(("Mean", [mean_legend]))
 
@@ -150,8 +155,7 @@ def plot_lm(
                 mean_legend = ax_i.line(
                     x_plotters_edge,
                     y_model_mean_edge,
-                    line_color="yellow",
-                    line_width=2,
+                    **y_model_mean_kwargs,
                 )
                 legend_it.append(("Mean", [mean_legend]))
 

--- a/arviz/plots/backends/bokeh/lmplot.py
+++ b/arviz/plots/backends/bokeh/lmplot.py
@@ -135,9 +135,7 @@ def plot_lm(
                 y_model_mean = np.mean(y_model_plotters, axis=1)
                 x_plotters_edge = [min(x_plotters), max(x_plotters)]
                 y_model_mean_edge = [min(y_model_mean), max(y_model_mean)]
-                mean_legend = ax_i.line(
-                    x_plotters_edge, y_model_mean_edge, **y_model_mean_kwargs
-                )
+                mean_legend = ax_i.line(x_plotters_edge, y_model_mean_edge, **y_model_mean_kwargs)
                 legend_it.append(("Mean", [mean_legend]))
 
             else:
@@ -153,19 +151,11 @@ def plot_lm(
                 y_model_mean = np.mean(y_model_plotters, axis=(0, 1))
                 x_plotters_edge = [min(x_plotters), max(x_plotters)]
                 y_model_mean_edge = [min(y_model_mean), max(y_model_mean)]
-                mean_legend = ax_i.line(
-                    x_plotters_edge,
-                    y_model_mean_edge,
-                    **y_model_mean_kwargs,
-                )
+                mean_legend = ax_i.line(x_plotters_edge, y_model_mean_edge, **y_model_mean_kwargs,)
                 legend_it.append(("Mean", [mean_legend]))
 
         if legend:
-            legend = Legend(
-                items=legend_it,
-                location="top_left",
-                orientation="vertical",
-            )
+            legend = Legend(items=legend_it, location="top_left", orientation="vertical",)
             ax_i.add_layout(legend)
             if textsize is not None:
                 ax_i.legend.label_text_font_size = f"{textsize}pt"

--- a/arviz/plots/backends/bokeh/lmplot.py
+++ b/arviz/plots/backends/bokeh/lmplot.py
@@ -26,6 +26,7 @@ def plot_lm(
     y_hat_fill_kwargs,
     y_model_plot_kwargs,
     y_model_fill_kwargs,
+    y_model_mean_kwargs,
     backend_kwargs,
     show,
     figsize,

--- a/arviz/plots/backends/bokeh/lmplot.py
+++ b/arviz/plots/backends/bokeh/lmplot.py
@@ -151,11 +151,19 @@ def plot_lm(
                 y_model_mean = np.mean(y_model_plotters, axis=(0, 1))
                 x_plotters_edge = [min(x_plotters), max(x_plotters)]
                 y_model_mean_edge = [min(y_model_mean), max(y_model_mean)]
-                mean_legend = ax_i.line(x_plotters_edge, y_model_mean_edge, **y_model_mean_kwargs,)
+                mean_legend = ax_i.line(
+                    x_plotters_edge,
+                    y_model_mean_edge,
+                    **y_model_mean_kwargs,
+                )
                 legend_it.append(("Mean", [mean_legend]))
 
         if legend:
-            legend = Legend(items=legend_it, location="top_left", orientation="vertical",)
+            legend = Legend(
+                items=legend_it,
+                location="top_left",
+                orientation="vertical",
+            )
             ax_i.add_layout(legend)
             if textsize is not None:
                 ax_i.legend.label_text_font_size = f"{textsize}pt"

--- a/arviz/plots/backends/bokeh/lmplot.py
+++ b/arviz/plots/backends/bokeh/lmplot.py
@@ -73,7 +73,7 @@ def plot_lm(
         y_model_fill_kwargs = {}
     y_model_fill_kwargs.setdefault("color", "black")
     y_model_fill_kwargs.setdefault("alpha", 0.5)
-    
+
     if y_model_mean_kwargs is None:
         y_model_mean_kwargs = {}
     y_model_mean_kwargs.setdefault("line_color", "yellow")

--- a/arviz/plots/backends/matplotlib/lmplot.py
+++ b/arviz/plots/backends/matplotlib/lmplot.py
@@ -124,10 +124,7 @@ def plot_lm(
                 ax_i.plot(x_plotters, y_model_mean, **y_model_mean_kwargs, label="Mean")
             else:
                 plot_hdi(
-                    x_plotters,
-                    y_model_plotters,
-                    fill_kwargs=y_model_fill_kwargs,
-                    ax=ax_i,
+                    x_plotters, y_model_plotters, fill_kwargs=y_model_fill_kwargs, ax=ax_i,
                 )
                 ax_i.plot([], color=y_model_fill_kwargs["color"], label="Uncertainty in mean")
 

--- a/arviz/plots/backends/matplotlib/lmplot.py
+++ b/arviz/plots/backends/matplotlib/lmplot.py
@@ -121,7 +121,7 @@ def plot_lm(
                 ax_i.plot([], **y_model_plot_kwargs, label="Uncertainty in mean")
 
                 y_model_mean = np.mean(y_model_plotters, axis=1)
-                ax_i.plot(x_plotters, y_model_mean, color="y", lw=0.8, zorder=11, label="Mean")
+                ax_i.plot(x_plotters, y_model_mean, **y_model_mean_kwargs, label="Mean")
             else:
                 plot_hdi(
                     x_plotters,

--- a/arviz/plots/backends/matplotlib/lmplot.py
+++ b/arviz/plots/backends/matplotlib/lmplot.py
@@ -124,7 +124,10 @@ def plot_lm(
                 ax_i.plot(x_plotters, y_model_mean, **y_model_mean_kwargs, label="Mean")
             else:
                 plot_hdi(
-                    x_plotters, y_model_plotters, fill_kwargs=y_model_fill_kwargs, ax=ax_i,
+                    x_plotters,
+                    y_model_plotters,
+                    fill_kwargs=y_model_fill_kwargs,
+                    ax=ax_i,
                 )
                 ax_i.plot([], color=y_model_fill_kwargs["color"], label="Uncertainty in mean")
 

--- a/arviz/plots/backends/matplotlib/lmplot.py
+++ b/arviz/plots/backends/matplotlib/lmplot.py
@@ -81,7 +81,7 @@ def plot_lm(
         y_model_fill_kwargs.setdefault("linewidth", 0.5)
         y_model_fill_kwargs.setdefault("zorder", 9)
         y_model_fill_kwargs.setdefault("alpha", 0.5)
-        
+
         y_model_mean_kwargs = matplotlib_kwarg_dealiaser(y_model_mean_kwargs, "plot")
         y_model_mean_kwargs.setdefault("color", "y")
         y_model_mean_kwargs.setdefault("linewidth", 0.8)

--- a/arviz/plots/backends/matplotlib/lmplot.py
+++ b/arviz/plots/backends/matplotlib/lmplot.py
@@ -24,6 +24,7 @@ def plot_lm(
     y_hat_fill_kwargs,
     y_model_plot_kwargs,
     y_model_fill_kwargs,
+    y_model_mean_kwargs,
     backend_kwargs,
     show,
     figsize,
@@ -80,6 +81,11 @@ def plot_lm(
         y_model_fill_kwargs.setdefault("linewidth", 0.5)
         y_model_fill_kwargs.setdefault("zorder", 9)
         y_model_fill_kwargs.setdefault("alpha", 0.5)
+        
+        y_model_mean_kwargs = matplotlib_kwarg_dealiaser(y_model_mean_kwargs, "plot")
+        y_model_mean_kwargs.setdefault("color", "y")
+        y_model_mean_kwargs.setdefault("linewidth", 0.8)
+        y_model_mean_kwargs.setdefault("zorder", 11)
 
         y_var_name, _, _, y_plotters = y[i]
         x_var_name, _, _, x_plotters = x[i]
@@ -126,7 +132,7 @@ def plot_lm(
                 ax_i.plot([], color=y_model_fill_kwargs["color"], label="Uncertainty in mean")
 
                 y_model_mean = np.mean(y_model_plotters, axis=(0, 1))
-                ax_i.plot(x_plotters, y_model_mean, color="y", lw=0.8, zorder=11, label="Mean")
+                ax_i.plot(x_plotters, y_model_mean, **y_model_mean_kwargs, label="Mean")
 
         if legend:
             ax_i.legend(fontsize=xt_labelsize, loc="upper left")

--- a/arviz/plots/lmplot.py
+++ b/arviz/plots/lmplot.py
@@ -332,6 +332,7 @@ def plot_lm(
         y_hat_fill_kwargs=y_hat_fill_kwargs,
         y_model_plot_kwargs=y_model_plot_kwargs,
         y_model_fill_kwargs=y_model_fill_kwargs,
+        y_model_mean_kwargs=y_model_mean_kwargs,
         backend_kwargs=backend_kwargs,
         show=show,
         figsize=figsize,

--- a/arviz/plots/lmplot.py
+++ b/arviz/plots/lmplot.py
@@ -28,6 +28,7 @@ def plot_lm(
     y_hat_fill_kwargs=None,
     y_model_plot_kwargs=None,
     y_model_fill_kwargs=None,
+    y_model_mean_kwargs=None,
     backend_kwargs=None,
     show=None,
     figsize=None,

--- a/arviz/plots/lmplot.py
+++ b/arviz/plots/lmplot.py
@@ -78,6 +78,9 @@ def plot_lm(
         and :meth:`bokeh:bokeh.plotting.Figure.line` in bokeh
     y_model_fill_kwargs : dict, optional
         Significant if ``kind_model`` is "hdi". Passed to :func:`arviz.plot_hdi`
+    y_model_mean_kwargs : dict, optional
+        Passed to :meth:`mpl:matplotlib.axes.Axes.plot` in matplotlib
+        and :meth:`bokeh:bokeh.plotting.Figure.line` in bokeh
     backend_kwargs : dict, optional
         These are kwargs specific to the backend being used. Passed to
         :func:`matplotlib.pyplot.subplots` or


### PR DESCRIPTION
## Description
The `plot_lm()` function currently allows the user to customize the appearance of every displayed group except for the model mean. This is a simple pull request to enable customization of the model mean line as well.

## Checklist

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [x] New features are properly documented (with an example if appropriate)?
- [x] Code style correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)
