### PR TITLE
copy kwargs to avoid modifying provided ones

### DIFF
--- a/arviz/plots/kdeplot.py
+++ b/arviz/plots/kdeplot.py
@@ -7,7 +7,7 @@ import xarray as xr
 from ..data import InferenceData
 from ..rcparams import rcParams
 from ..stats.density_utils import _fast_kde_2d, kde, _find_hdi_contours
-from .plot_utils import get_plotting_function
+from .plot_utils import get_plotting_function, _init_kwargs_dict
 
 
 def plot_kde(
@@ -293,27 +293,23 @@ def plot_kde(
             contour_level_list = [0] + list(contour_levels) + [density.max()]
 
             # Add keyword arguments to contour, contourf
-            if contour_kwargs is None:
-                contour_kwargs = {"levels": contour_level_list}
-            else:
-                if "levels" in contour_kwargs:
-                    warnings.warn(
-                        "Both 'levels' in contour_kwargs and 'hdi_probs' have been specified."
-                        "Using 'hdi_probs' in favor of 'levels'.",
-                        UserWarning,
-                    )
-                contour_kwargs["levels"] = contour_level_list
+            contour_kwargs = _init_kwargs_dict(contour_kwargs)
+            if "levels" in contour_kwargs:
+                warnings.warn(
+                    "Both 'levels' in contour_kwargs and 'hdi_probs' have been specified."
+                    "Using 'hdi_probs' in favor of 'levels'.",
+                    UserWarning,
+                )
+            contour_kwargs["levels"] = contour_level_list
 
-            if contourf_kwargs is None:
-                contourf_kwargs = {"levels": contour_level_list}
-            else:
-                if "levels" in contourf_kwargs:
-                    warnings.warn(
-                        "Both 'levels' in contourf_kwargs and 'hdi_probs' have been specified."
-                        "Using 'hdi_probs' in favor of 'levels'.",
-                        UserWarning,
-                    )
-                contourf_kwargs["levels"] = contour_level_list
+            contourf_kwargs = _init_kwargs_dict(contourf_kwargs)
+            if "levels" in contourf_kwargs:
+                warnings.warn(
+                    "Both 'levels' in contourf_kwargs and 'hdi_probs' have been specified."
+                    "Using 'hdi_probs' in favor of 'levels'.",
+                    UserWarning,
+                )
+            contourf_kwargs["levels"] = contour_level_list
 
         lower, upper, density_q = [None] * 3
 


### PR DESCRIPTION
I noticed that when overlaying plots (in which case I often use the same kwargs for all of them) the kwargs I was passing were being modified to have the `levels` key. The result was still right because hdi_probs takes preference, but it should not happen as it would result in very unintuitive results if one were to forget hdi_probs in the 2nd or 3rd plot.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Does the PR follow [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format?
- [x] Is the code style correct (follows pylint and black guidelines)?
- [ ] Is the fix listed in the [Maintenance and fixes](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#maintenance-and-fixes)
      section of the changelog?

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
