### PR TITLE
Make plot_compare easy to understand

### DIFF
--- a/arviz/plots/backends/bokeh/compareplot.py
+++ b/arviz/plots/backends/bokeh/compareplot.py
@@ -9,8 +9,8 @@ from . import backend_kwarg_defaults, create_axes_grid
 def plot_compare(
     ax,
     comp_df,
-    legend,
-    title,
+    legend,  # pylint: disable=unused-argument
+    title,  # pylint: disable=unused-argument
     figsize,
     plot_ic_diff,
     plot_standard_error,

--- a/arviz/plots/backends/bokeh/compareplot.py
+++ b/arviz/plots/backends/bokeh/compareplot.py
@@ -9,6 +9,8 @@ from . import backend_kwarg_defaults, create_axes_grid
 def plot_compare(
     ax,
     comp_df,
+    legend,
+    title,
     figsize,
     plot_ic_diff,
     plot_standard_error,

--- a/arviz/plots/backends/matplotlib/compareplot.py
+++ b/arviz/plots/backends/matplotlib/compareplot.py
@@ -84,7 +84,7 @@ def plot_compare(
     else:
         ax.set_yticks(yticks_pos[::2])
 
-    scale = comp_df[f"scale"][0]
+    scale = comp_df["scale"][0]
 
     if insample_dev:
         p_ic = comp_df[f"p_{information_criterion.split('_')[1]}"]

--- a/arviz/plots/backends/matplotlib/compareplot.py
+++ b/arviz/plots/backends/matplotlib/compareplot.py
@@ -8,6 +8,7 @@ from . import backend_kwarg_defaults, backend_show, create_axes_grid
 def plot_compare(
     ax,
     comp_df,
+    legend,
     figsize,
     plot_ic_diff,
     plot_standard_error,
@@ -41,12 +42,38 @@ def plot_compare(
     if ax is None:
         _, ax = create_axes_grid(1, backend_kwargs=backend_kwargs)
 
+    if plot_standard_error:
+        ax.errorbar(
+            x=comp_df[information_criterion],
+            y=yticks_pos[::2],
+            xerr=comp_df.se,
+            label="ELPD",
+            color=plot_kwargs.get("color_ic", "k"),
+            fmt=plot_kwargs.get("marker_ic", "o"),
+            mfc=plot_kwargs.get("marker_fc", "white"),
+            mew=linewidth,
+            lw=linewidth,
+        )
+    else:
+        ax.plot(
+            comp_df[information_criterion],
+            yticks_pos[::2],
+            label="ELPD",
+            color=plot_kwargs.get("color_ic", "k"),
+            marker=plot_kwargs.get("marker_ic", "o"),
+            mfc=plot_kwargs.get("marker_fc", "white"),
+            mew=linewidth,
+            lw=0,
+            zorder=3,
+        )
+
     if plot_ic_diff:
         ax.set_yticks(yticks_pos)
         ax.errorbar(
             x=comp_df[information_criterion].iloc[1:],
             y=yticks_pos[1::2],
             xerr=comp_df.dse[1:],
+            label="ELPD difference",
             color=plot_kwargs.get("color_dse", "grey"),
             fmt=plot_kwargs.get("marker_dse", "^"),
             mew=linewidth,
@@ -56,30 +83,9 @@ def plot_compare(
     else:
         ax.set_yticks(yticks_pos[::2])
 
-    if plot_standard_error:
-        ax.errorbar(
-            x=comp_df[information_criterion],
-            y=yticks_pos[::2],
-            xerr=comp_df.se,
-            color=plot_kwargs.get("color_ic", "k"),
-            fmt=plot_kwargs.get("marker_ic", "o"),
-            mfc="None",
-            mew=linewidth,
-            lw=linewidth,
-        )
-    else:
-        ax.plot(
-            comp_df[information_criterion],
-            yticks_pos[::2],
-            color=plot_kwargs.get("color_ic", "k"),
-            marker=plot_kwargs.get("marker_ic", "o"),
-            mfc="None",
-            mew=linewidth,
-            lw=0,
-        )
+    scale = comp_df[f"scale"][0]
 
     if insample_dev:
-        scale = comp_df[f"{information_criterion}_scale"][0]
         p_ic = comp_df[f"p_{information_criterion}"]
         if scale == "log":
             correction = p_ic
@@ -90,6 +96,7 @@ def plot_compare(
         ax.plot(
             comp_df[information_criterion] + correction,
             yticks_pos[::2],
+            label="In-sample ELPD",
             color=plot_kwargs.get("color_insample_dev", "k"),
             marker=plot_kwargs.get("marker_insample_dev", "o"),
             mew=linewidth,
@@ -102,13 +109,13 @@ def plot_compare(
         color=plot_kwargs.get("color_ls_min_ic", "grey"),
         lw=linewidth,
     )
+    if legend:
+        ax.legend(bbox_to_anchor=(1.01, 1), loc="upper left", ncol=1, fontsize=ax_labelsize)
 
-    scale_col = information_criterion + "_scale"
-    if scale_col in comp_df:
-        scale = comp_df[scale_col].iloc[0].capitalize()
-    else:
-        scale = "Deviance"
-    ax.set_xlabel(scale, fontsize=ax_labelsize)
+    if scale == "negative_log":
+        scale = "-log"
+
+    ax.set_xlabel(f"{information_criterion} ({scale})", fontsize=ax_labelsize)
     ax.set_yticklabels(yticks_labels)
     ax.set_ylim(-1 + step, 0 - step)
     ax.tick_params(labelsize=xt_labelsize)

--- a/arviz/plots/backends/matplotlib/compareplot.py
+++ b/arviz/plots/backends/matplotlib/compareplot.py
@@ -87,7 +87,6 @@ def plot_compare(
     scale = comp_df[f"scale"][0]
 
     if insample_dev:
-        print(information_criterion)
         p_ic = comp_df[f"p_{information_criterion.split('_')[1]}"]
         if scale == "log":
             correction = p_ic

--- a/arviz/plots/backends/matplotlib/compareplot.py
+++ b/arviz/plots/backends/matplotlib/compareplot.py
@@ -87,7 +87,8 @@ def plot_compare(
     scale = comp_df[f"scale"][0]
 
     if insample_dev:
-        p_ic = comp_df[f"p_{information_criterion}"]
+        print(information_criterion)
+        p_ic = comp_df[f"p_{information_criterion.split('_')[1]}"]
         if scale == "log":
             correction = p_ic
         elif scale == "negative_log":
@@ -115,7 +116,7 @@ def plot_compare(
 
     if title:
         ax.set_title(
-            f"Model comparison using the ELPD\n{'higher' if scale == 'log' else 'lower'} is better",
+            f"Model comparison\n{'higher' if scale == 'log' else 'lower'} is better",
             fontsize=ax_labelsize,
         )
 

--- a/arviz/plots/backends/matplotlib/compareplot.py
+++ b/arviz/plots/backends/matplotlib/compareplot.py
@@ -9,6 +9,7 @@ def plot_compare(
     ax,
     comp_df,
     legend,
+    title,
     figsize,
     plot_ic_diff,
     plot_standard_error,
@@ -112,10 +113,17 @@ def plot_compare(
     if legend:
         ax.legend(bbox_to_anchor=(1.01, 1), loc="upper left", ncol=1, fontsize=ax_labelsize)
 
+    if title:
+        ax.set_title(
+            f"Model comparison using the ELPD\n{'higher' if scale == 'log' else 'lower'} is better",
+            fontsize=ax_labelsize,
+        )
+
     if scale == "negative_log":
         scale = "-log"
 
     ax.set_xlabel(f"{information_criterion} ({scale})", fontsize=ax_labelsize)
+    ax.set_ylabel("ranked models", fontsize=ax_labelsize)
     ax.set_yticklabels(yticks_labels)
     ax.set_ylim(-1 + step, 0 - step)
     ax.tick_params(labelsize=xt_labelsize)

--- a/arviz/plots/compareplot.py
+++ b/arviz/plots/compareplot.py
@@ -1,5 +1,4 @@
 """Summary plot for model comparison."""
-from operator import le
 import numpy as np
 
 from ..labels import BaseLabeller
@@ -30,7 +29,7 @@ def plot_compare(
     Models are compared based on their expected log pointwise predictive density (ELPD),
     the ELPD is estimated either by Pareto smoothed importance sampling leave-one-out
     cross-validation (LOO) or using the widely applicable information criterion (WAIC).
-    We recommend LOO in line with the theory presented by Vehtari et al. (2016) available 
+    We recommend LOO in line with the work presented by Vehtari et al. (2016) available
     here: https://arxiv.org/abs/1507.04544.
 
     This plot is in the style of the one used in the book Statistical Rethinking by
@@ -43,7 +42,8 @@ def plot_compare(
         Result of the :func:`arviz.compare` method
     insample_dev : bool, optional
         Plot in-sample ELPD, that is the value of the information criteria without the
-        penalization given by the effective number of parameters (p_loo or p_waic). Defaults to False
+        penalization given by the effective number of parameters (p_loo or p_waic).
+        Defaults to False
     plot_standard_error : bool, optional
         Plot the standard error of the ELPD. Defaults to True
     plot_ic_diff : bool, optional

--- a/arviz/plots/compareplot.py
+++ b/arviz/plots/compareplot.py
@@ -24,7 +24,7 @@ def plot_compare(
     show=None,
 ):
     """
-    Summary plot for model comparison
+    Summary plot for model comparison.
 
     Models are compared based on their expected log pointwise predictive density (ELPD),
     the ELPD is estimated either by Pareto smoothed importance sampling leave-one-out

--- a/arviz/plots/compareplot.py
+++ b/arviz/plots/compareplot.py
@@ -29,8 +29,9 @@ def plot_compare(
 
     Models are compared based on their expected log pointwise predictive density (ELPD),
     the ELPD is estimated either by Pareto smoothed importance sampling leave-one-out
-    cross-validation (loo) or using the widely applicable information criterion (WAIC).
-    We recommend LOO.
+    cross-validation (LOO) or using the widely applicable information criterion (WAIC).
+    We recommend LOO in line with the theory presented by Vehtari et al. (2016) available 
+    here: https://arxiv.org/abs/1507.04544.
 
     This plot is in the style of the one used in the book Statistical Rethinking by
     Richard McElreath.Chapter 6 in the first edition or 7 in the second.

--- a/arviz/plots/compareplot.py
+++ b/arviz/plots/compareplot.py
@@ -14,6 +14,7 @@ def plot_compare(
     plot_ic_diff=True,
     order_by_rank=True,
     legend=True,
+    title=True,
     figsize=None,
     textsize=None,
     labeller=None,
@@ -53,6 +54,8 @@ def plot_compare(
         Add legend to figure. By default True.
     figsize : tuple, optional
         If None, size is (6, num of models) inches
+    title : bool:
+        Show a tittle with a description of how to interpret the plot. Defaults to True.
     textsize: float
         Text size scaling factor for labels, titles and lines. If None it will be autoscaled based
         on ``figsize``.
@@ -141,6 +144,7 @@ def plot_compare(
         ax=ax,
         comp_df=comp_df,
         legend=legend,
+        title=title,
         figsize=figsize,
         plot_ic_diff=plot_ic_diff,
         plot_standard_error=plot_standard_error,

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -65,7 +65,7 @@ def compare(
 
 
     The ELPD is estimated either by Pareto smoothed importance sampling leave-one-out
-    cross-validation (loo) or using the widely applicable information criterion (waic).
+    cross-validation (LOO) or using the widely applicable information criterion (WAIC).
     We recommend loo. Read more theory here - in a paper by some of the
     leading authorities on model comparison dx.doi.org/10.1111/1467-9868.00353
 
@@ -121,7 +121,7 @@ def compare(
         If `scale` is `deviance` or `negative_log` smaller values indicates
         higher out-of-sample predictive fit ("better" model).
     pIC: Estimated effective number of parameters.
-    elpd_diff: the difference in elpd for two models.
+    elpd_diff: The difference in ELPD between two models.
         If more than two models are compared, the difference is computed relative to the
         top-ranked model, that always has a elpd_diff of 0.
     weight: Relative weight for each model.
@@ -342,7 +342,7 @@ def _calculate_ics(
     ic: Optional[ICKeyword] = None,
     var_name: Optional[str] = None,
 ):
-    """Calculate loo or waic only if necessary.
+    """Calculate LOO or WAIC only if necessary.
 
     It always calls the ic function with ``pointwise=True``.
 

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -63,7 +63,6 @@ def compare(
 ):
     r"""Compare models based on  their expected log pointwise predictive density (ELPD).
 
-
     The ELPD is estimated either by Pareto smoothed importance sampling leave-one-out
     cross-validation (LOO) or using the widely applicable information criterion (WAIC).
     We recommend loo. Read more theory here - in a paper by some of the

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -157,8 +157,9 @@ def compare(
 
     See Also
     --------
-    loo : Compute the ELPD using the Pareto smoothed importance sampling Leave-one-out
-    cross-validation method.
+    loo :
+        Compute the ELPD using the Pareto smoothed importance sampling Leave-one-out
+        cross-validation method.
     waic : Compute the ELPD using the widely applicable information criterion.
     plot_compare : Summary plot for model comparison.
 

--- a/arviz/stats/stats_utils.py
+++ b/arviz/stats/stats_utils.py
@@ -496,7 +496,7 @@ class ELPDData(pd.Series):  # pylint: disable=too-many-ancestors
         """Alias to ``__str__``."""
         return self.__str__()
 
-    def copy(self, deep=True):
+    def copy(self, deep=True):  # pylint:disable=overridden-final-method
         """Perform a pandas deep copy of the ELPDData plus a copy of the stored data."""
         copied_obj = pd.Series.copy(self)
         for key in copied_obj.keys():

--- a/arviz/stats/stats_utils.py
+++ b/arviz/stats/stats_utils.py
@@ -496,7 +496,7 @@ class ELPDData(pd.Series):  # pylint: disable=too-many-ancestors
         """Alias to ``__str__``."""
         return self.__str__()
 
-    def copy(self, deep=True):  # pylint:disable=overridden-final-method
+    def copy(self, deep=True):
         """Perform a pandas deep copy of the ELPDData plus a copy of the stored data."""
         copied_obj = pd.Series.copy(self)
         for key in copied_obj.keys():

--- a/arviz/stats/stats_utils.py
+++ b/arviz/stats/stats_utils.py
@@ -462,12 +462,12 @@ class ELPDData(pd.Series):  # pylint: disable=too-many-ancestors
 
     def __str__(self):
         """Print elpd data in a user friendly way."""
-        kind = self.index[0]
+        kind = self.index[0].split("_")[1]
 
         if kind not in ("loo", "waic"):
             raise ValueError("Invalid ELPDData object")
 
-        scale_str = SCALE_DICT[self[f"{kind}_scale"]]
+        scale_str = SCALE_DICT[self["scale"]]
         padding = len(scale_str) + len(kind) + 1
         base = BASE_FMT.format(padding, padding - 2)
         base = base.format(

--- a/arviz/tests/base_tests/test_plots_bokeh.py
+++ b/arviz/tests/base_tests/test_plots_bokeh.py
@@ -339,12 +339,12 @@ def test_plot_compare_no_ic(models):
     model_compare = compare({"Model 1": models.model_1, "Model 2": models.model_2})
 
     # Drop column needed for plotting
-    model_compare = model_compare.drop("loo", axis=1)
+    model_compare = model_compare.drop("elpd_loo", axis=1)
     with pytest.raises(ValueError) as err:
         plot_compare(model_compare, backend="bokeh", show=False)
 
     assert "comp_df must contain one of the following" in str(err.value)
-    assert "['loo', 'waic']" in str(err.value)
+    assert "['elpd_loo', 'elpd_waic']" in str(err.value)
 
 
 def test_plot_ecdf_basic():

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -1127,7 +1127,7 @@ def test_plot_posterior_skipna_combinedims():
 
 
 @pytest.mark.parametrize(
-    "kwargs", [{"insample_dev": False}, {"plot_standard_error": False}, {"plot_ic_diff": False}]
+    "kwargs", [{"insample_dev": True}, {"plot_standard_error": False}, {"plot_ic_diff": False}]
 )
 def test_plot_compare(models, kwargs):
     model_compare = compare({"Model 1": models.model_1, "Model 2": models.model_2})

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -1141,12 +1141,12 @@ def test_plot_compare_no_ic(models):
     model_compare = compare({"Model 1": models.model_1, "Model 2": models.model_2})
 
     # Drop column needed for plotting
-    model_compare = model_compare.drop("loo", axis=1)
+    model_compare = model_compare.drop("elpd_loo", axis=1)
     with pytest.raises(ValueError) as err:
         plot_compare(model_compare)
 
     assert "comp_df must contain one of the following" in str(err.value)
-    assert "['loo', 'waic']" in str(err.value)
+    assert "['elpd_loo', 'elpd_waic']" in str(err.value)
 
 
 @pytest.mark.parametrize(

--- a/arviz/tests/base_tests/test_rcparams.py
+++ b/arviz/tests/base_tests/test_rcparams.py
@@ -280,10 +280,10 @@ def test_data_load():
 def test_stats_information_criterion(models):
     rcParams["stats.information_criterion"] = "waic"
     df_comp = compare({"model1": models.model_1, "model2": models.model_2})
-    assert "waic" in df_comp.columns
+    assert "elpd_waic" in df_comp.columns
     rcParams["stats.information_criterion"] = "loo"
     df_comp = compare({"model1": models.model_1, "model2": models.model_2})
-    assert "loo" in df_comp.columns
+    assert "elpd_loo" in df_comp.columns
 
 
 def test_http_type_request(monkeypatch):

--- a/arviz/tests/base_tests/test_stats.py
+++ b/arviz/tests/base_tests/test_stats.py
@@ -233,7 +233,7 @@ def test_compare_multiple_obs(multivariable_log_likelihood, centered_eight, non_
     }
     with pytest.raises(TypeError, match="several log likelihood arrays"):
         get_log_likelihood(compare_dict["problematic"])
-    with pytest.raises(TypeError, match="error in ic computation"):
+    with pytest.raises(TypeError, match="error in ELPD computation"):
         compare(compare_dict, ic=ic)
     assert compare(compare_dict, ic=ic, var_name="obs") is not None
 
@@ -248,8 +248,9 @@ def test_calculate_ics(centered_eight, non_centered_eight, ic):
     elpddata_out, _, _ = _calculate_ics(elpddata_dict, ic=ic)
     mixed_out, _, _ = _calculate_ics(mixed_dict, ic=ic)
     for model in idata_dict:
-        assert idata_out[model][ic] == elpddata_out[model][ic]
-        assert idata_out[model][ic] == mixed_out[model][ic]
+        ic_ = f"elpd_{ic}"
+        assert idata_out[model][ic_] == elpddata_out[model][ic_]
+        assert idata_out[model][ic_] == mixed_out[model][ic_]
         assert idata_out[model][f"p_{ic}"] == elpddata_out[model][f"p_{ic}"]
         assert idata_out[model][f"p_{ic}"] == mixed_out[model][f"p_{ic}"]
 
@@ -265,7 +266,7 @@ def test_calculate_ics_ic_override(centered_eight, non_centered_eight):
     with pytest.warns(UserWarning, match="precomputed elpddata: waic"):
         out_dict, _, ic = _calculate_ics(in_dict, ic="loo")
     assert ic == "waic"
-    assert out_dict["centered"]["waic"] == waic(centered_eight)["waic"]
+    assert out_dict["centered"]["elpd_waic"] == waic(centered_eight)["elpd_waic"]
 
 
 def test_summary_ndarray():
@@ -489,7 +490,7 @@ def test_loo(centered_eight, multidim_models, scale, multidim):
     assert loo_pointwise is not None
     assert "loo_i" in loo_pointwise
     assert "pareto_k" in loo_pointwise
-    assert "loo_scale" in loo_pointwise
+    assert "scale" in loo_pointwise
 
 
 def test_loo_one_chain(centered_eight):

--- a/arviz/tests/base_tests/test_stats_utils.py
+++ b/arviz/tests/base_tests/test_stats_utils.py
@@ -305,7 +305,7 @@ def test_get_log_likelihood_no_group():
 
 
 def test_elpd_data_error():
-    with pytest.raises(ValueError):
+    with pytest.raises(IndexError):
         repr(ELPDData(data=[0, 1, 2], index=["not IC", "se", "p"]))
 
 


### PR DESCRIPTION
This fixes #1989 

* Add a legend
* Make insample_dev False as default
* Add a label to the y-axis
* Make x-axis label clear, indicates what we are computing and the scale
* Add a title with a short description on how to interpret the plot. This is something we have discussed in the past to incorporate to ArviZ inspired by https://easystats.github.io/performance/index.html), in the future we could even have a global rcparams that turn this short guide on and off globally (or even have levels, beginner, intermedia, advanced)
* This also introduce changes in the names of the computed quantities, for example "elpd_loo" instead of just "loo". This is mainly to increase consistency with the loo R package. 
* Update the docstring a little. In the near future ArviZ is going to have an "educational" site with examples and recommendations on how to use and interpret arviz plots and diagnostics. Once that is ready the docstring will point to that.

~bokeh is not updated because at the moment I have problems displaying bokeh plots~

Old default 
![old_loo](https://user-images.githubusercontent.com/1338958/172727943-37ecd973-b39b-4f56-8563-33d0f538053e.png)


New default
![new_loo](https://user-images.githubusercontent.com/1338958/172727960-ef7c917e-10b3-45c1-afb5-c5cff65e9e1e.png)


Suggestions for the text in the plot and/or docstrings are more than welcome, @fonnesbeck, @yannmclatchie, @PabloGGaray. Maybe we should reduce the times ELPD is mentioned :-) 


update after discussion with @yannmclatchie :
What about this as the default, no legend and two axis one for the "raw ELPDs", the other for the differences?

![new_loo](https://user-images.githubusercontent.com/1338958/172905905-efd95a75-af82-496b-823f-ee8da2486d52.png)
