### PR TITLE
plot_hdi: add exception if `x` is type `np.datetime64` and `smooth=True`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 ### Maintenance and fixes
+* Add exception in `az.plot_hdi` for `x` of type `np.datetime64` and `smooth=True` ([2016](https://github.com/arviz-devs/arviz/pull/2016))
 
 ### Deprecation
 

--- a/arviz/plots/hdiplot.py
+++ b/arviz/plots/hdiplot.py
@@ -164,6 +164,9 @@ def plot_hdi(
         raise TypeError(msg.format(x_shape, hdi_shape))
 
     if smooth:
+        if isinstance(x[0], np.datetime64):
+            raise TypeError("Cannot deal with x as type datetime. Recommend setting smooth=False.")
+
         if smooth_kwargs is None:
             smooth_kwargs = {}
         smooth_kwargs.setdefault("window_length", 55)

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -148,18 +148,8 @@ def test_plot_density_discrete(discrete_model):
 
 def test_plot_density_no_subset():
     """Test plot_density works when variables are not subset of one another (#1093)."""
-    model_ab = from_dict(
-        {
-            "a": np.random.normal(size=200),
-            "b": np.random.normal(size=200),
-        }
-    )
-    model_bc = from_dict(
-        {
-            "b": np.random.normal(size=200),
-            "c": np.random.normal(size=200),
-        }
-    )
+    model_ab = from_dict({"a": np.random.normal(size=200), "b": np.random.normal(size=200),})
+    model_bc = from_dict({"b": np.random.normal(size=200), "c": np.random.normal(size=200),})
     axes = plot_density([model_ab, model_bc])
     assert axes.size == 3
 
@@ -169,18 +159,8 @@ def test_plot_density_nonstring_varnames():
     rv1 = TestRandomVariable("a")
     rv2 = TestRandomVariable("b")
     rv3 = TestRandomVariable("c")
-    model_ab = from_dict(
-        {
-            rv1: np.random.normal(size=200),
-            rv2: np.random.normal(size=200),
-        }
-    )
-    model_bc = from_dict(
-        {
-            rv2: np.random.normal(size=200),
-            rv3: np.random.normal(size=200),
-        }
-    )
+    model_ab = from_dict({rv1: np.random.normal(size=200), rv2: np.random.normal(size=200),})
+    model_bc = from_dict({rv2: np.random.normal(size=200), rv3: np.random.normal(size=200),})
     axes = plot_density([model_ab, model_bc])
     assert axes.size == 3
 
@@ -246,12 +226,10 @@ def test_plot_trace(models, kwargs):
 
 
 @pytest.mark.parametrize(
-    "compact",
-    [True, False],
+    "compact", [True, False],
 )
 @pytest.mark.parametrize(
-    "combined",
-    [True, False],
+    "combined", [True, False],
 )
 def test_plot_trace_legend(compact, combined):
     idata = load_arviz_data("rugby")
@@ -1192,6 +1170,12 @@ def test_plot_hdi_dataset_error(models):
         plot_hdi(np.arange(8), hdi_data=hdi_data)
 
 
+def test_plot_hdi_datetime_error(models):
+    """Check x as datetime raises an error."""
+    with pytest.raises(TypeError, match="Cannot deal with x as type datetime."):
+        plot_hdi(np.arange(start="2022-01-01", stop="2022-01-09", dtype=np.datetime64))
+
+
 @pytest.mark.parametrize("limits", [(-10.0, 10.0), (-5, 5), (None, None)])
 def test_kde_scipy(limits):
     """
@@ -1576,10 +1560,7 @@ def test_plot_dist_comparison(models, kwargs):
 
 def test_plot_dist_comparison_different_vars():
     data = from_dict(
-        posterior={
-            "x": np.random.randn(4, 100, 30),
-        },
-        prior={"x_hat": np.random.randn(4, 100, 30)},
+        posterior={"x": np.random.randn(4, 100, 30),}, prior={"x_hat": np.random.randn(4, 100, 30)},
     )
     with pytest.raises(KeyError):
         plot_dist_comparison(data, var_names="x")
@@ -1595,9 +1576,7 @@ def test_plot_dist_comparison_combinedims(models):
 
 def test_plot_dist_comparison_different_vars_combinedims():
     data = from_dict(
-        posterior={
-            "x": np.random.randn(4, 100, 30),
-        },
+        posterior={"x": np.random.randn(4, 100, 30),},
         prior={"x_hat": np.random.randn(4, 100, 30)},
         dims={"x": ["3rd_dim"], "x_hat": ["3rd_dim"]},
     )
@@ -1635,11 +1614,7 @@ def test_plot_bpv_discrete():
     "kwargs",
     [
         {},
-        {
-            "binwidth": 0.5,
-            "stackratio": 2,
-            "nquantiles": 20,
-        },
+        {"binwidth": 0.5, "stackratio": 2, "nquantiles": 20,},
         {"point_interval": True},
         {
             "point_interval": True,
@@ -1672,12 +1647,7 @@ def test_plot_dot(continuous_model, kwargs):
     "kwargs",
     [
         {"rotated": True},
-        {
-            "point_interval": True,
-            "rotated": True,
-            "dotcolor": "grey",
-            "binwidth": 0.5,
-        },
+        {"point_interval": True, "rotated": True, "dotcolor": "grey", "binwidth": 0.5,},
         {
             "rotated": True,
             "point_interval": True,
@@ -1781,12 +1751,7 @@ def test_plot_lm_multidim(multidim_models):
 
 
 @pytest.mark.parametrize(
-    "val_err_kwargs",
-    [
-        {},
-        {"kind_pp": "bad_kind"},
-        {"kind_model": "bad_kind"},
-    ],
+    "val_err_kwargs", [{}, {"kind_pp": "bad_kind"}, {"kind_model": "bad_kind"},],
 )
 def test_plot_lm_valueerror(multidim_models, val_err_kwargs):
     """Test error plot_dim gets no value for multidim data and wrong value in kind_... args."""
@@ -1796,11 +1761,7 @@ def test_plot_lm_valueerror(multidim_models, val_err_kwargs):
 
 
 @pytest.mark.parametrize(
-    "warn_kwargs",
-    [
-        {"y_hat": "bad_name"},
-        {"y_model": "bad_name"},
-    ],
+    "warn_kwargs", [{"y_hat": "bad_name"}, {"y_model": "bad_name"},],
 )
 def test_plot_lm_warning(models, warn_kwargs):
     """Test Warning when needed groups or variables are not there in idata."""
@@ -1909,10 +1870,7 @@ def test_plot_ts_multidim(kwargs):
         observed_data=data,
         posterior_predictive=posterior_predictive,
         constant_data=const_data,
-        dims={
-            "y": ["dim1", "dim2"],
-            "z": ["holdout_dim1", "holdout_dim2"],
-        },
+        dims={"y": ["dim1", "dim2"], "z": ["holdout_dim1", "holdout_dim2"],},
         coords={
             "dim1": range(ndim1),
             "dim2": range(ndim2),

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -148,8 +148,18 @@ def test_plot_density_discrete(discrete_model):
 
 def test_plot_density_no_subset():
     """Test plot_density works when variables are not subset of one another (#1093)."""
-    model_ab = from_dict({"a": np.random.normal(size=200), "b": np.random.normal(size=200),})
-    model_bc = from_dict({"b": np.random.normal(size=200), "c": np.random.normal(size=200),})
+    model_ab = from_dict(
+        {
+            "a": np.random.normal(size=200),
+            "b": np.random.normal(size=200),
+        }
+    )
+    model_bc = from_dict(
+        {
+            "b": np.random.normal(size=200),
+            "c": np.random.normal(size=200),
+        }
+    )
     axes = plot_density([model_ab, model_bc])
     assert axes.size == 3
 
@@ -159,8 +169,18 @@ def test_plot_density_nonstring_varnames():
     rv1 = TestRandomVariable("a")
     rv2 = TestRandomVariable("b")
     rv3 = TestRandomVariable("c")
-    model_ab = from_dict({rv1: np.random.normal(size=200), rv2: np.random.normal(size=200),})
-    model_bc = from_dict({rv2: np.random.normal(size=200), rv3: np.random.normal(size=200),})
+    model_ab = from_dict(
+        {
+            rv1: np.random.normal(size=200),
+            rv2: np.random.normal(size=200),
+        }
+    )
+    model_bc = from_dict(
+        {
+            rv2: np.random.normal(size=200),
+            rv3: np.random.normal(size=200),
+        }
+    )
     axes = plot_density([model_ab, model_bc])
     assert axes.size == 3
 
@@ -226,10 +246,12 @@ def test_plot_trace(models, kwargs):
 
 
 @pytest.mark.parametrize(
-    "compact", [True, False],
+    "compact",
+    [True, False],
 )
 @pytest.mark.parametrize(
-    "combined", [True, False],
+    "combined",
+    [True, False],
 )
 def test_plot_trace_legend(compact, combined):
     idata = load_arviz_data("rugby")
@@ -1563,7 +1585,10 @@ def test_plot_dist_comparison(models, kwargs):
 
 def test_plot_dist_comparison_different_vars():
     data = from_dict(
-        posterior={"x": np.random.randn(4, 100, 30),}, prior={"x_hat": np.random.randn(4, 100, 30)},
+        posterior={
+            "x": np.random.randn(4, 100, 30),
+        },
+        prior={"x_hat": np.random.randn(4, 100, 30)},
     )
     with pytest.raises(KeyError):
         plot_dist_comparison(data, var_names="x")
@@ -1579,7 +1604,9 @@ def test_plot_dist_comparison_combinedims(models):
 
 def test_plot_dist_comparison_different_vars_combinedims():
     data = from_dict(
-        posterior={"x": np.random.randn(4, 100, 30),},
+        posterior={
+            "x": np.random.randn(4, 100, 30),
+        },
         prior={"x_hat": np.random.randn(4, 100, 30)},
         dims={"x": ["3rd_dim"], "x_hat": ["3rd_dim"]},
     )
@@ -1617,7 +1644,11 @@ def test_plot_bpv_discrete():
     "kwargs",
     [
         {},
-        {"binwidth": 0.5, "stackratio": 2, "nquantiles": 20,},
+        {
+            "binwidth": 0.5,
+            "stackratio": 2,
+            "nquantiles": 20,
+        },
         {"point_interval": True},
         {
             "point_interval": True,
@@ -1650,7 +1681,12 @@ def test_plot_dot(continuous_model, kwargs):
     "kwargs",
     [
         {"rotated": True},
-        {"point_interval": True, "rotated": True, "dotcolor": "grey", "binwidth": 0.5,},
+        {
+            "point_interval": True,
+            "rotated": True,
+            "dotcolor": "grey",
+            "binwidth": 0.5,
+        },
         {
             "rotated": True,
             "point_interval": True,
@@ -1754,7 +1790,12 @@ def test_plot_lm_multidim(multidim_models):
 
 
 @pytest.mark.parametrize(
-    "val_err_kwargs", [{}, {"kind_pp": "bad_kind"}, {"kind_model": "bad_kind"},],
+    "val_err_kwargs",
+    [
+        {},
+        {"kind_pp": "bad_kind"},
+        {"kind_model": "bad_kind"},
+    ],
 )
 def test_plot_lm_valueerror(multidim_models, val_err_kwargs):
     """Test error plot_dim gets no value for multidim data and wrong value in kind_... args."""
@@ -1764,7 +1805,11 @@ def test_plot_lm_valueerror(multidim_models, val_err_kwargs):
 
 
 @pytest.mark.parametrize(
-    "warn_kwargs", [{"y_hat": "bad_name"}, {"y_model": "bad_name"},],
+    "warn_kwargs",
+    [
+        {"y_hat": "bad_name"},
+        {"y_model": "bad_name"},
+    ],
 )
 def test_plot_lm_warning(models, warn_kwargs):
     """Test Warning when needed groups or variables are not there in idata."""
@@ -1873,7 +1918,10 @@ def test_plot_ts_multidim(kwargs):
         observed_data=data,
         posterior_predictive=posterior_predictive,
         constant_data=const_data,
-        dims={"y": ["dim1", "dim2"], "z": ["holdout_dim1", "holdout_dim2"],},
+        dims={
+            "y": ["dim1", "dim2"],
+            "z": ["holdout_dim1", "holdout_dim2"],
+        },
         coords={
             "dim1": range(ndim1),
             "dim2": range(ndim2),

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -1172,9 +1172,11 @@ def test_plot_hdi_dataset_error(models):
 
 def test_plot_hdi_datetime_error(models):
     """Check x as datetime raises an error."""
-    y_data = np.random.normal(2 + x_data * 0.5, 0.5, (1, 200, 100))
+    x_data = np.arange(start="2022-01-01", stop="2022-03-01", dtype=np.datetime64)
+    y_data = np.random.normal(0, 5, (1, 200, x_data.shape[0]))
+    hdi_data = hdi(y_data)
     with pytest.raises(TypeError, match="Cannot deal with x as type datetime."):
-        plot_hdi(np.arange(start="2022-01-01", stop="2022-01-09", dtype=np.datetime64), y=y_data)
+        plot_hdi(x=x_data, y=y_data, hdi_data=hdi_data)
 
 
 @pytest.mark.parametrize("limits", [(-10.0, 10.0), (-5, 5), (None, None)])

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -1172,8 +1172,9 @@ def test_plot_hdi_dataset_error(models):
 
 def test_plot_hdi_datetime_error(models):
     """Check x as datetime raises an error."""
+    y_data = np.random.normal(2 + x_data * 0.5, 0.5, (1, 200, 100))
     with pytest.raises(TypeError, match="Cannot deal with x as type datetime."):
-        plot_hdi(np.arange(start="2022-01-01", stop="2022-01-09", dtype=np.datetime64))
+        plot_hdi(np.arange(start="2022-01-01", stop="2022-01-09", dtype=np.datetime64), y=y_data)
 
 
 @pytest.mark.parametrize("limits", [(-10.0, 10.0), (-5, 5), (None, None)])

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -1170,7 +1170,7 @@ def test_plot_hdi_dataset_error(models):
         plot_hdi(np.arange(8), hdi_data=hdi_data)
 
 
-def test_plot_hdi_datetime_error(models):
+def test_plot_hdi_datetime_error():
     """Check x as datetime raises an error."""
     x_data = np.arange(start="2022-01-01", stop="2022-03-01", dtype=np.datetime64)
     y_data = np.random.normal(0, 5, (1, 200, x_data.shape[0]))


### PR DESCRIPTION
In #1968 I pointed out that `az.plot_hdi` failed if `x` was of type `datetime` when `smooth=True`. This PR adds an exception to hopefully make this easier for a user to work out what is going wrong. 

FYI this is my first PR to `arviz`, so apologies if I've missed some steps.
