### PR TITLE
fix mistake in baselabeller that breaks novarlabeller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Maintenance and fixes
 * `psislw` now smooths log-weights even when shape is lower than `1/3`([2011](https://github.com/arviz-devs/arviz/pull/2011))
 * Fixes `from_cmdstanpy`,  handles parameter vectors of length 1 ([2023](https://github.com/arviz-devs/arviz/pull/2023))
+* Fix typo in `BaseLabeller` that broke `NoVarLabeller` ([2018](https://github.com/arviz-devs/arviz/pull/2018))
 
 ### Deprecation
 

--- a/arviz/labels.py
+++ b/arviz/labels.py
@@ -118,7 +118,7 @@ class BaseLabeller:
         sel_str = self.sel_to_str(sel, isel)
         if not sel_str:
             return var_name_str
-        if var_name is None:
+        if var_name_str is None:
             return sel_str
         return f"{var_name_str}[{sel_str}]"
 


### PR DESCRIPTION
## Description
Fix mistake in make_label_flat of baselabeller that broke novarlabeller.
No tests added as there are no tests yet, there is already an issue on this #1574 

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Does the PR follow [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format?
