### PR TITLE
fix mode scipy

### DIFF
--- a/arviz/plots/plot_utils.py
+++ b/arviz/plots/plot_utils.py
@@ -372,7 +372,7 @@ def calculate_point_estimate(point_estimate, values, bw="default", circular=Fals
             x, density = kde(values, circular=circular, bw=bw)
             point_value = x[np.argmax(density)]
         else:
-            point_value = mode(values)[0][0]
+            point_value = mode(values).mode
     elif point_estimate == "median":
         if skipna:
             point_value = np.nanmedian(values)


### PR DESCRIPTION
SciPy introduced changes into the computation of `stats.mode` a while ago, for backward compatibility it allowed getting the results by indexing the object, but that's no longer the case starting from 1.9.0.