### PR TITLE
Fix BASE_FMT text to clearly specify sample size

### DIFF
--- a/arviz/stats/stats_utils.py
+++ b/arviz/stats/stats_utils.py
@@ -439,7 +439,8 @@ def get_log_likelihood(idata, var_name=None):
         return log_likelihood
 
 
-BASE_FMT = """Computed from {{n_samples}} samples and {{n_points}} points log-likelihood matrix.
+BASE_FMT = """Computed from {{n_samples}} posterior samples and \
+{{n_points}} observations log-likelihood matrix.
 
 {{0:{0}}} Estimate       SE
 {{scale}}_{{kind}} {{1:8.2f}}  {{2:7.2f}}

--- a/arviz/stats/stats_utils.py
+++ b/arviz/stats/stats_utils.py
@@ -439,7 +439,7 @@ def get_log_likelihood(idata, var_name=None):
         return log_likelihood
 
 
-BASE_FMT = """Computed from {{n_samples}} by {{n_points}} log-likelihood matrix
+BASE_FMT = """Computed from {{n_samples}} samples and {{n_points}} points log-likelihood matrix.
 
 {{0:{0}}} Estimate       SE
 {{scale}}_{{kind}} {{1:8.2f}}  {{2:7.2f}}


### PR DESCRIPTION
## Description
Based on issue #2019 
This PR fixes the BASE_FMT text so that it explicitly states the number of samples and number of points. For instance, instead of `Computed from 4000 by 262 log-likelihood matrix` the message should read `Computed from 4000 samples and 262 points log-likelihood matrix`
<!--
Thank you so much for your PR! To help us review your contribution, please consider the following points:

- The PR title should summarize the changes, for example "Add new group argument for the pair plot".
  Avoid non-descriptive titles such as "Addresses issue #348".

- The description should provide at least 1-2 sentences describing the pull request in detail and
  link to any relevant issues.

- Please prefix the title of incomplete contributions with [WIP] (to indicate a work in
  progress). WIPs may be useful to (1) indicate you are working on something to avoid
  duplicated work, (2) request broad review of functionality or API, or (3) seek collaborators. -->

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Code style  correct (follows pylint and black guidelines)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
