### PR TITLE
Allow varnames that aren't strings to be used in InferenceData

### DIFF
--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -51,6 +51,7 @@ from ..helpers import (  # pylint: disable=unused-import
     eight_schools_params,
     models,
     multidim_models,
+    TestRandomVariable,
 )
 
 rcParams["data.load"] = "eager"
@@ -156,6 +157,27 @@ def test_plot_density_no_subset():
         {
             "b": np.random.normal(size=200),
             "c": np.random.normal(size=200),
+        }
+    )
+    axes = plot_density([model_ab, model_bc])
+    assert axes.size == 3
+
+
+def test_plot_density_nonstring_varnames():
+    """Test plot_density works when variables are not strings."""
+    a = TestRandomVariable("a")
+    b = TestRandomVariable("b")
+    c = TestRandomVariable("c")
+    model_ab = from_dict(
+        {
+            a: np.random.normal(size=200),
+            b: np.random.normal(size=200),
+        }
+    )
+    model_bc = from_dict(
+        {
+            b: np.random.normal(size=200),
+            c: np.random.normal(size=200),
         }
     )
     axes = plot_density([model_ab, model_bc])

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -165,19 +165,19 @@ def test_plot_density_no_subset():
 
 def test_plot_density_nonstring_varnames():
     """Test plot_density works when variables are not strings."""
-    a = TestRandomVariable("a")
-    b = TestRandomVariable("b")
-    c = TestRandomVariable("c")
+    rv1 = TestRandomVariable("a")
+    rv2 = TestRandomVariable("b")
+    rv3 = TestRandomVariable("c")
     model_ab = from_dict(
         {
-            a: np.random.normal(size=200),
-            b: np.random.normal(size=200),
+            rv1: np.random.normal(size=200),
+            rv2: np.random.normal(size=200),
         }
     )
     model_bc = from_dict(
         {
-            b: np.random.normal(size=200),
-            c: np.random.normal(size=200),
+            rv2: np.random.normal(size=200),
+            rv3: np.random.normal(size=200),
         }
     )
     axes = plot_density([model_ab, model_bc])

--- a/arviz/tests/base_tests/test_utils.py
+++ b/arviz/tests/base_tests/test_utils.py
@@ -17,6 +17,7 @@ from ...utils import (
     one_de,
     two_de,
 )
+from ..helpers import TestRandomVariable
 
 
 @pytest.fixture(scope="session")
@@ -118,6 +119,14 @@ def test_var_names_filter(var_args):
     )
     var_names, expected, filter_vars = var_args
     assert _var_names(var_names, data, filter_vars) == expected
+
+
+def test_nonstring_var_names():
+    """Check that non-string variables are preserved"""
+    mu = TestRandomVariable("mu")
+    samples = np.random.randn(10)
+    data = dict_to_dataset({mu: samples})
+    assert _var_names([mu], data) == [mu]
 
 
 def test_var_names_filter_invalid_argument():

--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -18,6 +18,14 @@ from ..data import InferenceData, from_dict
 _log = logging.getLogger(__name__)
 
 
+class TestRandomVariable:
+    def __init__(self, name):
+        self.name = name
+
+    def __repr__(self):
+        return self.name
+
+
 @pytest.fixture(scope="module")
 def eight_schools_params():
     """Share setup for eight schools."""

--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -19,10 +19,12 @@ _log = logging.getLogger(__name__)
 
 
 class TestRandomVariable:
+    """Example class for random variables"""
     def __init__(self, name):
         self.name = name
 
     def __repr__(self):
+        """Returns argument to constructor as string representation"""
         return self.name
 
 

--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -19,12 +19,13 @@ _log = logging.getLogger(__name__)
 
 
 class TestRandomVariable:
-    """Example class for random variables"""
+    """Example class for random variables."""
+
     def __init__(self, name):
         self.name = name
 
     def __repr__(self):
-        """Returns argument to constructor as string representation"""
+        """Return argument to constructor as string representation."""
         return self.name
 
 

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -50,7 +50,7 @@ def _var_names(var_names, data, filter_vars=None):
         else:
             all_vars = list(data.data_vars)
 
-        all_vars_tilde = [var for var in all_vars if var.startswith("~")]
+        all_vars_tilde = [var for var in all_vars if repr(var).startswith("~")]
         if all_vars_tilde:
             warnings.warn(
                 """ArviZ treats '~' as a negation character for variable selection.
@@ -94,7 +94,7 @@ def _subset_list(subset, whole_list, filter_items=None, warn=True):
         if isinstance(subset, str):
             subset = [subset]
 
-        whole_list_tilde = [item for item in whole_list if item.startswith("~")]
+        whole_list_tilde = [item for item in whole_list if repr(item).startswith("~")]
         if whole_list_tilde and warn:
             warnings.warn(
                 "ArviZ treats '~' as a negation character for selection. There are "
@@ -105,7 +105,7 @@ def _subset_list(subset, whole_list, filter_items=None, warn=True):
             )
 
         excluded_items = [
-            item[1:] for item in subset if item.startswith("~") and item not in whole_list
+            item[1:] for item in subset if repr(item).startswith("~") and item not in whole_list
         ]
         filter_items = str(filter_items).lower()
         not_found = []

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -19,8 +19,7 @@ STATIC_FILES = ("static/html/icons-svg-inline.html", "static/css/style.css")
 def check_tilde_start(x):
     if isinstance(x, str) and x.startswith("~"):
         return True
-    else:
-        return False
+    return False
 
 
 def _var_names(var_names, data, filter_vars=None):

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -16,6 +16,13 @@ from .rcparams import rcParams
 STATIC_FILES = ("static/html/icons-svg-inline.html", "static/css/style.css")
 
 
+def _repr_str(x):
+    if isinstance(x, str):
+        return x
+    else:
+        return repr(x)
+
+
 def _var_names(var_names, data, filter_vars=None):
     """Handle var_names input across arviz.
 
@@ -50,7 +57,7 @@ def _var_names(var_names, data, filter_vars=None):
         else:
             all_vars = list(data.data_vars)
 
-        all_vars_tilde = [var for var in all_vars if repr(var).startswith("~")]
+        all_vars_tilde = [var for var in all_vars if _repr_str(var).startswith("~")]
         if all_vars_tilde:
             warnings.warn(
                 """ArviZ treats '~' as a negation character for variable selection.
@@ -94,7 +101,7 @@ def _subset_list(subset, whole_list, filter_items=None, warn=True):
         if isinstance(subset, str):
             subset = [subset]
 
-        whole_list_tilde = [item for item in whole_list if repr(item).startswith("~")]
+        whole_list_tilde = [item for item in whole_list if _repr_str(item).startswith("~")]
         if whole_list_tilde and warn:
             warnings.warn(
                 "ArviZ treats '~' as a negation character for selection. There are "
@@ -105,7 +112,7 @@ def _subset_list(subset, whole_list, filter_items=None, warn=True):
             )
 
         excluded_items = [
-            item[1:] for item in subset if repr(item).startswith("~") and item not in whole_list
+            item[1:] for item in subset if _repr_str(item).startswith("~") and item not in whole_list
         ]
         filter_items = str(filter_items).lower()
         not_found = []

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -112,7 +112,9 @@ def _subset_list(subset, whole_list, filter_items=None, warn=True):
             )
 
         excluded_items = [
-            item[1:] for item in subset if _repr_str(item).startswith("~") and item not in whole_list
+            item[1:]
+            for item in subset
+            if _repr_str(item).startswith("~") and item not in whole_list
         ]
         filter_items = str(filter_items).lower()
         not_found = []

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -16,11 +16,11 @@ from .rcparams import rcParams
 STATIC_FILES = ("static/html/icons-svg-inline.html", "static/css/style.css")
 
 
-def _repr_str(x):
-    if isinstance(x, str):
-        return x
+def check_tilde_start(x):
+    if isinstance(x, str) and x.startswith("~"):
+        return True
     else:
-        return repr(x)
+        return False
 
 
 def _var_names(var_names, data, filter_vars=None):
@@ -57,7 +57,7 @@ def _var_names(var_names, data, filter_vars=None):
         else:
             all_vars = list(data.data_vars)
 
-        all_vars_tilde = [var for var in all_vars if _repr_str(var).startswith("~")]
+        all_vars_tilde = [var for var in all_vars if check_tilde_start(var)]
         if all_vars_tilde:
             warnings.warn(
                 """ArviZ treats '~' as a negation character for variable selection.
@@ -101,7 +101,7 @@ def _subset_list(subset, whole_list, filter_items=None, warn=True):
         if isinstance(subset, str):
             subset = [subset]
 
-        whole_list_tilde = [item for item in whole_list if _repr_str(item).startswith("~")]
+        whole_list_tilde = [item for item in whole_list if check_tilde_start(item)]
         if whole_list_tilde and warn:
             warnings.warn(
                 "ArviZ treats '~' as a negation character for selection. There are "
@@ -114,7 +114,7 @@ def _subset_list(subset, whole_list, filter_items=None, warn=True):
         excluded_items = [
             item[1:]
             for item in subset
-            if _repr_str(item).startswith("~") and item not in whole_list
+            if check_tilde_start(item) and item not in whole_list
         ]
         filter_items = str(filter_items).lower()
         not_found = []

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -16,7 +16,7 @@ from .rcparams import rcParams
 STATIC_FILES = ("static/html/icons-svg-inline.html", "static/css/style.css")
 
 
-def check_tilde_start(x):
+def _check_tilde_start(x):
     if isinstance(x, str) and x.startswith("~"):
         return True
     return False
@@ -56,7 +56,7 @@ def _var_names(var_names, data, filter_vars=None):
         else:
             all_vars = list(data.data_vars)
 
-        all_vars_tilde = [var for var in all_vars if check_tilde_start(var)]
+        all_vars_tilde = [var for var in all_vars if _check_tilde_start(var)]
         if all_vars_tilde:
             warnings.warn(
                 """ArviZ treats '~' as a negation character for variable selection.
@@ -100,7 +100,7 @@ def _subset_list(subset, whole_list, filter_items=None, warn=True):
         if isinstance(subset, str):
             subset = [subset]
 
-        whole_list_tilde = [item for item in whole_list if check_tilde_start(item)]
+        whole_list_tilde = [item for item in whole_list if _check_tilde_start(item)]
         if whole_list_tilde and warn:
             warnings.warn(
                 "ArviZ treats '~' as a negation character for selection. There are "
@@ -111,9 +111,7 @@ def _subset_list(subset, whole_list, filter_items=None, warn=True):
             )
 
         excluded_items = [
-            item[1:]
-            for item in subset
-            if check_tilde_start(item) and item not in whole_list
+            item[1:] for item in subset if _check_tilde_start(item) and item not in whole_list
         ]
         filter_items = str(filter_items).lower()
         not_found = []

--- a/doc/source/user_guide/plots_arguments_guide.md
+++ b/doc/source/user_guide/plots_arguments_guide.md
@@ -83,16 +83,11 @@ Use `var_names` to indicate which variables to exclude with the `~` prefix:
 az.plot_posterior(centered_eight, var_names=['~mu', '~theta']);
 ```
 
-Variables do not need to be strings to be used
+Variables do not need to be strings to be used. Anything that is
+hashable will work.
+
 ```{code-cell} ipython3
-class RandomVariable:
-    def __init__(self, name):
-        self.name = name
-
-    def __repr__(self):
-        return self.name
-
-mu = RandomVariable("mu")
+mu = ("mu", "var")
 samples = np.random.normal(0, 1, 100)
 data = az.dict_to_dataset({mu: samples})
 az.plot_posterior(data);

--- a/doc/source/user_guide/plots_arguments_guide.md
+++ b/doc/source/user_guide/plots_arguments_guide.md
@@ -83,6 +83,21 @@ Use `var_names` to indicate which variables to exclude with the `~` prefix:
 az.plot_posterior(centered_eight, var_names=['~mu', '~theta']);
 ```
 
+Variables do not need to be strings to be used
+```{code-cell} ipython3
+class RandomVariable:
+    def __init__(self, name):
+        self.name = name
+
+    def __repr__(self):
+        return self.name
+
+mu = RandomVariable("mu")
+samples = np.random.normal(0, 1, 100)
+data = az.dict_to_dataset({mu: samples})
+az.plot_posterior(data);
+```
+
 (common_filter_vars)=
 ## `filter_vars`
 If None (default), interpret `var_names` as the real variables names,


### PR DESCRIPTION
This updates the util functions so that variables don't need to be represented as strings. As far as I know
this is the only place in the codebase that assumes it.
