### PR TITLE
Correct a typo in allowed method in `compare`

### DIFF
--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -54,7 +54,7 @@ __all__ = [
 def compare(
     compare_dict: Mapping[str, InferenceData],
     ic: Optional[ICKeyword] = None,
-    method: Literal["stacking", "BB-pseudo-BMA", "pseudo-MA"] = "stacking",
+    method: Literal["stacking", "BB-pseudo-BMA", "pseudo-BMA"] = "stacking",
     b_samples: int = 1000,
     alpha: float = 1,
     seed=None,


### PR DESCRIPTION


## Description

It seems arviz allows `pseudo-BMA` instead of `pseudo-MA` as options, this PR corrects this typo.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [ ] New features are properly documented (with an example if appropriate)?
- [ ] Includes new or updated tests to cover the new feature
- [ ] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
