### PR TITLE
Removed fill_last, contour and plot_kwargs arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Change `ax.plot` usage to `ax.scatter` in `plot_pair` ([1990](https://github.com/arviz-devs/arviz/pull/1990))
 
 ### Deprecation
-* Deprecated `fill_last`, `contour` and `plot_kwargs` arguments from `plot_pair` function ([2085](https://github.com/arviz-devs/arviz/pull/2085))
+* Removed `fill_last`, `contour` and `plot_kwargs` arguments from `plot_pair` function ([2085](https://github.com/arviz-devs/arviz/pull/2085))
 
 ### Documentation
 * Add translation overview to contributing guide ([2041](https://github.com/arviz-devs/arviz/pull/2041))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Change `ax.plot` usage to `ax.scatter` in `plot_pair` ([1990](https://github.com/arviz-devs/arviz/pull/1990))
 
 ### Deprecation
+* Deprecated `fill_last`, `contour` and `plot_kwargs` arguments from `plot_pair` function ([2085](https://github.com/arviz-devs/arviz/pull/2085))
 
 ### Documentation
 * Add translation overview to contributing guide ([2041](https://github.com/arviz-devs/arviz/pull/2041))

--- a/arviz/plots/pairplot.py
+++ b/arviz/plots/pairplot.py
@@ -24,9 +24,6 @@ def plot_pair(
     textsize=None,
     kind: Union[str, List[str]] = "scatter",
     gridsize="auto",
-    contour: Optional[bool] = None,
-    plot_kwargs=None,
-    fill_last=False,
     divergences=False,
     colorbar=False,
     labeller=None,
@@ -82,11 +79,6 @@ def plot_pair(
         such that the hexagons are approximately regular. Alternatively, gridsize
         can be a tuple with two elements specifying the number of hexagons
         in the x-direction and the y-direction.
-    contour : bool, optional, deprecated, Defaults to True.
-        If True plot the 2D KDE using contours, otherwise plot a smooth 2D KDE. Defaults to True.
-        **Note:** this default is implemented in the body of the code, not in argument processing.
-    fill_last : bool
-        If True fill the last contour of the 2D KDE plot. Defaults to True.
     divergences: Boolean
         If True divergences will be plotted in a different color, only if group is either 'prior'
         or 'posterior'.
@@ -188,17 +180,6 @@ def plot_pair(
         kind_boolean = [kind[i] in valid_kinds for i in range(len(kind))]
     if not np.all(kind_boolean):
         raise ValueError(f"Plot type {kind} not recognized. Plot type must be in {valid_kinds}")
-    if fill_last or contour:
-        warnings.warn(
-            "fill_last and contour will be deprecated. Please use kde_kwargs",
-            UserWarning,
-        )
-    if plot_kwargs:
-        warnings.warn(
-            "plot_kwargs will be deprecated."
-            " Please use scatter_kwargs, kde_kwargs and/or hexbin_kwargs",
-            UserWarning,
-        )
 
     if coords is None:
         coords = {}


### PR DESCRIPTION
## Description
This PR resolves #2073 by removing unused arguments from `plot_pair`

## Checklist
- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Code style correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2085.org.readthedocs.build/en/2085/

<!-- readthedocs-preview arviz end -->