### PR TITLE
Enabled type checking as described by PEP 561

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include *.md
 include *.txt
 include *.toml
 include LICENSE
+include arviz/py.typed
 
 recursive-include arviz *.mplstyle
 recursive-include arviz *.nc

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ pydocstyle
 pylint
 pytest
 pytest-cov
-black<22.1.0 ; python_version >= '3.6'
+black==21.12b0 ; python_version >= '3.6'
 typing_copilot ; python_version >= '3.7'
 mypy<0.800
 cloudpickle<1.5.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ pydocstyle
 pylint
 pytest
 pytest-cov
-black ; python_version >= '3.6'
+black<22.1.0 ; python_version >= '3.6'
 typing_copilot ; python_version >= '3.7'
 mypy<0.800
 cloudpickle<1.5.0


### PR DESCRIPTION
[PEP 561](https://www.python.org/dev/peps/pep-0561/) describes how packages can tell tools such as `mypy` that they support typechecking.
Essentially there are three options:
* Separately released "stub packages"
* `.pyi` files with stub definitions
* inline type hints and a `py.typed` file

This PR adds a `py.typed` file as shown in the https://github.com/ethanhs/pep-561 example project.

The project structure here is a little different. I hope the line in `MANIFEST.in` is correct?

This way type checking in PyMC etc. should become more exact, even if there are still some inconsistencies left.