### PR TITLE
Fix bug in pair plot axis handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Pin to bokeh<3 version ([1954](https://github.com/arviz-devs/arviz/pull/1954))
 * Fix legend labels in plot_ppc to reflect prior or posterior. ([1967](https://github.com/arviz-devs/arviz/pull/1967))
 * Change `DataFrame.append` to `pandas.concat` ([1973](https://github.com/arviz-devs/arviz/pull/1973))
+* Fix axis sharing behaviour in `plot_pair`. ([1985](https://github.com/arviz-devs/arviz/pull/1985))
 
 ### Deprecation
 

--- a/arviz/plots/backends/matplotlib/pairplot.py
+++ b/arviz/plots/backends/matplotlib/pairplot.py
@@ -4,7 +4,6 @@ from copy import deepcopy
 
 import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.ticker import NullFormatter
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from ....rcparams import rcParams
@@ -324,18 +323,29 @@ def plot_pair(
                                 **reference_values_kwargs,
                             )
 
-                if j != vars_to_plot - 1:
-                    ax[j, i].axes.get_xaxis().set_major_formatter(NullFormatter())
-                else:
+                if j == vars_to_plot - 1:
                     ax[j, i].set_xlabel(f"{flat_var_names[i]}", fontsize=ax_labelsize, wrap=True)
-                if i != 0:
-                    ax[j, i].axes.get_yaxis().set_major_formatter(NullFormatter())
-                else:
+                elif backend_kwargs.get("sharex") is None:
+                    try:
+                        ax[j, i].axes.sharex(ax[-1, i])
+                        plt.setp(ax[j, i].get_xticklabels(), visible=False)
+                    except ValueError:
+                        # Raised if user has provided shared axes
+                        pass
+                if i == 0:
                     ax[j, i].set_ylabel(
                         f"{flat_var_names[j + not_marginals]}",
                         fontsize=ax_labelsize,
                         wrap=True,
                     )
+                elif backend_kwargs.get("sharey") is None:
+                    try:
+                        if i != j:
+                            ax[j, i].axes.sharey(ax[j, 0])
+                        plt.setp(ax[j, i].get_yticklabels(), visible=False)
+                    except ValueError:
+                        # Raised if user has provided shared axes
+                        pass
                 ax[j, i].tick_params(labelsize=xt_labelsize)
 
     if backend_show(show):

--- a/arviz/plots/backends/matplotlib/pairplot.py
+++ b/arviz/plots/backends/matplotlib/pairplot.py
@@ -245,11 +245,19 @@ def plot_pair(
         point_estimate_marker_kwargs.setdefault("s", markersize + 50)
 
         if ax is None:
+            backend_kwargs.setdefault("sharex", "col")
+            if not_marginals:
+                backend_kwargs.setdefault("sharey", "row")
             fig, ax = plt.subplots(
                 vars_to_plot,
                 vars_to_plot,
                 **backend_kwargs,
             )
+            if backend_kwargs.get("sharey") is None:
+                for j in range(0, vars_to_plot):
+                    for i in range(0, j):
+                        ax[j, i].axes.sharey(ax[j, 0])
+
         hexbin_values = []
         for i in range(0, vars_to_plot):
             var1 = plotters[i][-1].flatten()
@@ -323,29 +331,18 @@ def plot_pair(
                                 **reference_values_kwargs,
                             )
 
-                if j == vars_to_plot - 1:
+                if j != vars_to_plot - 1:
+                    plt.setp(ax[j, i].get_xticklabels(), visible=False)
+                else:
                     ax[j, i].set_xlabel(f"{flat_var_names[i]}", fontsize=ax_labelsize, wrap=True)
-                elif backend_kwargs.get("sharex") is None:
-                    try:
-                        ax[j, i].axes.sharex(ax[-1, i])
-                        plt.setp(ax[j, i].get_xticklabels(), visible=False)
-                    except ValueError:
-                        # Raised if user has provided shared axes
-                        pass
-                if i == 0:
+                if i != 0:
+                    plt.setp(ax[j, i].get_yticklabels(), visible=False)
+                else:
                     ax[j, i].set_ylabel(
                         f"{flat_var_names[j + not_marginals]}",
                         fontsize=ax_labelsize,
                         wrap=True,
                     )
-                elif backend_kwargs.get("sharey") is None:
-                    try:
-                        if i != j:
-                            ax[j, i].axes.sharey(ax[j, 0])
-                        plt.setp(ax[j, i].get_yticklabels(), visible=False)
-                    except ValueError:
-                        # Raised if user has provided shared axes
-                        pass
                 ax[j, i].tick_params(labelsize=xt_labelsize)
 
     if backend_show(show):

--- a/arviz/plots/backends/matplotlib/pairplot.py
+++ b/arviz/plots/backends/matplotlib/pairplot.py
@@ -245,7 +245,17 @@ def plot_pair(
         point_estimate_marker_kwargs.setdefault("s", markersize + 50)
 
         if ax is None:
-            backend_kwargs.setdefault("sharex", "col")
+            if backend_kwargs.pop("sharex", None) is not None:
+                warnings.warn(
+                    "'sharex' keyword is ignored. For non-standard sharing, provide 'ax'.",
+                    UserWarning,
+                )
+            if backend_kwargs.pop("sharey", None) is not None:
+                warnings.warn(
+                    "'sharey' keyword is ignored. For non-standard sharing, provide 'ax'.",
+                    UserWarning,
+                )
+            backend_kwargs["sharex"] = "col"
             if not_marginals:
                 backend_kwargs.setdefault("sharey", "row")
             fig, ax = plt.subplots(

--- a/arviz/plots/backends/matplotlib/pairplot.py
+++ b/arviz/plots/backends/matplotlib/pairplot.py
@@ -257,7 +257,7 @@ def plot_pair(
                 )
             backend_kwargs["sharex"] = "col"
             if not_marginals:
-                backend_kwargs.setdefault("sharey", "row")
+                backend_kwargs["sharey"] = "row"
             fig, ax = plt.subplots(
                 vars_to_plot,
                 vars_to_plot,

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -605,10 +605,13 @@ def test_plot_pair_shared(sharex, sharey, marginals):
     if sharex is None and sharey is None:
         ax = plot_pair(idata, marginals=marginals)
     else:
+        backend_kwargs = {}
+        if sharex is not None:
+            backend_kwargs["sharex"] = sharex
+        if sharey is not None:
+            backend_kwargs["sharey"] = sharey
         with pytest.warns(UserWarning):
-            ax = plot_pair(
-                idata, marginals=marginals, backend_kwargs={"sharex": sharex, "sharey": sharey}
-            )
+            ax = plot_pair(idata, marginals=marginals, backend_kwargs=backend_kwargs)
 
     # Check x axes shared correctly
     for i in range(numvars):

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -594,6 +594,50 @@ def test_plot_pair_shapes(marginals, max_subplots):
     assert ax.shape == (side, side)
 
 
+@pytest.mark.parametrize("sharex", [True, "col", False, None])
+@pytest.mark.parametrize("sharey", [True, "row", False, None])
+def test_plot_pair_shared(sharex, sharey):
+    # Generate kwarg dict
+    kwargs = {}
+    if sharex is not None:
+        kwargs["sharex"] = sharex
+    if sharey is not None:
+        kwargs["sharey"] = sharey
+
+    # Generate fake data and plot
+    rng = np.random.default_rng()
+    idata = from_dict({"a": rng.standard_normal((4, 500, 5))})
+    ax = plot_pair(idata, marginals=True, backend_kwargs=kwargs)
+
+    # Check x axes shared correctly
+    for i in range(5):
+        if sharex is None or sharex == "col":
+            num_shared_x = 5 - i
+        elif not sharex:
+            num_shared_x = 1
+        else:
+            num_shared_x = 15
+        assert len(ax[-1, i].get_shared_x_axes().get_siblings(ax[-1, i])) == num_shared_x
+
+    # Check y axes shared correctly
+    for j in range(5):
+        if sharey is None:
+            num_shared_y = j
+
+            # Check diagonal has unshared axis
+            assert len(ax[j, j].get_shared_y_axes().get_siblings(ax[j, j])) == 1
+
+            if j == 0:
+                continue
+        elif sharey == "row":
+            num_shared_y = j + 1
+        elif not sharey:
+            num_shared_y = 1
+        else:
+            num_shared_y = 15
+        assert len(ax[j, 0].get_shared_y_axes().get_siblings(ax[j, 0])) == num_shared_y
+
+
 @pytest.mark.parametrize("kind", ["kde", "cumulative", "scatter"])
 @pytest.mark.parametrize("alpha", [None, 0.2, 1])
 @pytest.mark.parametrize("animated", [False, True])


### PR DESCRIPTION
## Description
<!--
Thank you so much for your PR! To help us review your contribution, please consider the following points:

- The PR title should summarize the changes, for example "Add new group argument for the pair plot".
  Avoid non-descriptive titles such as "Addresses issue #348".

- The description should provide at least 1-2 sentences describing the pull request in detail and
  link to any relevant issues.

- Please prefix the title of incomplete contributions with [WIP] (to indicate a work in
  progress). WIPs may be useful to (1) indicate you are working on something to avoid
  duplicated work, (2) request broad review of functionality or API, or (3) seek collaborators. -->

This is an attempt at fixing #1981, in which the subplot axes do not have the same range by default but also lack unique labels. In doing so, I hope to correct some of the counterintuitive behaviour around passing "sharex" or "sharey" as backend parameters. I've written a fix, ~and am in the process of adding unit tests for said fix~ and unit tests for the fix. 

**Update** __(23/02/22)__:
I generated an example plot of the marginals, based on the plotpair example gallery code, to illustrate that the marginal axes now fall in the correct place.
![example](https://user-images.githubusercontent.com/30499074/155308086-a0e89da8-9371-42ff-b2a5-27bfdb1ab2a2.png)

Cf. the old behaviour, where the marginal plot axis ticks are not aligned with the plots beneath them, but the labels are also missing.

![broken](https://user-images.githubusercontent.com/30499074/155309202-ddeed4de-5d5f-4b72-b1d4-15f357986db0.png)


## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [x] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

(I removed the "new features" documentation from the list because this isn't a new feature, just a bug fix to correct unexpected behaviour)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
