### PR TITLE
[WIP] add find_prior function

### DIFF
--- a/arviz/__init__.py
+++ b/arviz/__init__.py
@@ -32,6 +32,7 @@ _log = Logger("arviz")
 from .data import *
 from .plots import *
 from .plots.backends import *
+from .priors import *
 from .stats import *
 from .rcparams import rc_context, rcParams
 from .utils import Numba, Dask, interactive_backend

--- a/arviz/priors/__init__.py
+++ b/arviz/priors/__init__.py
@@ -1,0 +1,9 @@
+# pylint: disable=wildcard-import
+"""Functions to assist prior elicitation"""
+from .find_prior import find_prior
+from .prior_utils import *
+
+
+__all__ = [
+    "find_prior",
+]

--- a/arviz/priors/find_prior.py
+++ b/arviz/priors/find_prior.py
@@ -2,19 +2,29 @@ from scipy import stats
 from scipy.optimize import least_squares
 import matplotlib.pyplot as plt
 
-from .prior_utils import (get_parametrization,
-                          check_boundaries,
-                          relative_error,
-                          sane_scipy,
-                          compute_xvals,
-                          func,
-                          get_normal,
-                          dist_dict,
-                          )
+from .prior_utils import (
+    get_parametrization,
+    check_boundaries,
+    relative_error,
+    sane_scipy,
+    compute_xvals,
+    func,
+    get_normal,
+    dist_dict,
+)
 
 
-
-def find_prior(name="normal", lower=-1, upper=1, mass=0.90, extra=None, parametrization="pymc", plot=True, figsize=(10,4), ax=None):
+def find_prior(
+    name="normal",
+    lower=-1,
+    upper=1,
+    mass=0.90,
+    extra=None,
+    parametrization="pymc",
+    plot=True,
+    figsize=(10, 4),
+    ax=None,
+):
     """
     Find parameters for a given distribution with `mass` between `lower` and `upper`.
 
@@ -32,7 +42,7 @@ def find_prior(name="normal", lower=-1, upper=1, mass=0.90, extra=None, parametr
         Whether to plot the distribution, and lower and upper bounds. Defautls to True.
     figsize: tuple
         size of the figure when ``plot=True``
-    ax: 
+    ax:
 
     Returns
     -------
@@ -40,29 +50,29 @@ def find_prior(name="normal", lower=-1, upper=1, mass=0.90, extra=None, parametr
     rv_frozen : scipy.stats.distributions.rv_frozen
         Notice that the returned rv_frozen object always use the scipy parametrization,
         irrespective of the value of `parametrization` argument.
-        Unlike standard rv_frozen objects this one has a name attribute    
+        Unlike standard rv_frozen objects this one has a name attribute
     opt: scipy.optimize.OptimizeResult
         Represents the optimization result.
     """
     check_boundaries(name, lower, upper)
-        
+
     opt = get_normal(lower, upper, mass)
     mu_init, sigma_init = opt["x"]
-        
+
     if name == "normal":
         rv_frozen = stats.norm(mu_init, sigma_init)
         rv_frozen.name = name
         a, b = opt["x"]
     else:
         if name == "beta":
-            kappa = (mu_init*(1-mu_init) / (sigma_init)**2) -1
+            kappa = (mu_init * (1 - mu_init) / (sigma_init) ** 2) - 1
             a = mu_init * kappa
-            b = (1-mu_init) * kappa
+            b = (1 - mu_init) * kappa
             dist = stats.beta
-    
+
         elif name == "lognormal":
-            a = np.log(mu_init**2 / (sigma_init**2 + mu_init**2)**0.5)
-            b = np.log(sigma_init**2 / mu_init**2 + 1)**0.5
+            a = np.log(mu_init ** 2 / (sigma_init ** 2 + mu_init ** 2) ** 0.5)
+            b = np.log(sigma_init ** 2 / mu_init ** 2 + 1) ** 0.5
             dist = stats.lognorm
 
         elif name == "exponential":
@@ -71,32 +81,32 @@ def find_prior(name="normal", lower=-1, upper=1, mass=0.90, extra=None, parametr
             dist = stats.expon
 
         elif name == "gamma":
-            a = mu_init**2 / sigma_init**2
-            b = sigma_init**2 / mu_init
+            a = mu_init ** 2 / sigma_init ** 2
+            b = sigma_init ** 2 / mu_init
             dist = stats.gamma
         elif name == "student":
             a = mu_init
             b = sigma_init
             dist = stats.t
-            
+
         opt = least_squares(func, x0=(a, b), args=(dist, lower, upper, mass, extra))
         a, b = opt["x"]
-        rv_frozen =  sane_scipy(dist, a, b, extra)
+        rv_frozen = sane_scipy(dist, a, b, extra)
 
     if plot:
         r_error = relative_error(rv_frozen, upper, lower, mass)
         x = compute_xvals(rv_frozen)
         if ax is None:
             _, ax = plt.subplots(figsize=figsize)
-        color = next(ax._get_lines.prop_cycler)['color']
+        color = next(ax._get_lines.prop_cycler)["color"]
         ax.plot([lower, upper], [0, 0], "o", color=color, alpha=0.5)
         title = get_parametrization(name, a, b, extra, dist_dict, parametrization)
         subtitle = f"relative error = {r_error:.2f}"
-        ax.plot(x, rv_frozen.pdf(x), label=title+"\n"+subtitle, color=color)
+        ax.plot(x, rv_frozen.pdf(x), label=title + "\n" + subtitle, color=color)
 
     box = ax.get_position()
     ax.set_position([box.x0, box.y0, box.width, box.height])
-    ax.legend(loc='center left', bbox_to_anchor=(1, 0.5))
+    ax.legend(loc="center left", bbox_to_anchor=(1, 0.5))
     ax.set_yticks([])
 
     return ax, rv_frozen, opt

--- a/arviz/priors/find_prior.py
+++ b/arviz/priors/find_prior.py
@@ -1,0 +1,102 @@
+from scipy import stats
+from scipy.optimize import least_squares
+import matplotlib.pyplot as plt
+
+from .prior_utils import (get_parametrization,
+                          check_boundaries,
+                          relative_error,
+                          sane_scipy,
+                          compute_xvals,
+                          func,
+                          get_normal,
+                          dist_dict,
+                          )
+
+
+
+def find_prior(name="normal", lower=-1, upper=1, mass=0.90, extra=None, parametrization="pymc", plot=True, figsize=(10,4), ax=None):
+    """
+    Find parameters for a given distribution with `mass` between `lower` and `upper`.
+
+    Parameters
+    ----------
+    name : str
+        Name of the distribution to use as prior
+    lower : float
+        Lower bound
+    upper : float
+        Upper bound
+    mass: float
+        Probability mass between ``lower`` and ``upper`` bounds. Defaults to 0.9
+    plot: bool
+        Whether to plot the distribution, and lower and upper bounds. Defautls to True.
+    figsize: tuple
+        size of the figure when ``plot=True``
+    ax: 
+
+    Returns
+    -------
+    axes: matplotlib axes
+    rv_frozen : scipy.stats.distributions.rv_frozen
+        Notice that the returned rv_frozen object always use the scipy parametrization,
+        irrespective of the value of `parametrization` argument.
+        Unlike standard rv_frozen objects this one has a name attribute    
+    opt: scipy.optimize.OptimizeResult
+        Represents the optimization result.
+    """
+    check_boundaries(name, lower, upper)
+        
+    opt = get_normal(lower, upper, mass)
+    mu_init, sigma_init = opt["x"]
+        
+    if name == "normal":
+        rv_frozen = stats.norm(mu_init, sigma_init)
+        rv_frozen.name = name
+        a, b = opt["x"]
+    else:
+        if name == "beta":
+            kappa = (mu_init*(1-mu_init) / (sigma_init)**2) -1
+            a = mu_init * kappa
+            b = (1-mu_init) * kappa
+            dist = stats.beta
+    
+        elif name == "lognormal":
+            a = np.log(mu_init**2 / (sigma_init**2 + mu_init**2)**0.5)
+            b = np.log(sigma_init**2 / mu_init**2 + 1)**0.5
+            dist = stats.lognorm
+
+        elif name == "exponential":
+            a = mu_init
+            b = sigma_init
+            dist = stats.expon
+
+        elif name == "gamma":
+            a = mu_init**2 / sigma_init**2
+            b = sigma_init**2 / mu_init
+            dist = stats.gamma
+        elif name == "student":
+            a = mu_init
+            b = sigma_init
+            dist = stats.t
+            
+        opt = least_squares(func, x0=(a, b), args=(dist, lower, upper, mass, extra))
+        a, b = opt["x"]
+        rv_frozen =  sane_scipy(dist, a, b, extra)
+
+    if plot:
+        r_error = relative_error(rv_frozen, upper, lower, mass)
+        x = compute_xvals(rv_frozen)
+        if ax is None:
+            _, ax = plt.subplots(figsize=figsize)
+        color = next(ax._get_lines.prop_cycler)['color']
+        ax.plot([lower, upper], [0, 0], "o", color=color, alpha=0.5)
+        title = get_parametrization(name, a, b, extra, dist_dict, parametrization)
+        subtitle = f"relative error = {r_error:.2f}"
+        ax.plot(x, rv_frozen.pdf(x), label=title+"\n"+subtitle, color=color)
+
+    box = ax.get_position()
+    ax.set_position([box.x0, box.y0, box.width, box.height])
+    ax.legend(loc='center left', bbox_to_anchor=(1, 0.5))
+    ax.set_yticks([])
+
+    return ax, rv_frozen, opt

--- a/arviz/priors/prior_utils.py
+++ b/arviz/priors/prior_utils.py
@@ -3,13 +3,15 @@ from scipy import stats
 from scipy.optimize import least_squares
 
 
-dist_dict = {"beta": ("alpha", "beta"),
-             "exponential":  ("lam",),
-             "gamma":  ("alpha", "beta"),
-             "lognormal": ("mu", "sigma"),
-             "normal": ("mu", "sigma"),
-             "student": ("nu", "mu", "sigma"),
-            } # This names could be different for different "parametrizations"
+dist_dict = {
+    "beta": ("alpha", "beta"),
+    "exponential": ("lam",),
+    "gamma": ("alpha", "beta"),
+    "lognormal": ("mu", "sigma"),
+    "normal": ("mu", "sigma"),
+    "student": ("nu", "mu", "sigma"),
+}  # This names could be different for different "parametrizations"
+
 
 def get_parametrization(name, a, b, extra, dist_dict, parametrization):
     if parametrization == "pymc":
@@ -32,20 +34,25 @@ def get_parametrization(name, a, b, extra, dist_dict, parametrization):
             title = f"{name}({dist_dict[name][0]}={extra:.2f}, {dist_dict[name][1]}={a:.2f}, {dist_dict[name][2]}={b:.2f})"
     return title
 
+
 def check_boundaries(name, lower, upper):
     DOMAIN_ERROR = f"The provided boundaries are outside the domain of the {name} distribution"
     if name == "beta":
         if lower == 0 and upper == 1:
-            raise ValueError("Given the provided boundaries, mass will be always 1. Please provide other values")
+            raise ValueError(
+                "Given the provided boundaries, mass will be always 1. Please provide other values"
+            )
         if lower < 0 or upper > 1:
-                raise ValueError(DOMAIN_ERROR)
+            raise ValueError(DOMAIN_ERROR)
     elif name in ["exponential", "gamma", "lognormal"]:
         if lower < 0:
             raise ValueError(DOMAIN_ERROR)
 
+
 def relative_error(rv_frozen, upper, lower, requiered_mass):
     computed_mass = rv_frozen.cdf(upper) - rv_frozen.cdf(lower)
-    return (computed_mass-requiered_mass) / requiered_mass * 100
+    return (computed_mass - requiered_mass) / requiered_mass * 100
+
 
 def sane_scipy(dist, a, b, extra=None):
     dist_name = dist.name
@@ -63,12 +70,13 @@ def sane_scipy(dist, a, b, extra=None):
     rv_frozen.name = dist_name
     return rv_frozen
 
+
 def compute_xvals(rv_frozen):
     if np.isfinite(rv_frozen.a):
         lq = rv_frozen.a
     else:
         lq = 0.001
-    
+
     if np.isfinite(rv_frozen.b):
         uq = rv_frozen.b
     else:
@@ -77,16 +85,18 @@ def compute_xvals(rv_frozen):
     x = np.linspace(rv_frozen.ppf(lq), rv_frozen.ppf(uq), 1000)
     return x
 
+
 def func(params, dist, lower, upper, mass, extra=None):
     a, b = params
     rv_frozen = sane_scipy(dist, a, b, extra)
     cdf0 = rv_frozen.cdf(lower)
     cdf1 = rv_frozen.cdf(upper)
-    cdf_loss = ((cdf1 - cdf0) - mass)
+    cdf_loss = (cdf1 - cdf0) - mass
     return cdf_loss
 
+
 def get_normal(lower, upper, mass):
-    mu_init = (lower+upper)/2
-    sigma_init = ((upper-lower) / 4) / mass
+    mu_init = (lower + upper) / 2
+    sigma_init = ((upper - lower) / 4) / mass
     opt = least_squares(func, x0=(mu_init, sigma_init), args=(stats.norm, lower, upper, mass))
     return opt

--- a/arviz/priors/prior_utils.py
+++ b/arviz/priors/prior_utils.py
@@ -1,0 +1,92 @@
+import numpy as np
+from scipy import stats
+from scipy.optimize import least_squares
+
+
+dist_dict = {"beta": ("alpha", "beta"),
+             "exponential":  ("lam",),
+             "gamma":  ("alpha", "beta"),
+             "lognormal": ("mu", "sigma"),
+             "normal": ("mu", "sigma"),
+             "student": ("nu", "mu", "sigma"),
+            } # This names could be different for different "parametrizations"
+
+def get_parametrization(name, a, b, extra, dist_dict, parametrization):
+    if parametrization == "pymc":
+        if name == "gamma":
+            title = f"{name}({dist_dict[name][0]}={a:.2f}, {dist_dict[name][1]}={1/b:.2f})"
+        elif name == "exponential":
+            title = f"{name}({dist_dict[name][0]}={1/a:.2f})"
+        elif name == "lognormal":
+            title = f"{name}({dist_dict[name][0]}={a:.2f}, {dist_dict[name][1]}={b:.2f})"
+        elif name in ["normal", "beta"]:
+            title = f"{name}({dist_dict[name][0]}={a:.2f}, {dist_dict[name][1]}={b:.2f})"
+        elif name == "student":
+            title = f"{name}({dist_dict[name][0]}={extra:.2f}, {dist_dict[name][1]}={a:.2f}, {dist_dict[name][2]}={b:.2f})"
+    elif parametrization == "scipy":
+        if name in ["gamma", "lognormal", "normal"]:
+            title = f"{name}({dist_dict[name][0]}={a:.2f}, {dist_dict[name][1]}={b:.2f})"
+        elif name == "exponential":
+            title = f"{name}({dist_dict[name][0]}={a:.2f})"
+        elif name == "student":
+            title = f"{name}({dist_dict[name][0]}={extra:.2f}, {dist_dict[name][1]}={a:.2f}, {dist_dict[name][2]}={b:.2f})"
+    return title
+
+def check_boundaries(name, lower, upper):
+    DOMAIN_ERROR = f"The provided boundaries are outside the domain of the {name} distribution"
+    if name == "beta":
+        if lower == 0 and upper == 1:
+            raise ValueError("Given the provided boundaries, mass will be always 1. Please provide other values")
+        if lower < 0 or upper > 1:
+                raise ValueError(DOMAIN_ERROR)
+    elif name in ["exponential", "gamma", "lognormal"]:
+        if lower < 0:
+            raise ValueError(DOMAIN_ERROR)
+
+def relative_error(rv_frozen, upper, lower, requiered_mass):
+    computed_mass = rv_frozen.cdf(upper) - rv_frozen.cdf(lower)
+    return (computed_mass-requiered_mass) / requiered_mass * 100
+
+def sane_scipy(dist, a, b, extra=None):
+    dist_name = dist.name
+    if dist_name in ["norm", "beta"]:
+        rv_frozen = dist(a, b)
+    elif dist_name == "gamma":
+        rv_frozen = dist(a=a, scale=b)
+    elif dist_name == "lognorm":
+        rv_frozen = dist(b, scale=np.exp(a))
+    elif dist_name == "expon":
+        rv_frozen = dist(scale=a)
+    elif dist_name == "t":
+        rv_frozen = dist(df=extra, loc=a, scale=b)
+
+    rv_frozen.name = dist_name
+    return rv_frozen
+
+def compute_xvals(rv_frozen):
+    if np.isfinite(rv_frozen.a):
+        lq = rv_frozen.a
+    else:
+        lq = 0.001
+    
+    if np.isfinite(rv_frozen.b):
+        uq = rv_frozen.b
+    else:
+        uq = 0.999
+
+    x = np.linspace(rv_frozen.ppf(lq), rv_frozen.ppf(uq), 1000)
+    return x
+
+def func(params, dist, lower, upper, mass, extra=None):
+    a, b = params
+    rv_frozen = sane_scipy(dist, a, b, extra)
+    cdf0 = rv_frozen.cdf(lower)
+    cdf1 = rv_frozen.cdf(upper)
+    cdf_loss = ((cdf1 - cdf0) - mass)
+    return cdf_loss
+
+def get_normal(lower, upper, mass):
+    mu_init = (lower+upper)/2
+    sigma_init = ((upper-lower) / 4) / mass
+    opt = least_squares(func, x0=(mu_init, sigma_init), args=(stats.norm, lower, upper, mass))
+    return opt


### PR DESCRIPTION
This is a proof of concept of a new ArviZ function, tentatively named `find_prior`. This is inspired in a recent function added to PyMC, but here I am trying to extend the functionality and offer a solution that works outside of PyMC.


The function is called

```python
az.find_prior("normal", lower=-3, upper=3, mass=0.90)
```

In this case we are asking to return the parameters of a normal distribution with 90% mass between `lower` and `upper`. The function returns 3 objects:

* axes: matplotlib axes
* rv_frozen : scipy.stats.distributions.rv_frozen
* opt: scipy.optimize.OptimizeResult

Having access to the `rv_frozen`, allow the user to then ask for other quantities like the mean, std, quantiles. make other plots, etc. 

Optionally, the function also generates a plot.


for example 
```python
lower = 0
upper = 1.5
ax, st, opt = az.find_prior("lognormal", lower=lower, upper=upper, mass=0.95)
ax, st, opt = az.find_prior("lognormal", lower=lower+0.5, upper=upper, mass=0.95, ax=ax)
```
![index](https://user-images.githubusercontent.com/1338958/155122499-98133b51-5609-4ea0-bc81-3ea6064f9ead.png)


Another example. The `extra` argument is used to indicate the degrees of freedom of the Student-T distribution.

```python
ax, st, opt = az.find_prior("normal", lower=-3, upper=3, mass=0.90)
ax, st, opt = az.find_prior("student", lower=-3, upper=3, mass=0.90, extra=5, ax=ax)
```
![index](https://user-images.githubusercontent.com/1338958/155122667-069ad7d0-f48a-4bd2-8a3f-6c853fa5e99e.png)


The function has a `parametrization` argument, currently it only has two options "pymc" and "scipy". The reason for having this  arguments is that distributions are parametrized in different ways in different PPLs/packages. 

Probably still a lot of room for improvement but I would like to see if we can agree on a minimal set of features for a first merge. Also, I am suggesting to host at least part of the new "prior elicitation" functionality inside a new `priors` module/folder with a new `prior_utils.py`, that could be shared with other upcoming prior-related functions like those in #1965.