### PR TITLE
Smooth weights with psislw even for low shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### New features
 
 ### Maintenance and fixes
+* `psislw` now smooths log-weights even when shape is lower than `1/3`([2011](https://github.com/arviz-devs/arviz/pull/2011))
 
 ### Deprecation
 

--- a/arviz/tests/base_tests/test_stats.py
+++ b/arviz/tests/base_tests/test_stats.py
@@ -534,6 +534,7 @@ def test_psislw(centered_eight):
     log_likelihood = log_likelihood.stack(__sample__=("chain", "draw"))
     assert_allclose(pareto_k, psislw(-log_likelihood, 0.7)[1])
 
+
 def test_psislw_smooths_for_low_k():
     # check that log-weights are smoothed even when k < 1/3
     # https://github.com/arviz-devs/arviz/issues/2010

--- a/arviz/tests/base_tests/test_stats.py
+++ b/arviz/tests/base_tests/test_stats.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_almost_equal, assert_array_equal
+from scipy.special import logsumexp
 from scipy.stats import linregress
 from xarray import DataArray, Dataset
 
@@ -532,6 +533,15 @@ def test_psislw(centered_eight):
     log_likelihood = get_log_likelihood(centered_eight)
     log_likelihood = log_likelihood.stack(__sample__=("chain", "draw"))
     assert_allclose(pareto_k, psislw(-log_likelihood, 0.7)[1])
+
+def test_psislw_smooths_for_low_k():
+    # check that log-weights are smoothed even when k < 1/3
+    # https://github.com/arviz-devs/arviz/issues/2010
+    rng = np.random.default_rng(44)
+    x = rng.normal(size=100)
+    x_smoothed, k = psislw(x.copy())
+    assert k < 1 / 3
+    assert not np.allclose(x - logsumexp(x), x_smoothed)
 
 
 @pytest.mark.parametrize("probs", [True, False])


### PR DESCRIPTION
## Description

Fixes #2010 by removing the `k_min` threshold below which the tail weights were not smoothed. Now these weights are smoothed unless `k` is `nan` or infinite (indicating failure to fit GPD).

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [ ] New features are properly documented (with an example if appropriate)?
- [x] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)