### PR TITLE
Allow `log_weights` to specify the log_likelihood variable name in `loo_pit` (and `plot_loo_pit`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add new convenience function `arviz.extract_dataset` ([1725](https://github.com/arviz-devs/arviz/pull/1725))
 * [experimental] Enable dask chunking information to be passed to `InferenceData.from_netcdf` with regex support ([1749](https://github.com/arviz-devs/arviz/pull/1749))
 * Allow kwargs to customize appearance of the mean in `plot_lm`
+* Allow `log_weights` to specificy the log_likelihood variable name in `loo_pit` (and `plot_loo_pit`)
 
 ### Maintenance and fixes
 * Drop Python 3.6 support ([1430](https://github.com/arviz-devs/arviz/pull/1430))

--- a/arviz/plots/loopitplot.py
+++ b/arviz/plots/loopitplot.py
@@ -46,8 +46,9 @@ def plot_loo_pit(
         extra dimension at the end of size n_samples (chains and draws stacked). If str or
         None, ``idata`` must contain the posterior predictive group. If None, ``y_hat`` is taken
         equal to y, thus, y must be str too.
-    log_weights : array or DataArray
-        Smoothed log_weights. It must have the same shape as ``y_hat``
+    log_weights: array, DataArray, or str
+        Smoothed log_weights. It must have the same shape as ``y_hat``. If str, it should be
+        the name of a variable in the log_likelihood group.
     ecdf : bool, optional
         Plot the difference between the LOO-PIT Empirical Cumulative Distribution Function
         (ECDF) and the uniform CDF instead of LOO-PIT kde.

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -1597,8 +1597,9 @@ def loo_pit(idata=None, *, y=None, y_hat=None, log_weights=None):
         extra dimension at the end of size n_samples (chains and draws stacked). If str or
         None, ``idata`` must contain the posterior predictive group. If None, y_hat is taken
         equal to y, thus, y must be str too.
-    log_weights: array or DataArray
-        Smoothed log_weights. It must have the same shape as ``y_hat``
+    log_weights: array, DataArray, or str
+        Smoothed log_weights. It must have the same shape as ``y_hat``. If str, it should be
+        the name of a variable in the log_likelihood group.
     dask_kwargs : dict, optional
         Dask related kwargs passed to :func:`~arviz.wrap_xarray_ufunc`.
 
@@ -1663,8 +1664,10 @@ def loo_pit(idata=None, *, y=None, y_hat=None, log_weights=None):
             y_hat = idata.posterior_predictive[y_hat].stack(__sample__=("chain", "draw")).values
         elif not isinstance(y_hat, (np.ndarray, xr.DataArray)):
             raise ValueError(f"y_hat must be of types array, DataArray or str, not {type(y_hat)}")
-        if log_weights is None:
-            if y_str:
+        if log_weights is None or isinstance(log_weights, str):
+            if isinstance(log_weights, str):
+                log_likelihood = _get_log_likelihood(idata, var_name=log_weights)
+            elif y_str:
                 try:
                     log_likelihood = _get_log_likelihood(idata, var_name=y_str)
                 except TypeError:

--- a/arviz/tests/base_tests/test_stats.py
+++ b/arviz/tests/base_tests/test_stats.py
@@ -633,6 +633,22 @@ def test_loo_pit_multi_lik():
     assert np.all((loo_pit_data >= 0) & (loo_pit_data <= 1))
 
 
+def test_loo_pit_multi_lik_other_varname():
+    rng = np.random.default_rng(0)
+    post_pred = rng.standard_normal(size=(4, 100, 10))
+    obs = np.quantile(post_pred, np.linspace(0, 1, 10))
+    obs[0] *= 0.9
+    obs[-1] *= 1.1
+    idata = from_dict(
+        posterior={"a": np.random.randn(4, 100)},
+        posterior_predictive={"y": post_pred},
+        observed_data={"y": obs},
+        log_likelihood={"y_ll": -(post_pred ** 2), "decoy_ll": np.zeros_like(post_pred)},
+    )
+    loo_pit_data = loo_pit(idata, y="y", log_weights="y_ll")
+    assert np.all((loo_pit_data >= 0) & (loo_pit_data <= 1))
+
+
 @pytest.mark.parametrize("input_type", ["idataarray", "idatanone_ystr", "yarr_yhatnone"])
 def test_loo_pit_bad_input(centered_eight, input_type):
     """Test incompatible input combinations."""


### PR DESCRIPTION
It may not always be the case that variables in the log_likelihood group match exactly the names in observed or posterior predictive groups. This change allows to pass a str as "log_weights" which points to the log_likelihood variable to pair with the observed and posterior predictive ones.
This is helpful with InferenceData coming from Stan which won't allow, as far as I know, to use the same name for observed and log-likelihood variables in the same model file.
I've added the corresponding test.

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] New features are properly documented (with an example if appropriate)?
- [x] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)
