### PR TITLE
Modified main page of Contributing section of ArviZ python library website

### DIFF
--- a/doc/source/contributing/contributing_prs.md
+++ b/doc/source/contributing/contributing_prs.md
@@ -13,6 +13,8 @@ to ensure that any new contribution does not strongly overlap with existing
 functionality and open a "Feature Request" issue before starting to work
 on the new feature.
 
+(steps_before_working)=
+
 ## Steps before starting work
 Before starting work on a pull request double-check that no one else
 is working on the ticket in both issue tickets and pull requests.

--- a/doc/source/contributing/doc_toolchain.md
+++ b/doc/source/contributing/doc_toolchain.md
@@ -1,3 +1,4 @@
+(doc_toolchain)=
 # Documentation toolchain
 
 ArviZ documentation is built using a Python documentation tool, [Sphinx](https://www.sphinx-doc.org/en/master/).

--- a/doc/source/contributing/index.md
+++ b/doc/source/contributing/index.md
@@ -1,7 +1,7 @@
 (contributing_guide)=
 # Contributing to ArviZ
 ## Welcome
-Welcome to the [ArviZ](https://www.arviz.org/en/latest/) project! If you’re reading this guide, that probably means you’d like to get involved and start contributing to the project. ArviZ is a  multi-language open-source project that provides tools for exploratory analysis of Bayesian models.   The package includes functions for posterior analysis, data storage, sample diagnostics, model checking, and comparison.
+Welcome to the {doc}`ArviZ <arviz_org:index>` project! If you’re reading this guide, that probably means you’d like to get involved and start contributing to the project. ArviZ is a  multi-language open-source project that provides tools for exploratory analysis of Bayesian models.   The package includes functions for posterior analysis, data storage, sample diagnostics, model checking, and comparison.
 
 As a scientific, community-driven, open-source software project, we welcome contributions from interested individuals or groups. The guidelines specified in this document can help new contributors make their contributions compliant with the conventions of the ArviZ python library, and maximize the probability of such contributions being merged as quickly and as efficiently as possible.
 
@@ -16,35 +16,6 @@ Contact us on [Gitter](https://gitter.im/arviz-devs/community) if you want to co
 ## Contributing to ArviZ
 The most common way of contributing to the project is sending pull requests on the main [ArviZ Github repository](https://github.com/arviz-devs/arviz). You can contribute to ArviZ in the following ways:
 
-### Create an issue
-[Submit issues](https://github.com/arviz-devs/arviz/issues/new/choose) for existing bugs or desired enhancements. Check [Issue reports](https://arviz-devs.github.io/arviz/contributing/issue_reports.html) for details on how to write an issue.
-
-### Translate ArviZ website
-You can [translate](https://python.arviz.org/en/latest/contributing/translate.html#translate) our website to languages other than english. 
-
-### Review PRs
-{ref}`Review pull requests <review_prs>` to ensure that the contributions are well tested and documented. For example, you can check if the documentation renders correctly and has no typos or mistakes. 
-
-### Manage issues
-Helping to manage or triage the open issues can be a great contribution and a great opportunity to learn about the various areas of the project. You can [triage existing issues](https://arviz-devs.github.io/arviz/contributing/issue_triaging.html#issue-triaging) to make them clear and/or provide temporary workarounds for them. 
-
-### Write documentation
-You can contribute to ArviZ’s documentation by either creating new content or editing existing content. For instance, you can add new ArviZ examples. To get involved with the documentation:
-1. Familiarize yourself with the [documentation content structure](https://arviz-devs.github.io/arviz/contributing/content_structure.html) and the [tool chain](https://arviz-devs.github.io/arviz/contributing/doc_toolchain.html) involved in creating the website.
-2. Understand the basic workflow for opening a [pull request](https://arviz-devs.github.io/arviz/contributing/pr_tutorial.html) and [reviewing changes](https://arviz-devs.github.io/arviz/contributing/review_prs.html).
-3. Work on your content.
-4. {ref}`Build <sphinx_doc_build>` your documentation and preview the doc changes. 
-   
-### Support outreach initiatives
-Support ArviZ {ref}`outreach initiatives <oureach_contrib>` such as writing blog posts, case studies,  getting people to use ArviZ at your company or university, etc.
-
-### Make changes in the code
-Fix outstanding issues (bugs) in the existing codebase. The issue can range from low-level software bugs to high-level design problems. You can also add new features to the codebase or improve the existing functionality. To fix bugs or add new features, do the following:
-1. Familiarize yourself with the {ref}`guidelines <steps_before_working>` before starting your work.
-2. Understand the {ref}`development process <dev_summary>` and code conventions.
-3. Understand the basic workflow for opening a [pull request](https://arviz-devs.github.io/arviz/contributing/pr_tutorial.html) and [reviewing](https://arviz-devs.github.io/arviz/contributing/review_prs.html) changes.
-4. Review and test your code. 
-
 ```{toctree}
 :maxdepth: 2
 :caption: Contribution types
@@ -55,8 +26,39 @@ issue_triaging
 outreach
 review_prs
 contributing_prs
-pr_tutorial
+
 ```
+
+### Create an issue
+[Submit issues](https://github.com/arviz-devs/arviz/issues/new/choose) for existing bugs or desired enhancements. Check  {ref}`issue_reports <issue_reports>` for details on how to write an issue.
+
+### Translate ArviZ website
+You can {ref}`translate <translate>` our website to languages other than english. 
+
+### Review PRs
+{ref}`Review pull requests <review_prs>` to ensure that the contributions are well tested and documented. For example, you can check if the documentation renders correctly and has no typos or mistakes. 
+
+### Manage issues
+Helping to manage or triage the open issues can be a great contribution and a great opportunity to learn about the various areas of the project. You can {ref} `triage existing issues <issue_triaging>`to make them clear and/or provide temporary workarounds for them. 
+
+### Write documentation
+You can contribute to ArviZ’s documentation by either creating new content or editing existing content. For instance, you can add new ArviZ examples. To get involved with the documentation:
+1. Familiarize yourself with the  {ref}`documentation content structure <content_structure>` and the {ref}`tool chain <doc_toolchain>`] involved in creating the website.
+2. Understand the basic workflow for opening a {ref} `pull request <pr_tutorial>` and {ref}`reviewing changes <review_prs>`.
+3. Work on your content.
+4. {ref}`Build <sphinx_doc_build>` your documentation and preview the doc changes. 
+   
+### Support outreach initiatives
+Support ArviZ {ref}`outreach initiatives <oureach_contrib>` such as writing blog posts, case studies,  getting people to use ArviZ at your company or university, etc.
+
+### Make changes in the code
+Fix outstanding issues (bugs) in the existing codebase. The issue can range from low-level software bugs to high-level design problems. You can also add new features to the codebase or improve the existing functionality. To fix bugs or add new features, do the following:
+1. Familiarize yourself with the {ref}`guidelines <steps_before_working>` before starting your work.
+2. Understand the {ref}`development process <dev_summary>` and code conventions.
+3. Understand the basic workflow for opening a {ref} `pull request <pr_tutorial>` and {ref}`reviewing <review_prs>`changes.
+4. Review and test your code. 
+
+
 
 :::{toctree}
 :hidden:

--- a/doc/source/contributing/index.md
+++ b/doc/source/contributing/index.md
@@ -45,7 +45,7 @@ For example, you can check if the documentation renders correctly and has no typ
 ### Manage issues
 Helping to manage or triage the open issues can be a great contribution and
 a great opportunity to learn about the various areas of the project.
-You can {ref} `triage existing issues <issue_triaging>`to make them clear and/or provide temporary workarounds for them.
+You can {ref}`triage existing issues <issue_triaging>` to make them clear and/or provide temporary workarounds for them.
 
 ### Write documentation
 You can contribute to ArviZ’s documentation by either creating new content or editing existing content.

--- a/doc/source/contributing/index.md
+++ b/doc/source/contributing/index.md
@@ -33,7 +33,7 @@ but there are many other ways to help the project.
 You can contribute to ArviZ in the following ways:
 
 ### Create an issue
-[Submit issues](https://github.com/arviz-devs/arviz/issues/new/choose) for existing bugs or desired enhancements. Check  {ref}`issue_reports <issue_reports>` for details on how to write an issue.
+[Submit issues](https://github.com/arviz-devs/arviz/issues/new/choose) for existing bugs or desired enhancements. Check  {ref}`issue_reports` for details on how to write an issue.
 
 ### Translate ArviZ website
 You can {ref}`translate <translate>` our website to languages other than english.
@@ -66,7 +66,7 @@ You can also add new features to the codebase or improve the existing functional
 To fix bugs or add new features, do the following:
 1. Familiarize yourself with the {ref}`guidelines <steps_before_working>` before starting your work.
 2. Understand the {ref}`development process <dev_summary>` and code conventions.
-3. Understand the basic workflow for opening a {ref}`pull request <pr_tutorial>` and {ref}`reviewing <review_prs>`changes.
+3. Understand the basic workflow for opening a {ref}`pull request <pr_tutorial>` and {ref}`reviewing <review_prs>` changes.
 4. Review and test your code.
 
 ```{toctree}

--- a/doc/source/contributing/index.md
+++ b/doc/source/contributing/index.md
@@ -32,18 +32,6 @@ sending pull requests on the main [ArviZ Github repository](https://github.com/a
 but there are many other ways to help the project.
 You can contribute to ArviZ in the following ways:
 
-```{toctree}
-:maxdepth: 2
-:caption: Contribution types
-
-issue_reports
-translate
-issue_triaging
-outreach
-review_prs
-contributing_prs
-```
-
 ### Create an issue
 [Submit issues](https://github.com/arviz-devs/arviz/issues/new/choose) for existing bugs or desired enhancements. Check  {ref}`issue_reports <issue_reports>` for details on how to write an issue.
 
@@ -51,15 +39,16 @@ contributing_prs
 You can {ref}`translate <translate>` our website to languages other than english.
 
 ### Review PRs
-{ref}`Review pull requests <review_prs>` to ensure that the contributions are well tested and documented. For example, you can check if the documentation renders correctly and has no typos or mistakes.
+{ref}`Review pull requests <review_prs>` to ensure that the contributions are well tested and documented.
+For example, you can check if the documentation renders correctly and has no typos or mistakes.
 
 ### Manage issues
 Helping to manage or triage the open issues can be a great contribution and a great opportunity to learn about the various areas of the project. You can {ref} `triage existing issues <issue_triaging>`to make them clear and/or provide temporary workarounds for them.
 
 ### Write documentation
 You can contribute to ArviZ’s documentation by either creating new content or editing existing content. For instance, you can add new ArviZ examples. To get involved with the documentation:
-1. Familiarize yourself with the  {ref}`documentation content structure <content_structure>` and the {ref}`tool chain <doc_toolchain>`] involved in creating the website.
-2. Understand the basic workflow for opening a {ref} `pull request <pr_tutorial>` and {ref}`reviewing changes <review_prs>`.
+1. Familiarize yourself with the  {ref}`documentation content structure <content_structure>` and the {ref}`tool chain <doc_toolchain>` involved in creating the website.
+2. Understand the basic workflow for opening a {ref}`pull request <pr_tutorial>` and {ref}`reviewing changes <review_prs>`.
 3. Work on your content.
 4. {ref}`Build <sphinx_doc_build>` your documentation and preview the doc changes.
 
@@ -74,6 +63,19 @@ Fix outstanding issues (bugs) in the existing codebase. The issue can range from
 4. Review and test your code.
 
 
+
+```{toctree}
+:maxdepth: 2
+:caption: Contribution types
+
+issue_reports
+translate
+issue_triaging
+outreach
+review_prs
+contributing_prs
+pr_tutorial
+```
 
 :::{toctree}
 :hidden:

--- a/doc/source/contributing/index.md
+++ b/doc/source/contributing/index.md
@@ -1,20 +1,36 @@
 (contributing_guide)=
 # Contributing to ArviZ
 ## Welcome
-Welcome to the {doc}`ArviZ <arviz_org:index>` project! If you’re reading this guide, that probably means you’d like to get involved and start contributing to the project. ArviZ is a  multi-language open-source project that provides tools for exploratory analysis of Bayesian models.   The package includes functions for posterior analysis, data storage, sample diagnostics, model checking, and comparison.
+Welcome to the {doc}`ArviZ <arviz_org:index>` project!
+If you’re reading this guide, that probably means you’d like to get involved
+and start contributing to the project.
+ArviZ is a  multi-language open-source project that provides tools for exploratory analysis of Bayesian models.
+The package includes functions for posterior analysis, data storage,
+sample diagnostics, model checking, and comparison.
 
-As a scientific, community-driven, open-source software project, we welcome contributions from interested individuals or groups. The guidelines specified in this document can help new contributors make their contributions compliant with the conventions of the ArviZ python library, and maximize the probability of such contributions being merged as quickly and as efficiently as possible.
+As a scientific, community-driven, open-source software project,
+we welcome contributions from interested individuals or groups.
+The guidelines specified in this document can help new contributors
+make their contributions compliant with the conventions of the ArviZ python library,
+and maximize the probability of such contributions being merged as quickly and as efficiently as possible.
 
-All kinds of contributions to ArviZ, either on its codebase, its documentation, or its community are valuable and we appreciate your help. We constantly encourage non-code contributors to become a core contributor and participate in {ref}`ArviZ governance <arviz_org:governance>`.
+All kinds of contributions to ArviZ, either on its codebase, its documentation,
+or its community are valuable and we appreciate your help.
+We constantly encourage non-code contributors to become core contributors
+and participate in {ref}`ArviZ governance <arviz_org:governance>`.
 
 ## Before you begin
-Before contributing to ArviZ, please make sure to read and observe the [Code of Conduct](https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md).   
- 
+Before contributing to ArviZ, please make sure to read and observe the [Code of Conduct](https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md).
+
 ## Communication
-Contact us on [Gitter](https://gitter.im/arviz-devs/community) if you want to contribute to the project but you are not sure where you can contribute or how to start.
+Contact us on [Gitter](https://gitter.im/arviz-devs/community)
+if you want to contribute to the project but you are not sure where you can contribute or how to start.
 
 ## Contributing to ArviZ
-The most common way of contributing to the project is sending pull requests on the main [ArviZ Github repository](https://github.com/arviz-devs/arviz). You can contribute to ArviZ in the following ways:
+Historically, the most common way of contributing to the project is
+sending pull requests on the main [ArviZ Github repository](https://github.com/arviz-devs/arviz),
+but there are many other ways to help the project.
+You can contribute to ArviZ in the following ways:
 
 ```{toctree}
 :maxdepth: 2
@@ -26,28 +42,27 @@ issue_triaging
 outreach
 review_prs
 contributing_prs
-
 ```
 
 ### Create an issue
 [Submit issues](https://github.com/arviz-devs/arviz/issues/new/choose) for existing bugs or desired enhancements. Check  {ref}`issue_reports <issue_reports>` for details on how to write an issue.
 
 ### Translate ArviZ website
-You can {ref}`translate <translate>` our website to languages other than english. 
+You can {ref}`translate <translate>` our website to languages other than english.
 
 ### Review PRs
-{ref}`Review pull requests <review_prs>` to ensure that the contributions are well tested and documented. For example, you can check if the documentation renders correctly and has no typos or mistakes. 
+{ref}`Review pull requests <review_prs>` to ensure that the contributions are well tested and documented. For example, you can check if the documentation renders correctly and has no typos or mistakes.
 
 ### Manage issues
-Helping to manage or triage the open issues can be a great contribution and a great opportunity to learn about the various areas of the project. You can {ref} `triage existing issues <issue_triaging>`to make them clear and/or provide temporary workarounds for them. 
+Helping to manage or triage the open issues can be a great contribution and a great opportunity to learn about the various areas of the project. You can {ref} `triage existing issues <issue_triaging>`to make them clear and/or provide temporary workarounds for them.
 
 ### Write documentation
 You can contribute to ArviZ’s documentation by either creating new content or editing existing content. For instance, you can add new ArviZ examples. To get involved with the documentation:
 1. Familiarize yourself with the  {ref}`documentation content structure <content_structure>` and the {ref}`tool chain <doc_toolchain>`] involved in creating the website.
 2. Understand the basic workflow for opening a {ref} `pull request <pr_tutorial>` and {ref}`reviewing changes <review_prs>`.
 3. Work on your content.
-4. {ref}`Build <sphinx_doc_build>` your documentation and preview the doc changes. 
-   
+4. {ref}`Build <sphinx_doc_build>` your documentation and preview the doc changes.
+
 ### Support outreach initiatives
 Support ArviZ {ref}`outreach initiatives <oureach_contrib>` such as writing blog posts, case studies,  getting people to use ArviZ at your company or university, etc.
 
@@ -56,7 +71,7 @@ Fix outstanding issues (bugs) in the existing codebase. The issue can range from
 1. Familiarize yourself with the {ref}`guidelines <steps_before_working>` before starting your work.
 2. Understand the {ref}`development process <dev_summary>` and code conventions.
 3. Understand the basic workflow for opening a {ref} `pull request <pr_tutorial>` and {ref}`reviewing <review_prs>`changes.
-4. Review and test your code. 
+4. Review and test your code.
 
 
 

--- a/doc/source/contributing/index.md
+++ b/doc/source/contributing/index.md
@@ -59,10 +59,8 @@ Support ArviZ {ref}`outreach initiatives <oureach_contrib>` such as writing blog
 Fix outstanding issues (bugs) in the existing codebase. The issue can range from low-level software bugs to high-level design problems. You can also add new features to the codebase or improve the existing functionality. To fix bugs or add new features, do the following:
 1. Familiarize yourself with the {ref}`guidelines <steps_before_working>` before starting your work.
 2. Understand the {ref}`development process <dev_summary>` and code conventions.
-3. Understand the basic workflow for opening a {ref} `pull request <pr_tutorial>` and {ref}`reviewing <review_prs>`changes.
+3. Understand the basic workflow for opening a {ref}`pull request <pr_tutorial>` and {ref}`reviewing <review_prs>`changes.
 4. Review and test your code.
-
-
 
 ```{toctree}
 :maxdepth: 2

--- a/doc/source/contributing/index.md
+++ b/doc/source/contributing/index.md
@@ -1,43 +1,53 @@
 (contributing_guide)=
 # Contributing to ArviZ
-As a scientific, community-driven, open source software project,
-ArviZ welcomes contributions from interested individuals or groups.
-These guidelines are provided to give potential contributors information
-to make their contributions compliant with the conventions of the ArviZ project,
-and maximize the probability of such contributions to be merged as quickly
-and efficiently as possible.
+## Welcome
+Welcome to the [ArviZ](https://www.arviz.org/en/latest/) project! If you’re reading this guide, that probably means you’d like to get involved and start contributing to the project. ArviZ is a  multi-language open-source project that provides tools for exploratory analysis of Bayesian models.   The package includes functions for posterior analysis, data storage, sample diagnostics, model checking, and comparison.
 
-Even though contributing code or documentation by sending pull requests on
-the main [ArviZ GitHub repository](https://github.com/arviz-devs/arviz) is the most common way of contributing and
-therefore this guide dedicates many resources to these, ArviZ welcomes any kind of contribution.
-As a clear proof, you can become a core contributor and participate in
-{ref}`ArviZ governance <arviz_org:governance>`
-without having contributed code to ArviZ.
-All contributions to ArviZ, either on its codebase, its documentation,
-or its community are valuable and we really appreciate your help.
+As a scientific, community-driven, open-source software project, we welcome contributions from interested individuals or groups. The guidelines specified in this document can help new contributors make their contributions compliant with the conventions of the ArviZ python library, and maximize the probability of such contributions being merged as quickly and as efficiently as possible.
 
-:::{tip}
-Contact us on [Gitter](https://gitter.im/arviz-devs/community) if you want to
-contribute to the project but you are not sure where you can contribute or how to start.
-:::
+All kinds of contributions to ArviZ, either on its codebase, its documentation, or its community are valuable and we appreciate your help. We constantly encourage non-code contributors to become a core contributor and participate in {ref}`ArviZ governance <arviz_org:governance>`.
 
-Below we list some examples of contributions that might serve as inspiration.
+## Before you begin
+Before contributing to ArviZ, please make sure to read and observe the [Code of Conduct](https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md).   
+ 
+## Communication
+Contact us on [Gitter](https://gitter.im/arviz-devs/community) if you want to contribute to the project but you are not sure where you can contribute or how to start.
 
-* [Submitting issues](https://github.com/arviz-devs/arviz/issues/new/choose) related to bugs or desired enhancements. Check the details at {doc}`issue_reports`.
-* Translate our website to languages other than English. Check the details at {ref}`translate`
-* Fixing outstanding [issues](https://github.com/arviz-devs/arviz/issues) (bugs) with the existing codebase. They range from low-level software bugs to higher-level design problems.
-* Contributing or improving the {ref}`documentation <homepage>` (`docs`) or examples (`arviz/examples`).
-* Help users submitting issues by making sure their issue is clear and/or providing temporal
-  workarounds for them. Check the details at {ref}`issue_triaging`
-* Review Pull Requests ensuring contributions are well tested and documented, that documentation
-  renders correctly and has no typos or mistakes. Check the details at {ref}`review_prs`
-* Adding new or improved functionality to the existing codebase.
+## Contributing to ArviZ
+The most common way of contributing to the project is sending pull requests on the main [ArviZ Github repository](https://github.com/arviz-devs/arviz). You can contribute to ArviZ in the following ways:
 
-Further information on how to contribute to ArviZ can be found on these specific pages:
+### Create an issue
+[Submit issues](https://github.com/arviz-devs/arviz/issues/new/choose) for existing bugs or desired enhancements. Check [Issue reports](https://arviz-devs.github.io/arviz/contributing/issue_reports.html) for details on how to write an issue.
+
+### Translate ArviZ website
+You can [translate](https://python.arviz.org/en/latest/contributing/translate.html#translate) our website to languages other than english. 
+
+### Review PRs
+{ref}`Review pull requests <review_prs>` to ensure that the contributions are well tested and documented. For example, you can check if the documentation renders correctly and has no typos or mistakes. 
+
+### Manage issues
+Helping to manage or triage the open issues can be a great contribution and a great opportunity to learn about the various areas of the project. You can [triage existing issues](https://arviz-devs.github.io/arviz/contributing/issue_triaging.html#issue-triaging) to make them clear and/or provide temporary workarounds for them. 
+
+### Write documentation
+You can contribute to ArviZ’s documentation by either creating new content or editing existing content. For instance, you can add new ArviZ examples. To get involved with the documentation:
+1. Familiarize yourself with the [documentation content structure](https://arviz-devs.github.io/arviz/contributing/content_structure.html) and the [tool chain](https://arviz-devs.github.io/arviz/contributing/doc_toolchain.html) involved in creating the website.
+2. Understand the basic workflow for opening a [pull request](https://arviz-devs.github.io/arviz/contributing/pr_tutorial.html) and [reviewing changes](https://arviz-devs.github.io/arviz/contributing/review_prs.html).
+3. Work on your content.
+4. {ref}`Build <sphinx_doc_build>` your documentation and preview the doc changes. 
+   
+### Support outreach initiatives
+Support ArviZ {ref}`outreach initiatives <oureach_contrib>` such as writing blog posts, case studies,  getting people to use ArviZ at your company or university, etc.
+
+### Make changes in the code
+Fix outstanding issues (bugs) in the existing codebase. The issue can range from low-level software bugs to high-level design problems. You can also add new features to the codebase or improve the existing functionality. To fix bugs or add new features, do the following:
+1. Familiarize yourself with the {ref}`guidelines <steps_before_working>` before starting your work.
+2. Understand the {ref}`development process <dev_summary>` and code conventions.
+3. Understand the basic workflow for opening a [pull request](https://arviz-devs.github.io/arviz/contributing/pr_tutorial.html) and [reviewing](https://arviz-devs.github.io/arviz/contributing/review_prs.html) changes.
+4. Review and test your code. 
 
 ```{toctree}
 :maxdepth: 2
-:caption: Contribution types overview
+:caption: Contribution types
 
 issue_reports
 translate
@@ -45,6 +55,7 @@ issue_triaging
 outreach
 review_prs
 contributing_prs
+pr_tutorial
 ```
 
 :::{toctree}

--- a/doc/source/contributing/index.md
+++ b/doc/source/contributing/index.md
@@ -43,27 +43,34 @@ You can {ref}`translate <translate>` our website to languages other than english
 For example, you can check if the documentation renders correctly and has no typos or mistakes.
 
 ### Manage issues
-Helping to manage or triage the open issues can be a great contribution and a great opportunity to learn about the various areas of the project. You can {ref} `triage existing issues <issue_triaging>`to make them clear and/or provide temporary workarounds for them.
+Helping to manage or triage the open issues can be a great contribution and
+a great opportunity to learn about the various areas of the project.
+You can {ref} `triage existing issues <issue_triaging>`to make them clear and/or provide temporary workarounds for them.
 
 ### Write documentation
-You can contribute to ArviZ’s documentation by either creating new content or editing existing content. For instance, you can add new ArviZ examples. To get involved with the documentation:
+You can contribute to ArviZ’s documentation by either creating new content or editing existing content.
+For instance, you can add new ArviZ examples.
+To get involved with the documentation:
 1. Familiarize yourself with the  {ref}`documentation content structure <content_structure>` and the {ref}`tool chain <doc_toolchain>` involved in creating the website.
 2. Understand the basic workflow for opening a {ref}`pull request <pr_tutorial>` and {ref}`reviewing changes <review_prs>`.
 3. Work on your content.
 4. {ref}`Build <sphinx_doc_build>` your documentation and preview the doc changes.
 
 ### Support outreach initiatives
-Support ArviZ {ref}`outreach initiatives <oureach_contrib>` such as writing blog posts, case studies,  getting people to use ArviZ at your company or university, etc.
+Support ArviZ {ref}`outreach initiatives <oureach_contrib>` such as writing blog posts, case studies, getting people to use ArviZ at your company or university, etc.
 
 ### Make changes in the code
-Fix outstanding issues (bugs) in the existing codebase. The issue can range from low-level software bugs to high-level design problems. You can also add new features to the codebase or improve the existing functionality. To fix bugs or add new features, do the following:
+Fix outstanding issues (bugs) in the existing codebase.
+The issue can range from low-level software bugs to high-level design problems.
+You can also add new features to the codebase or improve the existing functionality.
+To fix bugs or add new features, do the following:
 1. Familiarize yourself with the {ref}`guidelines <steps_before_working>` before starting your work.
 2. Understand the {ref}`development process <dev_summary>` and code conventions.
 3. Understand the basic workflow for opening a {ref}`pull request <pr_tutorial>` and {ref}`reviewing <review_prs>`changes.
 4. Review and test your code.
 
 ```{toctree}
-:maxdepth: 2
+:hidden:
 :caption: Contribution types
 
 issue_reports
@@ -72,7 +79,6 @@ issue_triaging
 outreach
 review_prs
 contributing_prs
-pr_tutorial
 ```
 
 :::{toctree}

--- a/doc/source/contributing/issue_reports.md
+++ b/doc/source/contributing/issue_reports.md
@@ -1,3 +1,4 @@
+(issue_reports)=
 # Issue reports
 
 We appreciate being notified of problems with the existing ArviZ code.


### PR DESCRIPTION
## Description
I had an offline discussion with @OriolAbril and made the following changes to the Contributing section of ArviZ python library website. I have introduced the following new sections to improve the clarity of the Contributing guide.

**Welcome** 
Provides a brief introduction to the project.
**Before you begin**
Provides prerequisites for new contributors.
**Communication**
Gitter channel details to help contributors get in touch with the community.
**Contributing to ArviZ**
Identifies multiple ways of contributing to ArviZ


