### PR TITLE
fix min_ess use in relative ess evolution plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Fix R2 implementation ([1666](https://github.com/arviz-devs/arviz/pull/1666))
 * Added warning message in `plot_dist_comparison()` in case subplots go over the limit ([1688](https://github.com/arviz-devs/arviz/pull/1688))
 * Fix coord value ignoring for default dims ([2001](https://github.com/arviz-devs/arviz/pull/2001))
+* Fix min_ess usage in plot_ess ([2002](https://github.com/arviz-devs/arviz/pull/2002))
 
 ### Deprecation
 

--- a/arviz/plots/backends/bokeh/essplot.py
+++ b/arviz/plots/backends/bokeh/essplot.py
@@ -52,6 +52,13 @@ def plot_ess(
 
     (figsize, *_, _linewidth, _markersize) = _scale_fig_size(figsize, textsize, rows, cols)
 
+    if hline_kwargs is None:
+        hline_kwargs = {}
+    hline_kwargs.setdefault("line_color", "red")
+    hline_kwargs.setdefault("line_width", 3)
+    hline_kwargs.setdefault("line_dash", "dashed")
+    hline_kwargs.setdefault("line_alpha", 1)
+
     if ax is None:
         ax = create_axes_grid(
             len(plotters),
@@ -134,16 +141,17 @@ def plot_ess(
 
             ax_.renderers.append(hline)
 
-        hline = Span(
-            location=400 / n_samples if relative else min_ess,
-            dimension="width",
-            line_color="red",
-            line_width=3,
-            line_dash="dashed",
-            line_alpha=1.0,
-        )
+        if relative and kind == "evolution":
+            thin_xdata = np.linspace(xdata.min(), xdata.max(), 100)
+            ax_.line(thin_xdata, min_ess/thin_xdata, **hline_kwargs)
+        else:
+            hline = Span(
+                location=min_ess / n_samples if relative else min_ess,
+                dimension="width",
+                **hline_kwargs
+            )
 
-        ax_.renderers.append(hline)
+            ax_.renderers.append(hline)
 
         if kind == "evolution":
             legend = Legend(

--- a/arviz/plots/backends/bokeh/essplot.py
+++ b/arviz/plots/backends/bokeh/essplot.py
@@ -143,12 +143,12 @@ def plot_ess(
 
         if relative and kind == "evolution":
             thin_xdata = np.linspace(xdata.min(), xdata.max(), 100)
-            ax_.line(thin_xdata, min_ess/thin_xdata, **hline_kwargs)
+            ax_.line(thin_xdata, min_ess / thin_xdata, **hline_kwargs)
         else:
             hline = Span(
                 location=min_ess / n_samples if relative else min_ess,
                 dimension="width",
-                **hline_kwargs
+                **hline_kwargs,
             )
 
             ax_.renderers.append(hline)

--- a/arviz/plots/backends/matplotlib/essplot.py
+++ b/arviz/plots/backends/matplotlib/essplot.py
@@ -142,7 +142,12 @@ def plot_ess(
                 **text_kwargs,
             )
 
-        ax_.axhline(400 / n_samples if relative else min_ess, **hline_kwargs)
+        if relative and kind == "evolution":
+            thin_xdata = np.linspace(xdata.min(), xdata.max(), 100)
+            ax_.plot(thin_xdata, min_ess/thin_xdata, **hline_kwargs)
+        else:
+            hline = min_ess / n_samples if relative else min_ess
+            ax_.axhline(hline, **hline_kwargs)
 
         ax_.set_title(
             labeller.make_label_vert(var_name, selection, isel), fontsize=titlesize, wrap=True

--- a/arviz/plots/backends/matplotlib/essplot.py
+++ b/arviz/plots/backends/matplotlib/essplot.py
@@ -144,7 +144,7 @@ def plot_ess(
 
         if relative and kind == "evolution":
             thin_xdata = np.linspace(xdata.min(), xdata.max(), 100)
-            ax_.plot(thin_xdata, min_ess/thin_xdata, **hline_kwargs)
+            ax_.plot(thin_xdata, min_ess / thin_xdata, **hline_kwargs)
         else:
             hline = min_ess / n_samples if relative else min_ess
             ax_.axhline(hline, **hline_kwargs)

--- a/arviz/plots/essplot.py
+++ b/arviz/plots/essplot.py
@@ -76,7 +76,9 @@ def plot_ess(
     extra_methods: bool, optional
         Plot mean and sd ESS as horizontal lines. Not taken into account in evolution kind
     min_ess: int
-        Minimum number of ESS desired.
+        Minimum number of ESS desired. If ``relative=True`` the line is plotted at
+        ``min_ess / n_samples`` for local and quantile kinds and as a curve following
+        the ``min_ess / n`` dependency in evolution kind.
     labeller : labeller instance, optional
         Class providing the method ``make_label_vert`` to generate the labels in the plot titles.
         Read the :ref:`label_guide` for more details and usage examples.
@@ -91,7 +93,10 @@ def plot_ess(
         for extra methods lines labels. It accepts the additional
         key ``x`` to set ``xy=(text_kwargs["x"], mcse)``
     hline_kwargs: dict, optional
-        kwargs passed to ax.axhline for the horizontal minimum ESS line.
+        kwargs passed to :func:`~matplotlib.axes.Axes.axhline` or to :class:`~bokeh.models.Span`
+        depending on the backend for the horizontal minimum ESS line.
+        For relative ess evolution plots the kwargs are passed to
+        :func:`~matplotlib.axes.Axes.plot` or to :class:`~bokeh.plotting.figure.line`
     rug_kwargs: dict
         kwargs passed to rug plot.
     backend: str, optional

--- a/arviz/tests/base_tests/test_plots_bokeh.py
+++ b/arviz/tests/base_tests/test_plots_bokeh.py
@@ -409,7 +409,7 @@ def test_plot_energy_bad(models):
         {},
         {"var_names": ["theta"], "relative": True, "color": "r"},
         {"coords": {"school": slice(4)}, "n_points": 10},
-        {"min_ess": 600, "hline_kwargs": {"color": "r"}},
+        {"min_ess": 600, "hline_kwargs": {"line_color": "red"}},
     ],
 )
 @pytest.mark.parametrize("kind", ["local", "quantile", "evolution"])


### PR DESCRIPTION
## Description
I like to explain why I end up working in a PR in its description, so here goes today's story. I was trying different cut offs with `min_ess` and decided to try the relative ess view too and I realized there min_ess was ignored and the value was hard coded to 400. Once I got to fix that I ended up fixing the threshold line for the relative ess evolution view and their kwargs in bokeh too, mostly due to lack of self control.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] New features are properly documented (with an example if appropriate)?
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)
