### PR TITLE
Fix legend labels in plot_ppc to reflect prior or posterior.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Bokeh 3 compatibility. ([1919](https://github.com/arviz-devs/arviz/pull/1919))
 * Remove manual setting of 2d KDE limits ([1939](https://github.com/arviz-devs/arviz/pull/1939))
 * Pin to bokeh<3 version ([1954](https://github.com/arviz-devs/arviz/pull/1954))
+* Fix legend labels in plot_ppc to reflect prior or posterior. ([1967](https://github.com/arviz-devs/arviz/pull/1967))
 
 ### Deprecation
 

--- a/arviz/plots/backends/matplotlib/ppcplot.py
+++ b/arviz/plots/backends/matplotlib/ppcplot.py
@@ -350,12 +350,7 @@ def plot_ppc(
                         alpha=alpha,
                     )
 
-            ax_i.plot(
-                [],
-                color=colors[0],
-                marker="o",
-                label=f"{group.capitalize()} predictive"
-            )
+            ax_i.plot([], color=colors[0], marker="o", label=f"{group.capitalize()} predictive")
 
             ax_i.set_yticks([])
 

--- a/arviz/plots/backends/matplotlib/ppcplot.py
+++ b/arviz/plots/backends/matplotlib/ppcplot.py
@@ -257,7 +257,7 @@ def plot_ppc(
                     drawstyle=drawstyle,
                     linewidth=linewidth,
                 )
-            ax_i.plot([], color=colors[0], label="Posterior predictive")
+            ax_i.plot([], color=colors[0], label=f"{group.capitalize()} predictive")
             if mean:
                 ax_i.plot(
                     *_empirical_cdf(pp_vals.flatten()),
@@ -265,7 +265,7 @@ def plot_ppc(
                     linestyle="--",
                     linewidth=linewidth * 1.5,
                     drawstyle=drawstyle,
-                    label="Posterior predictive mean",
+                    label=f"{group.capitalize()} predictive mean",
                 )
             ax_i.set_yticks([0, 0.5, 1])
 
@@ -280,7 +280,7 @@ def plot_ppc(
                             "linewidth": linewidth * 1.5,
                             "zorder": 3,
                         },
-                        label="Posterior predictive mean",
+                        label=f"{group.capitalize()} predictive mean",
                         ax=ax_i,
                         legend=legend,
                     )
@@ -294,7 +294,7 @@ def plot_ppc(
                         hist,
                         color=colors[2],
                         linewidth=linewidth * 1.5,
-                        label="Posterior predictive mean",
+                        label=f"{group.capitalize()} predictive mean",
                         zorder=3,
                         linestyle="--",
                         drawstyle="steps-pre",
@@ -350,7 +350,12 @@ def plot_ppc(
                         alpha=alpha,
                     )
 
-            ax_i.plot([], color=colors[0], marker="o", label="Posterior predictive")
+            ax_i.plot(
+                [],
+                color=colors[0],
+                marker="o",
+                label=f"{group.capitalize()} predictive"
+            )
 
             ax_i.set_yticks([])
 


### PR DESCRIPTION
## Description

Legend labels were not tracking the selected group. In many instances
they were hardcoded to "Posterior ...".

Addresses #1966.

## Checklist

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)
