### PR TITLE
remove plot_joint from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ python setup.py install
   </td>
 
   <td>
-  <a href="https://arviz-devs.github.io/arviz/examples/plot_joint.html">
+  <a href="https://arviz-devs.github.io/arviz/examples/plot_dot.html">
   <img alt="Joint plot"
-  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_static/plot_joint_thumb.png" />
+  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_static/plot_dot_thumb.png" />
   </a>
   </td>
 

--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -250,7 +250,7 @@ def plot_kde(
     """
     if isinstance(values, xr.Dataset):
         raise ValueError(
-            "Xarray dataset object detected.Use plot_posterior, plot_density, plot_joint"
+            "Xarray dataset object detected.Use plot_posterior, plot_density"
             "or plot_pair instead of plot_kde"
         )
     if isinstance(values, InferenceData):

--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -140,11 +140,6 @@ def plot_pair(
     -------
     axes: matplotlib axes or bokeh figures
 
-    See Also
-    --------
-    plot_joint : Plot a scatter or hexbin of two variables with their
-                 respective marginals distributions.
-
     Examples
     --------
     KDE Pair Plot

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -183,9 +183,9 @@ If you use ArviZ and want to **cite** it please use |JOSS|. Here is the citation
             </a>
             </div>
             <div class="col">
-            <a href="examples/plot_joint.html">
+            <a href="examples/plot_dot.html">
             <div class="img-thumbnail">
-                <img src="_static/plot_joint_thumb.png">
+                <img src="_static/plot_dot_thumb.png">
             </div>
             </a>
             </div>


### PR DESCRIPTION
We remove plot_joint some time ago, but we forgot to clean references to it.