### PR TITLE
fix issue when coords for default dims are provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Change `DataFrame.append` to `pandas.concat` ([1973](https://github.com/arviz-devs/arviz/pull/1973))
 * Fix axis sharing behaviour in `plot_pair`. ([1985](https://github.com/arviz-devs/arviz/pull/1985))
 * Added warning message in `plot_dist_comparison()` in case subplots go over the limit ([1688](https://github.com/arviz-devs/arviz/pull/1688))
+* Fix coord value ignoring for default dims ([2001](https://github.com/arviz-devs/arviz/pull/2001))
 
 ### Deprecation
 

--- a/arviz/data/base.py
+++ b/arviz/data/base.py
@@ -157,7 +157,11 @@ def generate_dims_coords(
         dim_name = dims[idx]
         if dim_name not in coords:
             coords[dim_name] = np.arange(index_origin, dim_len + index_origin)
-    coords = {key: coord for key, coord in coords.items() if any(key == dim for dim in dims)}
+    coords = {
+        key: coord
+        for key, coord in coords.items()
+        if any(key == dim for dim in dims + default_dims)
+    }
     return dims, coords
 
 

--- a/arviz/tests/base_tests/test_data.py
+++ b/arviz/tests/base_tests/test_data.py
@@ -150,6 +150,26 @@ def test_dims_coords():
     assert len(coords["x_dim_2"]) == 5
 
 
+def test_dims_coords_default_dims():
+    shape = 4, 7
+    var_name = "x"
+    dims, coords = generate_dims_coords(
+        shape,
+        var_name,
+        dims=["dim1", "dim2"],
+        coords={"chain": ["a", "b", "c"]},
+        default_dims=["chain", "draw"],
+    )
+    assert "dim1" in dims
+    assert "dim2" in dims
+    assert "chain" not in dims
+    assert "draw" not in dims
+    assert len(coords["dim1"]) == 4
+    assert len(coords["dim2"]) == 7
+    assert len(coords["chain"]) == 3
+    assert "draw" not in coords
+
+
 def test_dims_coords_extra_dims():
     shape = 4, 20
     var_name = "x"


### PR DESCRIPTION
## Description
Currently if coordinate values are provided for "default dims" they are ignored.
This is an issue for example in pymc where posterior and posterior predictive are
separate sampling steps and you can choose to thin the posterior if generating
posterior predictive samples is expensive as it prevents the original
draw/chain ids to be preserved as coordinate values of the posterior predictive.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)
