### PR TITLE
Update layout for example gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,28 +64,28 @@ python setup.py install
   <td>
   <a href="https://python.arviz.org/en/latest/examples/plot_forest_ridge.html">
   <img alt="Ridge plot"
-  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_static/plot_forest_ridge_thumb.png" />
+  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_forest_ridge.png" />
   </a>
   </td>
 
   <td>
   <a href="https://python.arviz.org/en/latest/examples/plot_parallel.html">
   <img alt="Parallel plot"
-  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_static/plot_parallel_minmax_thumb.png" />
+  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_parallel.png" />
   </a>
   </td>
 
   <td>
   <a href="https://python.arviz.org/en/latest/examples/plot_trace.html">
   <img alt="Trace plot"
-  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_static/plot_trace_bars_thumb.png" />
+  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_trace.png" />
   </a>
   </td>
 
   <td>
   <a href="https://python.arviz.org/en/latest/examples/plot_density.html">
   <img alt="Density plot"
-  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_static/plot_density_thumb.png" />
+  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_density.png" />
   </a>
   </td>
 
@@ -95,28 +95,28 @@ python setup.py install
   <td>
   <a href="https://python.arviz.org/en/latest/examples/plot_posterior.html">
   <img alt="Posterior plot"
-  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_static/plot_posterior_thumb.png" />
+  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_posterior.png" />
   </a>
   </td>
 
   <td>
   <a href="https://python.arviz.org/en/latest/examples/plot_dot.html">
   <img alt="Joint plot"
-  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_static/plot_dot_thumb.png" />
+  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_dot.png" />
   </a>
   </td>
 
   <td>
   <a href="https://python.arviz.org/en/latest/examples/plot_ppc.html">
   <img alt="Posterior predictive plot"
-  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_static/plot_ppc_thumb.png" />
+  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_ppc.png" />
   </a>
   </td>
 
   <td>
   <a href="https://python.arviz.org/en/latest/examples/plot_pair.html">
   <img alt="Pair plot"
-  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_static/plot_pair_thumb.png" />
+  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_pair.png" />
   </a>
   </td>
 
@@ -126,28 +126,28 @@ python setup.py install
   <td>
   <a href="https://python.arviz.org/en/latest/examples/plot_energy.html">
   <img alt="Energy Plot"
-  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_static/plot_pair_hex_thumb.png" />
+  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_pair_hex.png" />
   </a>
   </td>
 
   <td>
   <a href="https://python.arviz.org/en/latest/examples/plot_violin.html">
   <img alt="Violin Plot"
-  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_static/plot_violin_thumb.png" />
+  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_violin.png" />
   </a>
   </td>
 
   <td>
   <a href="https://python.arviz.org/en/latest/examples/plot_forest.html">
   <img alt="Forest Plot"
-  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_static/plot_forest_thumb.png" />
+  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_forest.png" />
   </a>
   </td>
 
   <td>
   <a href="https://python.arviz.org/en/latest/examples/plot_autocorr.html">
   <img alt="Autocorrelation Plot"
-  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_static/plot_autocorr_thumb.png" />
+  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_autocorr.png" />
   </a>
   </td>
 

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,16 +1,5 @@
 {% extends "!layout.html" %}
 
-<!-- Make body have full width in home page -->
-{% block docs_main %}
-  {% if pagename == 'index' %}
-    <main class="col-12 py-md-5 pl-md-5 pr-md-4 bd-content" role="main">
-      {% block body %} {% endblock %}
-    </main>
-  {% else %}
-    {{ super() }}
-  {% endif %}
-{% endblock %}
-
 <!-- Add banner to all pages! -->
 {%- block scripts_end %}
 {{ super() }}

--- a/doc/_templates/sections/sidebar-primary.html
+++ b/doc/_templates/sections/sidebar-primary.html
@@ -1,8 +1,0 @@
-{% extends "!sections/sidebar-primary.html" %}
-
-<!-- Hide left sidebar in home page -->
-{% block docs_sidebar %}
-  {% if pagename != 'index' %}
-    {{ super() }}
-  {% endif %}
-{% endblock %}

--- a/doc/_templates/sections/sidebar-secondary.html
+++ b/doc/_templates/sections/sidebar-secondary.html
@@ -1,8 +1,0 @@
-{% extends "!sections/sidebar-secondary.html" %}
-
-<!-- Hide right sidebar in home page -->
-{% block docs_toc %}
-  {% if pagename != 'index' %}
-    {{ super() }}
-  {% endif %}
-{% endblock %}

--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -29,7 +29,7 @@ html[data-theme="dark"] {
 
 .bd-content {
   flex-grow: 1;
-  max-width: 60em;
+  max-width: 70em; /* Override 60em default, can use 100% */
 }
 
 /* -------------------- HOMEPAGE -------------------- */
@@ -42,19 +42,10 @@ html[data-theme="dark"] {
   padding: 20px 0px 40px;
 }
 
-.home-img-plot {
-  width: 200px;
-  height: 120px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  overflow: hidden
-}
-
 .home-img-plot,
 .home-img-plot-overlay {
-  width: 200px;
-  height: 120px;
+  width: 235px;
+  height: 130px;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -83,11 +74,6 @@ html[data-theme="dark"] {
 }
 
 /* -------------------- EXAMPLE GALLERY OVERRIDES -------------------- */
-
-.bd-content .sd-card .sd-card-body,
-.bd-content .sd-card .sd-card-footer {
-  background-color: var(--pst-color-background);
-}
 
 /* Each card has same height (across all rows in the grid) */
 .sd-card.example-gallery {
@@ -129,11 +115,9 @@ html[data-theme="dark"] {
   font-size: 0.8rem;
 }
 
-/* -------------------- EXAMPLE PLOTS -------------------- */
+/* -------------------- EXAMPLE PLOTS - DOWNLOAD PYTHON SOURCE CODE -------------------- */
 
-/* Download Python Source Code */
 .example-plot-download {
-  background-color: #0fbcbc12;
   border: 0.05rem solid rgb(222, 222, 222);
   border-radius: 0.2rem;
   /* Center button */
@@ -142,14 +126,17 @@ html[data-theme="dark"] {
   box-shadow: 0 0.2rem 0.5rem rgb(0 0 0 / 5%), 0 0 0.0625rem rgb(0 0 0 / 10%);
 }
 .example-plot-download p a {
-  font-weight: 700;
-  font-size: 0.8rem;
-  text-align: center;
   padding: 0.4rem 2rem;
-  margin: 0;
 }
 .example-plot-download p { /* Override margin defaults for p */
   margin: 0;
+}
+.example-plot-download code.literal { /* Override defaults for code.literal */
+  border: 0px;
+  background-color: transparent;
+}
+.example-plot-download a.download:hover  { /* Override defaults for hover */
+  color: var(--pst-color-primary);
 }
 
 /* -------------------- TOCTREE OVERRIDES -------------------- */

--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -1,16 +1,87 @@
 .sphinx-codeautolink-a{
-    border-bottom-color: rgb(0, 0, 0);
-    border-bottom-style: dotted;
-    border-bottom-width: 1px;
+  border-bottom-color: rgb(0, 0, 0);
+  border-bottom-style: dotted;
+  border-bottom-width: 1px;
 }
 .sphinx-codeautolink-a:hover{
-    color: rgb(255, 139, 139);
+  color: rgb(255, 139, 139);
 }
 
 .supportbutton a {
- color: var(--pst-color-sidebar-link-active);
+color: var(--pst-color-sidebar-link-active);
 }
 
 .navbar-brand {
-  display: inline-block !important;
+display: inline-block !important;
+}
+
+
+/* -------------------- EXAMPLE GALLERY -------------------- */
+
+.example-gallery-figure {
+  position: relative;
+  float: left;
+  margin: 10px;
+  width: 180px;
+  height: 200px;
+}
+
+.example-gallery-figure img {
+  position: absolute;
+  display: inline;
+  left: 0;
+  width: 170px;
+  height: 170px;
+  opacity:1.0;
+  filter:alpha(opacity=100); /* For IE8 and earlier */
+}
+
+.example-gallery-figure:hover img {
+  -webkit-filter: blur(3px);
+  -moz-filter: blur(3px);
+  -o-filter: blur(3px);
+  -ms-filter: blur(3px);
+  filter: blur(3px);
+  opacity:1.0;
+  filter:alpha(opacity=100); /* For IE8 and earlier */
+}
+
+span.example-gallery-figure-label {
+  position: absolute;
+  display: inline;
+  left: 0;
+  width: 170px;
+  height: 170px;
+  background: #000;
+  color: #fff;
+  visibility: hidden;
+  opacity: 0;
+  z-index: 100;
+}
+
+.example-gallery-figure p {
+  position: absolute;
+  top: 45%;
+  width: 170px;
+  font-size: 110%;
+}
+
+.example-gallery-figure:hover span {
+  visibility: visible;
+  opacity: .4;
+}
+
+.example-gallery-figure .example-gallery-figure-title p {
+  position: relative;
+  top: 170px;
+  color: black;
+  visibility: visible;
+  text-align: center !important;
+  line-height: normal;
+}
+
+.example-gallery-figure .example-gallery-figure-title span {
+  top: 170px;
+  position: relative;
+  visibility: visible;
 }

--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -18,7 +18,7 @@ display: inline-block !important;
 /* -------------------- THEME OVERRIDES -------------------- */
 
 html[data-theme="light"] {
-  --pst-color-primary: rgb(0 192 191);
+  --pst-color-primary: rgb(11 117 145);
   --pst-color-secondary: rgb(238 144 64);
 }
 
@@ -44,6 +44,15 @@ html[data-theme="dark"] {
   padding: 20px 0px 40px;
 }
 
+.home-img-plot {
+  width: 200px;
+  height: 120px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden
+}
+
 .home-img-plot,
 .home-img-plot-overlay {
   width: 200px;
@@ -65,7 +74,7 @@ html[data-theme="dark"] {
   position: absolute;
   border: 1px solid #dee2e6;  /* Same dimensions as img-thumbnail from pydata css */
   border-radius: 0.25rem;  /* Same dimensions as img-thumbnail from pydata css */
-  color: #fff;
+  color: var(--pst-color-background);
   opacity: 0;
   transition: .2s ease;
   text-align: center;

--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -15,18 +15,21 @@ color: var(--pst-color-sidebar-link-active);
 display: inline-block !important;
 }
 
-
 /* -------------------- EXAMPLE GALLERY OVERRIDES -------------------- */
 
-.example-gallery {
+.bd-content .sd-card .sd-card-body,
+.bd-content .sd-card .sd-card-footer {
+  background-color: transparent;
+}
+
+/* Each card has same height (across all rows in the grid) */
+.sd-card.example-gallery {
   height: 250px;
-  display: flex;
-  justify-content: space-between;
-  flex-direction: column;
   border-radius: 0.2rem;
   border: 0.6px solid rgba(255,255,255,0) !important;  /* Override Sphinx class */
 }
 
+/* Hover effects for each card */
 .example-gallery:hover {
   box-shadow: 0 0 0.5rem 0.2rem rgba(15, 187, 188, 0.3) !important;  /* Override Sphinx class */
   border: 0.6px solid #0fbbbc;
@@ -35,27 +38,22 @@ display: inline-block !important;
   color: #0fbbbc;
 }
 
-.example-gallery img.sd-card-img-top {
-  padding: 10px;
-  object-fit: contain;
-  max-height: 60%;
+/* Images in each card are scaled to fit 60% of the card */
+.example-gallery .sd-card-body {
+  height: 60%;
+  display: flex;  /* This vertically centers the img */
+}
+.example-gallery .sd-card-body img {
+  max-height: 100%;
   max-width: 100%;
-  flex-grow: 6;
+  margin: auto;  /* This keeps img ratio and horizontally centers the img */
 }
 
+/* Plot titles go in the footer and are aligned to fit 40% of the card */
+.example-gallery .sd-card-footer {
+  height: 40%;
+  width: 100%;
+}
 .example-gallery .sd-card-text {
   color: #086c86;
-}
-
-.bd-content .sd-card .sd-card-body,
-.bd-content .sd-card .sd-card-footer {
-  background-color: transparent;
-}
-
-.example-gallery .sd-card-body {
-  height: 40%;
-  flex-grow: 4;
-  position: absolute;
-  bottom: 0;
-  width: 100%;
 }

--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -15,33 +15,94 @@ color: var(--pst-color-sidebar-link-active);
 display: inline-block !important;
 }
 
+/* -------------------- THEME OVERRIDES -------------------- */
+
+html[data-theme="light"] {
+  --pst-color-primary: rgb(0 192 191);
+  --pst-color-secondary: rgb(238 144 64);
+}
+
+html[data-theme="dark"] {
+  --pst-color-primary: rgb(0 192 191);
+  --pst-color-secondary: rgb(238 144 64);
+}
+
+.bd-container .bd-container__inner {
+  justify-content: center;
+}
+.bd-content {
+  max-width: 60em;
+}
+
+/* -------------------- HOMEPAGE -------------------- */
+
+.home-flex-grid {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: center;
+  gap: 10px;
+  padding: 20px 0px 40px;
+}
+
+.home-img-plot,
+.home-img-plot-overlay {
+  width: 200px;
+  height: 120px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden
+}
+
+.home-img-plot img {
+  flex-shrink: 0;
+  min-width: 100%;
+  min-height: 100%;
+}
+
+.home-img-plot-overlay {
+  background: var(--pst-color-primary);
+  position: absolute;
+  border: 1px solid #dee2e6;  /* Same dimensions as img-thumbnail from pydata css */
+  border-radius: 0.25rem;  /* Same dimensions as img-thumbnail from pydata css */
+  color: #fff;
+  opacity: 0;
+  transition: .2s ease;
+  text-align: center;
+}
+
+.home-img-plot-overlay:hover {
+  opacity: 90%;
+}
+
 /* -------------------- EXAMPLE GALLERY OVERRIDES -------------------- */
 
 .bd-content .sd-card .sd-card-body,
 .bd-content .sd-card .sd-card-footer {
-  background-color: transparent;
+  background-color: var(--pst-color-background);
 }
 
 /* Each card has same height (across all rows in the grid) */
 .sd-card.example-gallery {
-  height: 250px;
+  height: 200px;
+  padding: 0.2rem;
   border-radius: 0.2rem;
-  border: 0.6px solid rgba(255,255,255,0) !important;  /* Override Sphinx class */
+  border: 0.6px solid var(--pst-color-background); /* Same width as hover effect */
 }
 
 /* Hover effects for each card */
 .example-gallery:hover {
-  box-shadow: 0 0 0.5rem 0.2rem rgba(15, 187, 188, 0.3) !important;  /* Override Sphinx class */
-  border: 0.6px solid #0fbbbc;
+  border: 0.6px solid var(--pst-color-primary);
 }
 .example-gallery:hover p {
-  color: #0fbbbc;
+  color: var(--pst-color-primary);
 }
 
 /* Images in each card are scaled to fit 60% of the card */
 .example-gallery .sd-card-body {
-  height: 60%;
+  height: 70%;
   display: flex;  /* This vertically centers the img */
+  padding: 10px 10px 5px;
 }
 .example-gallery .sd-card-body img {
   max-height: 100%;
@@ -51,36 +112,16 @@ display: inline-block !important;
 
 /* Plot titles go in the footer and are aligned to fit 40% of the card */
 .example-gallery .sd-card-footer {
-  height: 40%;
+  height: 30%;
   width: 100%;
+  padding: 0px 10px 10px;
 }
 .example-gallery .sd-card-text {
-  color: #086c86;
+  color: var(--pst-color-text-muted);
+  font-size: 0.8rem;
 }
 
 /* -------------------- EXAMPLE PLOTS -------------------- */
-
-/* API Reference */
-.example-plot-api-container {
-  margin: 1.5em auto;
-  padding: 0 0.6rem 0.4rem;
-  border: 0.05rem solid rgb(222, 222, 222);
-  border-left: 0.2rem solid;
-  border-left-color: #0fbbbc;
-  border-radius: 0.2rem;
-  box-shadow: 0 0.2rem 0.5rem rgb(0 0 0 / 5%), 0 0 0.0625rem rgb(0 0 0 / 10%);
-}
-.example-plot-api-title {
-  background-color:#0fbcbc12;
-  padding: 0.4rem 0.6rem 0.4rem 1rem;
-  margin: 0 -0.6rem;  /* Same as padding from container */
-  font-weight: 700;
-  font-size: 0.8rem;
-}
-.example-plot-api-name p {
-  padding: 0.4rem 0.6rem 0.4rem 1.2rem;
-  margin: 0rem;
-}
 
 /* Download Python Source Code */
 .example-plot-download {
@@ -101,4 +142,15 @@ display: inline-block !important;
 }
 .example-plot-download p { /* Override margin defaults for p */
   margin: 0;
+}
+
+/* -------------------- TOCTREE OVERRIDES -------------------- */
+
+.toctree-wrapper a {
+  color: var(--pst-color-text-muted);
+}
+
+.toctree-wrapper a:hover {
+  text-decoration: none;  /* No underline */
+  color: var(--pst-color-primary);
 }

--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -29,7 +29,7 @@ html[data-theme="dark"] {
 
 .bd-content {
   flex-grow: 1;
-  max-width: 100%;
+  max-width: 60em;
 }
 
 /* -------------------- HOMEPAGE -------------------- */
@@ -122,6 +122,7 @@ html[data-theme="dark"] {
   height: 30%;
   width: 100%;
   padding: 0px 10px 10px;
+  border-top: none !important;
 }
 .example-gallery .sd-card-text {
   color: var(--pst-color-text-muted);

--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -27,11 +27,9 @@ html[data-theme="dark"] {
   --pst-color-secondary: rgb(238 144 64);
 }
 
-.bd-container .bd-container__inner {
-  justify-content: center;
-}
 .bd-content {
-  max-width: 60em;
+  flex-grow: 1;
+  max-width: 100%;
 }
 
 /* -------------------- HOMEPAGE -------------------- */

--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -16,72 +16,46 @@ display: inline-block !important;
 }
 
 
-/* -------------------- EXAMPLE GALLERY -------------------- */
+/* -------------------- EXAMPLE GALLERY OVERRIDES -------------------- */
 
-.example-gallery-figure {
-  position: relative;
-  float: left;
-  margin: 10px;
-  width: 180px;
-  height: 200px;
+.example-gallery {
+  height: 250px;
+  display: flex;
+  justify-content: space-between;
+  flex-direction: column;
+  border-radius: 0.2rem;
+  border: 0.6px solid rgba(255,255,255,0) !important;  /* Override Sphinx class */
 }
 
-.example-gallery-figure img {
+.example-gallery:hover {
+  box-shadow: 0 0 0.5rem 0.2rem rgba(15, 187, 188, 0.3) !important;  /* Override Sphinx class */
+  border: 0.6px solid #0fbbbc;
+}
+.example-gallery:hover p {
+  color: #0fbbbc;
+}
+
+.example-gallery img.sd-card-img-top {
+  padding: 10px;
+  object-fit: contain;
+  max-height: 60%;
+  max-width: 100%;
+  flex-grow: 6;
+}
+
+.example-gallery .sd-card-text {
+  color: #086c86;
+}
+
+.bd-content .sd-card .sd-card-body,
+.bd-content .sd-card .sd-card-footer {
+  background-color: transparent;
+}
+
+.example-gallery .sd-card-body {
+  height: 40%;
+  flex-grow: 4;
   position: absolute;
-  display: inline;
-  left: 0;
-  width: 170px;
-  height: 170px;
-  opacity:1.0;
-  filter:alpha(opacity=100); /* For IE8 and earlier */
-}
-
-.example-gallery-figure:hover img {
-  -webkit-filter: blur(3px);
-  -moz-filter: blur(3px);
-  -o-filter: blur(3px);
-  -ms-filter: blur(3px);
-  filter: blur(3px);
-  opacity:1.0;
-  filter:alpha(opacity=100); /* For IE8 and earlier */
-}
-
-span.example-gallery-figure-label {
-  position: absolute;
-  display: inline;
-  left: 0;
-  width: 170px;
-  height: 170px;
-  background: #000;
-  color: #fff;
-  visibility: hidden;
-  opacity: 0;
-  z-index: 100;
-}
-
-.example-gallery-figure p {
-  position: absolute;
-  top: 45%;
-  width: 170px;
-  font-size: 110%;
-}
-
-.example-gallery-figure:hover span {
-  visibility: visible;
-  opacity: .4;
-}
-
-.example-gallery-figure .example-gallery-figure-title p {
-  position: relative;
-  top: 170px;
-  color: black;
-  visibility: visible;
-  text-align: center !important;
-  line-height: normal;
-}
-
-.example-gallery-figure .example-gallery-figure-title span {
-  top: 170px;
-  position: relative;
-  visibility: visible;
+  bottom: 0;
+  width: 100%;
 }

--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -57,3 +57,48 @@ display: inline-block !important;
 .example-gallery .sd-card-text {
   color: #086c86;
 }
+
+/* -------------------- EXAMPLE PLOTS -------------------- */
+
+/* API Reference */
+.example-plot-api-container {
+  margin: 1.5em auto;
+  padding: 0 0.6rem 0.4rem;
+  border: 0.05rem solid rgb(222, 222, 222);
+  border-left: 0.2rem solid;
+  border-left-color: #0fbbbc;
+  border-radius: 0.2rem;
+  box-shadow: 0 0.2rem 0.5rem rgb(0 0 0 / 5%), 0 0 0.0625rem rgb(0 0 0 / 10%);
+}
+.example-plot-api-title {
+  background-color:#0fbcbc12;
+  padding: 0.4rem 0.6rem 0.4rem 1rem;
+  margin: 0 -0.6rem;  /* Same as padding from container */
+  font-weight: 700;
+  font-size: 0.8rem;
+}
+.example-plot-api-name p {
+  padding: 0.4rem 0.6rem 0.4rem 1.2rem;
+  margin: 0rem;
+}
+
+/* Download Python Source Code */
+.example-plot-download {
+  background-color: #0fbcbc12;
+  border: 0.05rem solid rgb(222, 222, 222);
+  border-radius: 0.2rem;
+  /* Center button */
+  width: fit-content;
+  margin: 0 auto;
+  box-shadow: 0 0.2rem 0.5rem rgb(0 0 0 / 5%), 0 0 0.0625rem rgb(0 0 0 / 10%);
+}
+.example-plot-download p a {
+  font-weight: 700;
+  font-size: 0.8rem;
+  text-align: center;
+  padding: 0.4rem 2rem;
+  margin: 0;
+}
+.example-plot-download p { /* Override margin defaults for p */
+  margin: 0;
+}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -38,10 +38,6 @@ arviz.Numba.disable_numba()
 # ones.
 sys.path.insert(0, os.path.abspath("../sphinxext"))
 
-thumb_directory = "example_thumbs"
-if not os.path.isdir(thumb_directory):
-    os.mkdir(thumb_directory)
-
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.doctest",
@@ -192,7 +188,7 @@ html_sidebars: Dict[str, Any] = {
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 # html_theme_path = sphinx_bootstrap_theme.get_html_theme_path()
-html_static_path = ["_static", thumb_directory]
+html_static_path = ["_static"]
 html_css_files = ["custom.css"]
 
 # use additional pages to add a 404 page

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -181,6 +181,7 @@ html_context = {
     "default_mode": "light",
 }
 html_sidebars: Dict[str, Any] = {
+    "index": [],
     "community": ["search-field.html", "sidebar-nav-bs.html", "twitter.html"],
 }
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,3 +1,5 @@
+:html_theme.sidebar_secondary.remove:
+
 .. _homepage:
 
 ArviZ: Exploratory analysis of Bayesian models

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -101,31 +101,6 @@ and specification.
         </a>
     </div>
 
-|pypi|
-|Build Status|
-|Coverage Status|
-|Zenodo|
-|NumFocus|
-
-.. |pypi| image:: https://badge.fury.io/py/arviz.svg
-    :target: https://badge.fury.io/py/arviz
-
-.. |JOSS| image:: https://joss.theoj.org/papers/10.21105/joss.01143/status.svg
-   :target: https://doi.org/10.21105/joss.01143
-
-.. |Zenodo| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.2540944.svg
-   :target: https://doi.org/10.5281/zenodo.2540944
-
-.. |NumFocus| image:: https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A
-   :target: https://www.numfocus.org/
-
-.. |Build Status| image:: https://dev.azure.com/ArviZ/ArviZ/_apis/build/status/arviz-devs.arviz?branchName=main
-   :target: https://dev.azure.com/ArviZ/ArviZ/_build/latest?definitionId=1&branchName=main
-
-.. |Coverage Status| image:: https://codecov.io/gh/arviz-devs/arviz/branch/main/graph/badge.svg
-  :target: https://codecov.io/gh/arviz-devs/arviz
-
-
 Installation
 ------------
 
@@ -196,5 +171,5 @@ If you use ArviZ and want to **cite** it please use |JOSS|. Here is the citation
   Contributing<contributing/index>
 
 
-
-
+.. |JOSS| image:: https://joss.theoj.org/papers/10.21105/joss.01143/status.svg
+   :target: https://doi.org/10.21105/joss.01143

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,13 +1,104 @@
-.. raw:: html
-
-    <form class="bd-search align-items-center" action="search.html" method="get">
-      <input type="search" class="form-control search-front-page" name="q" id="search-input" placeholder="&#128269; Search the docs ..." aria-label="Search the docs ..." autocomplete="off">
-    </form>
-
 .. _homepage:
 
 ArviZ: Exploratory analysis of Bayesian models
 ==============================================
+
+ArviZ is a Python package for exploratory analysis of Bayesian models. Includes functions for posterior analysis, data storage, sample diagnostics, model checking, and comparison.
+
+The goal is to provide backend-agnostic tools for diagnostics and visualizations of Bayesian inference in Python,
+by first converting inference data into `xarray <https://xarray.pydata.org/en/stable/>`_ objects.
+See :ref:`here <xarray_for_arviz>` for more on xarray and ArviZ usage
+and :ref:`here <schema>` for more on ``InferenceData`` structure
+and specification.
+
+.. raw:: html
+
+    <div class="home-flex-grid">
+        <a href="examples/plot_pair.html">
+            <div class="home-img-plot img-thumbnail">
+                <img src="./_images/mpl_plot_pair.png">
+                <span class="home-img-plot-overlay">Pair Plot</span>
+            </div>
+        </a>
+
+        <a href="examples/plot_forest.html">
+            <div class="home-img-plot img-thumbnail">
+                <img src="./_images/mpl_plot_forest.png">
+                <span class="home-img-plot-overlay">Forest Plot</span>
+            </div>
+        </a>
+
+        <a href="examples/plot_density.html">
+            <div class="home-img-plot img-thumbnail">
+                <img src="./_images/mpl_plot_density.png">
+                <span class="home-img-plot-overlay">Density Plot</span>
+            </div>
+        </a>
+
+        <a href="examples/plot_energy.html">
+            <div class="home-img-plot img-thumbnail">
+                <img src="./_images/mpl_plot_energy.png">
+                <span class="home-img-plot-overlay">Energy Plot</span>
+            </div>
+        </a>
+
+        <a href="examples/plot_posterior.html">
+            <div class="home-img-plot img-thumbnail">
+                <img src="./_images/mpl_plot_posterior.png">
+                <span class="home-img-plot-overlay">Posterior Plot</span>
+            </div>
+        </a>
+
+        <a href="examples/plot_kde_2d.html">
+            <div class="home-img-plot img-thumbnail">
+                <img src="./_images/mpl_plot_kde_2d.png">
+                <span class="home-img-plot-overlay">KDE 2D Plot</span>
+            </div>
+        </a>
+
+        <a href="examples/plot_forest_ridge.html">
+            <div class="home-img-plot img-thumbnail">
+                <img src="./_images/mpl_plot_forest_ridge.png">
+                <span class="home-img-plot-overlay">Forest Ridge Plot</span>
+            </div>
+        </a>
+
+        <a href="examples/plot_parallel.html">
+            <div class="home-img-plot img-thumbnail">
+                <img src="./_images/mpl_plot_parallel.png">
+                <span class="home-img-plot-overlay">Parallel Plot</span>
+            </div>
+        </a>
+
+        <a href="examples/plot_trace.html">
+            <div class="home-img-plot img-thumbnail">
+                <img src="./_images/mpl_plot_trace.png">
+                <span class="home-img-plot-overlay">Trace Plot</span>
+            </div>
+        </a>
+
+        <a href="examples/plot_dot.html">
+            <div class="home-img-plot img-thumbnail">
+                <img src="./_images/mpl_plot_dot.png">
+                <span class="home-img-plot-overlay">Dot Plot</span>
+            </div>
+        </a>
+
+        <a href="examples/plot_ppc.html">
+            <div class="home-img-plot img-thumbnail">
+                <img src="./_images/mpl_plot_ppc.png">
+                <span class="home-img-plot-overlay">Posterior Predictive Checks</span>
+            </div>
+        </a>
+
+        <a href="examples/plot_autocorr.html">
+            <div class="home-img-plot img-thumbnail">
+                <img src="./_images/mpl_plot_autocorr.png">
+                <span class="home-img-plot-overlay">Autocorrelation Plot</span>
+            </div>
+        </a>
+    </div>
+
 |pypi|
 |Build Status|
 |Coverage Status|
@@ -32,35 +123,26 @@ ArviZ: Exploratory analysis of Bayesian models
 .. |Coverage Status| image:: https://codecov.io/gh/arviz-devs/arviz/branch/main/graph/badge.svg
   :target: https://codecov.io/gh/arviz-devs/arviz
 
-.. raw:: html
 
+Installation
+------------
 
-    <div class="container-xl">
-      <div class="row">
-        <div class="col-md-6">
-
-ArviZ is a Python package for exploratory analysis of Bayesian models. Includes functions for posterior analysis, data storage, sample diagnostics, model checking, and comparison.
-
-The goal is to provide backend-agnostic tools for diagnostics and visualizations of Bayesian inference in Python,
-by first converting inference data into `xarray <https://xarray.pydata.org/en/stable/>`_ objects.
-See :ref:`here <xarray_for_arviz>` for more on xarray and ArviZ usage
-and :ref:`here <schema>` for more on ``InferenceData`` structure
-and specification.
-
-
-**Installation** using pip
+Using pip
 
 .. code:: bash
 
     pip install arviz
 
-Alternatively you can use conda-forge
+Using conda-forge
 
 .. code:: bash
 
     conda install -c conda-forge arviz
 
 To install the latest development version of ArviZ, please check the :ref:`Installation guide <dev-version>` for details.
+
+Contribution
+------------
 
 **Contributions** and **issue reports** are very welcome at `the github repository <https://github.com/arviz-devs/arviz>`_. We have a `contributing guide <https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md>`_ to help you through the process. If you have any doubts, please do not hesitate to contact us on `gitter <https://gitter.im/arviz-devs/community>`_.
 
@@ -79,6 +161,8 @@ also available. It provides built-in support for
 
 ArviZ is a non-profit project under NumFOCUS umbrella. If you want to **support ArviZ financially**, you can donate `here <https://numfocus.org/donate-to-arviz>`_.
 
+Citation
+--------
 
 If you use ArviZ and want to **cite** it please use |JOSS|. Here is the citation in BibTeX format
 
@@ -109,107 +193,6 @@ If you use ArviZ and want to **cite** it please use |JOSS|. Here is the citation
   community
   Contributing<contributing/index>
 
-
-.. raw:: html
-
-    </div>
-    <div class="col-md-6">
-      <div class="container">
-        <div class="row">
-            <div class="col">
-            <a href="examples/plot_pair.html">
-            <div class="img-thumbnail">
-                <img src="_static/plot_pair_thumb.png">
-            </div>
-            </a>
-            </div>
-            <div class="col">
-            <a href="examples/plot_forest.html">
-            <div class="img-thumbnail">
-                <img src="_static/plot_forest_thumb.png">
-            </div>
-            </a>
-            </div>
-            <div class="col">
-            <a href="examples/plot_density.html">
-            <div class="img-thumbnail">
-                <img src="_static/plot_density_thumb.png">
-            </div>
-            </a>
-            </div>
-            <div class="col">
-            <a href="examples/plot_energy.html">
-            <div class="img-thumbnail">
-                <img src="_static/plot_energy_thumb.png">
-            </div>
-            </a>
-            </div>
-        </div>
-        <div class="row">
-            <div class="col">
-            <a href="examples/plot_posterior.html">
-            <div class="img-thumbnail">
-                <img src="_static/plot_posterior_thumb.png">
-            </div>
-            </a>
-            </div>
-            <div class="col">
-            <a href="examples/plot_kde_2d.html">
-            <div class="img-thumbnail">
-                <img src="_static/plot_kde_2d_thumb.png">
-            </div>
-            </a>
-            </div>
-            <div class="col">
-            <a href="examples/plot_forest_ridge.html">
-            <div class="img-thumbnail">
-                <img src="_static/plot_forest_ridge_thumb.png">
-            </div>
-            </a>
-            </div>
-            <div class="col">
-            <a href="examples/plot_parallel.html">
-            <div class="img-thumbnail">
-                <img src="_static/plot_parallel_thumb.png">
-            </div>
-            </a>
-            </div>
-        </div>
-        <div class="row">
-            <div class="col">
-            <a href="examples/plot_trace.html">
-            <div class="img-thumbnail">
-                <img src="_static/plot_trace_thumb.png">
-            </div>
-            </a>
-            </div>
-            <div class="col">
-            <a href="examples/plot_dot.html">
-            <div class="img-thumbnail">
-                <img src="_static/plot_dot_thumb.png">
-            </div>
-            </a>
-            </div>
-            <div class="col">
-            <a href="examples/plot_ppc.html">
-            <div class="img-thumbnail">
-                <img src="_static/plot_ppc_thumb.png">
-            </div>
-            </a>
-            </div>
-            <div class="col">
-            <a href="examples/plot_autocorr.html">
-            <div class="img-thumbnail">
-                <img src="_static/plot_autocorr_thumb.png">
-            </div>
-            </a>
-            </div>
-        </div>
-      </div>
-    </div>
-
-    </div>
-    </div>
 
 
 

--- a/doc/sphinxext/gallery_generator.py
+++ b/doc/sphinxext/gallery_generator.py
@@ -29,17 +29,29 @@ MPL_RST_TEMPLATE = """
 
 {docstring}
 
-**API documentation:** {api_name}
+.. raw:: html
+
+    <div class='example-plot-api-container'>
+        <p class='example-plot-api-title'>API Reference</p>
+        <div class='example-plot-api-name'>
+        
+{api_name}
+
+.. raw:: html
+
+    </div></div>
 
 .. tab-set::
     .. tab-item:: Matplotlib
 
         .. image:: {img_file}
 
-        **Python source code:** :download:`[download source: {fname}]<{fname}>`
-
         .. literalinclude:: {fname}
             :lines: {end_line}-
+        
+        .. div:: example-plot-download
+
+           :download:`Download Python Source Code: {fname}<{fname}>`
 
 """
 
@@ -49,10 +61,12 @@ BOKEH_RST_TEMPLATE = """
         .. bokeh-plot:: {absfname}
             :source-position: none
 
-        **Python source code:** :download:`[download source: {fname}]<{fname}>`
-
         .. literalinclude:: {fname}
             :lines: {end_line}-
+        
+        .. div:: example-plot-download
+
+           :download:`Download Python Source Code: {fname}<{fname}>`
 """
 
 RST_TEMPLATES = {"matplotlib": MPL_RST_TEMPLATE, "bokeh": BOKEH_RST_TEMPLATE}
@@ -207,36 +221,30 @@ class ExampleGenerator:
                     first_par = paragraphs[0]
             break
 
-        thumbloc = None
-        title: Optional[str] = None
+        # thumbloc = None
+        # title: Optional[str] = None
         ex_title: str = ""
         for line in docstring.split("\n"):
-            # we've found everything we need...
-            if thumbloc and title and ex_title != "":
-                break
-            m = re.match(r"^_thumb: (\.\d+),\s*(\.\d+)", line)
-            if m:
-                thumbloc = float(m.group(1)), float(m.group(2))
-                continue
-            m = re.match(r"^_example_title: (.*)$", line)
-            if m:
-                title = m.group(1)
-                continue
+            # # we've found everything we need...
+            # if thumbloc and title and ex_title != "":
+            #     break
+            # m = re.match(r"^_thumb: (\.\d+),\s*(\.\d+)", line)
+            # if m:
+            #     thumbloc = float(m.group(1)), float(m.group(2))
+            #     continue
+            # m = re.match(r"^_example_title: (.*)$", line)
+            # if m:
+            #     title = m.group(1)
+            #     continue
             # capture the first non-empty line of the docstring as title
             if ex_title == "":
                 ex_title = line
         assert ex_title != ""
-        if thumbloc is not None:
-            self.thumbloc = thumbloc
-            docstring = "\n".join([l for l in docstring.split("\n") if not l.startswith("_thumb")])
+        # if thumbloc is not None:
+        #     self.thumbloc = thumbloc
+        #     docstring = "\n".join([l for l in docstring.split("\n") if not l.startswith("_thumb")])
 
-        if title is not None:
-            docstring = "\n".join(
-                [l for l in docstring.split("\n") if not l.startswith("_example_title")]
-            )
-        else:
-            title = ex_title
-        self._title = title
+        self._title = ex_title
 
         self.docstring = docstring
         self.short_desc = first_par
@@ -270,7 +278,6 @@ class ExampleGenerator:
             sphinx_tag=self.sphinxtag,
             title=self.title,
         )
-
 
 def main(app):
     # Get paths for files

--- a/doc/sphinxext/gallery_generator.py
+++ b/doc/sphinxext/gallery_generator.py
@@ -59,87 +59,6 @@ BOKEH_RST_TEMPLATE = """
 RST_TEMPLATES = {"matplotlib": MPL_RST_TEMPLATE, "bokeh": BOKEH_RST_TEMPLATE}
 
 INDEX_TEMPLATE = """
-
-.. raw:: html
-
-    <style type="text/css">
-    .figure {{
-        position: relative;
-        float: left;
-        margin: 10px;
-        width: 180px;
-        height: 200px;
-    }}
-
-    .figure img {{
-        position: absolute;
-        display: inline;
-        left: 0;
-        width: 170px;
-        height: 170px;
-        opacity:1.0;
-        filter:alpha(opacity=100); /* For IE8 and earlier */
-    }}
-
-    .figure:hover img {{
-        -webkit-filter: blur(3px);
-        -moz-filter: blur(3px);
-        -o-filter: blur(3px);
-        -ms-filter: blur(3px);
-        filter: blur(3px);
-        opacity:1.0;
-        filter:alpha(opacity=100); /* For IE8 and earlier */
-    }}
-
-    span.figure-label {{
-        position: absolute;
-        display: inline;
-        left: 0;
-        width: 170px;
-        height: 170px;
-        background: #000;
-        color: #fff;
-        visibility: hidden;
-        opacity: 0;
-        z-index: 100;
-    }}
-
-    .figure p {{
-        position: absolute;
-        top: 45%;
-        width: 170px;
-        font-size: 110%;
-    }}
-
-    .figure:hover span {{
-        visibility: visible;
-        opacity: .4;
-    }}
-
-    .caption {{
-        position: absolute;
-        width: 180px;
-        top: 170px;
-        text-align: center !important;
-    }}
-
-    .figure .gallery-figure-title p {{
-        position: relative;
-        top: 170px;
-        color: black;
-        visibility: visible;
-        text-align: center !important;
-        line-height: normal;
-    }}
-    .figure .gallery-figure-title span {{
-        top: 170px;
-        position: relative;
-        visibility: visible;
-    }}
-    </style>
-
-.. _{sphinx_tag}:
-
 Example gallery
 ===============
 
@@ -149,20 +68,20 @@ Example gallery
 
 CONTENTS_ENTRY_TEMPLATE = (
     ".. raw:: html\n\n"
-    "    <div class='figure align-center'>\n"
+    "    <div class='example-gallery-figure align-center'>\n"
     "    <a href=./{htmlfilename}>\n"
     "    <img src=../_static/{thumbfilename}>\n"
-    "    <span class='figure-label'>\n"
+    "    <span class='example-gallery-figure-label'>\n"
     "    <p>{sphinx_tag}</p>\n"
     "    </span>\n"
-    '    <span class="gallery-figure-title">\n'
+    '    <span class="example-gallery-figure-title">\n'
     "      <p>{title}</p>\n"
     "    </span>\n"
     "    </a>\n"
     "    </div>\n\n"
     "\n\n"
     ""
-)
+) 
 
 
 def create_thumbnail(infile, thumbfile, width=275, height=275, cx=0.5, cy=0.5, border=4):

--- a/doc/sphinxext/gallery_generator.py
+++ b/doc/sphinxext/gallery_generator.py
@@ -91,10 +91,8 @@ CONTENTS_ENTRY_TEMPLATE = """
       :text-align: center
       :shadow: none
       :class-card: example-gallery
-      :class-header: test test
 
       .. image:: ./matplotlib/{pngfilename}
-	     :alt: alt text would go here (optional for now, could be the description we discussed)
 
       +++
       {title}

--- a/doc/sphinxext/gallery_generator.py
+++ b/doc/sphinxext/gallery_generator.py
@@ -29,17 +29,9 @@ MPL_RST_TEMPLATE = """
 
 {docstring}
 
-.. raw:: html
+.. seealso::
 
-    <div class='example-plot-api-container'>
-        <p class='example-plot-api-title'>API Reference</p>
-        <div class='example-plot-api-name'>
-        
-{api_name}
-
-.. raw:: html
-
-    </div></div>
+    API Documentation: {api_name}
 
 .. tab-set::
     .. tab-item:: Matplotlib

--- a/doc/sphinxext/gallery_generator.py
+++ b/doc/sphinxext/gallery_generator.py
@@ -40,7 +40,7 @@ MPL_RST_TEMPLATE = """
 
         .. literalinclude:: {fname}
             :lines: {end_line}-
-        
+
         .. div:: example-plot-download
 
            :download:`Download Python Source Code: {fname}<{fname}>`
@@ -55,7 +55,7 @@ BOKEH_RST_TEMPLATE = """
 
         .. literalinclude:: {fname}
             :lines: {end_line}-
-        
+
         .. div:: example-plot-download
 
            :download:`Download Python Source Code: {fname}<{fname}>`
@@ -64,6 +64,8 @@ BOKEH_RST_TEMPLATE = """
 RST_TEMPLATES = {"matplotlib": MPL_RST_TEMPLATE, "bokeh": BOKEH_RST_TEMPLATE}
 
 INDEX_TEMPLATE = """
+:html_theme.sidebar_secondary.remove:
+
 .. _{sphinx_tag}:
 
 Example gallery
@@ -84,7 +86,7 @@ CONTENTS_START = """
 """
 
 CONTENTS_ENTRY_TEMPLATE = """
-   .. grid-item-card:: 
+   .. grid-item-card::
       :link: ./{htmlfilename}
       :text-align: center
       :shadow: none
@@ -93,7 +95,7 @@ CONTENTS_ENTRY_TEMPLATE = """
 
       .. image:: ./matplotlib/{pngfilename}
 	     :alt: alt text would go here (optional for now, could be the description we discussed)
-      
+
       +++
       {title}
 """
@@ -305,7 +307,7 @@ def main(app):
             "image_dir": image_dir,
         }
 
-    # Begin templates for table of contents and content cards 
+    # Begin templates for table of contents and content cards
     toctree = TOCTREE_START
     contents = CONTENTS_START
 

--- a/examples/bokeh/bokeh_plot_autocorr.py
+++ b/examples/bokeh/bokeh_plot_autocorr.py
@@ -1,8 +1,6 @@
 """
 Autocorrelation Plot
 ====================
-
-_thumb: .8, .8
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_bpv.py
+++ b/examples/bokeh/bokeh_plot_bpv.py
@@ -1,6 +1,6 @@
 """
-Bayesian p-value Posterior plot
-===============================
+Bayesian u-value Plot
+=====================
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_bpv.py
+++ b/examples/bokeh/bokeh_plot_bpv.py
@@ -1,8 +1,6 @@
 """
 Bayesian p-value Posterior plot
 ===============================
-
-_thumb: .6, .5
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_bpv_tstat.py
+++ b/examples/bokeh/bokeh_plot_bpv_tstat.py
@@ -1,8 +1,6 @@
 """
 Bayesian p-value with median T statistic Posterior plot
 =======================================================
-
-_thumb: .6, .5
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_bpv_tstat.py
+++ b/examples/bokeh/bokeh_plot_bpv_tstat.py
@@ -1,6 +1,6 @@
 """
-Bayesian p-value with median T statistic Posterior plot
-=======================================================
+Bayesian p-value with T statistic Plot
+======================================
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_compare.py
+++ b/examples/bokeh/bokeh_plot_compare.py
@@ -1,8 +1,6 @@
 """
 Compare Plot
 ============
-
-_thumb: .5, .5
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_density.py
+++ b/examples/bokeh/bokeh_plot_density.py
@@ -1,8 +1,6 @@
 """
 Density Plot
 ============
-
-_thumb: .5, .5
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_dist.py
+++ b/examples/bokeh/bokeh_plot_dist.py
@@ -1,8 +1,6 @@
 """
 Dist Plot Bokeh
 ===============
-
-_thumb: .2, .8
 """
 import bokeh.plotting as bkp
 import numpy as np

--- a/examples/bokeh/bokeh_plot_dot.py
+++ b/examples/bokeh/bokeh_plot_dot.py
@@ -1,9 +1,6 @@
 """
 Dot Plot
 =========
-
-_thumb: .2, .8
-_example_title: Plot distribution.
 """
 import numpy as np
 import arviz as az

--- a/examples/bokeh/bokeh_plot_elpd.py
+++ b/examples/bokeh/bokeh_plot_elpd.py
@@ -1,8 +1,6 @@
 """
 ELPD Plot
 =========
-
-_thumb: .8, .8
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_energy.py
+++ b/examples/bokeh/bokeh_plot_energy.py
@@ -1,8 +1,6 @@
 """
 Energy Plot
 ===========
-
-_thumb: .7, .5
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_ess_evolution.py
+++ b/examples/bokeh/bokeh_plot_ess_evolution.py
@@ -1,6 +1,6 @@
 """
-ESS Quantile Plot
-=================
+ESS Evolution Plot
+==================
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_ess_evolution.py
+++ b/examples/bokeh/bokeh_plot_ess_evolution.py
@@ -1,8 +1,6 @@
 """
 ESS Quantile Plot
 =================
-
-_thumb: .2, .8
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_ess_local.py
+++ b/examples/bokeh/bokeh_plot_ess_local.py
@@ -1,8 +1,6 @@
 """
 ESS Local Plot
 ==============
-
-_thumb: .6, .5
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_ess_quantile.py
+++ b/examples/bokeh/bokeh_plot_ess_quantile.py
@@ -1,8 +1,6 @@
 """
 ESS Quantile Plot
 =================
-
-_thumb: .4, .5
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_forest.py
+++ b/examples/bokeh/bokeh_plot_forest.py
@@ -1,8 +1,6 @@
 """
 Forest Plot
 ===========
-
-_thumb: .5, .8
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_forest_ridge.py
+++ b/examples/bokeh/bokeh_plot_forest_ridge.py
@@ -1,8 +1,6 @@
 """
 Ridgeplot
 =========
-
-_thumb: .8, .5
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_hdi.py
+++ b/examples/bokeh/bokeh_plot_hdi.py
@@ -1,8 +1,6 @@
 """
 Plot HDI
 ========
-
-_thumb: .8, .8
 """
 import bokeh.plotting as bkp
 import numpy as np

--- a/examples/bokeh/bokeh_plot_joint.py
+++ b/examples/bokeh/bokeh_plot_joint.py
@@ -1,8 +1,6 @@
 """
 Joint Plot
 ==========
-
-_thumb: .5, .8
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_kde.py
+++ b/examples/bokeh/bokeh_plot_kde.py
@@ -1,8 +1,6 @@
 """
 KDE Plot Bokeh
 ==============
-
-_thumb: .2, .8
 """
 import bokeh.plotting as bkp
 import numpy as np

--- a/examples/bokeh/bokeh_plot_kde_2d.py
+++ b/examples/bokeh/bokeh_plot_kde_2d.py
@@ -1,8 +1,6 @@
 """
 2d KDE (default style)
 ======================
-
-_thumb: .1, .8
 """
 import numpy as np
 

--- a/examples/bokeh/bokeh_plot_kde_2d_bis.py
+++ b/examples/bokeh/bokeh_plot_kde_2d_bis.py
@@ -1,8 +1,6 @@
 """
 2d KDE (custom style)
 =====================
-
-_thumb: .1, .8
 """
 import numpy as np
 

--- a/examples/bokeh/bokeh_plot_kde_2d_hdi.py
+++ b/examples/bokeh/bokeh_plot_kde_2d_hdi.py
@@ -1,9 +1,6 @@
 """
 2d KDE with HDI Contours
 ========================
-
-_thumb: .5, .8
-_example_title: 2d KDE with HDI Contours
 """
 import numpy as np
 

--- a/examples/bokeh/bokeh_plot_kde_quantiles.py
+++ b/examples/bokeh/bokeh_plot_kde_quantiles.py
@@ -1,8 +1,6 @@
 """
 KDE quantiles Bokeh
 ===================
-
-_thumb: .2, .8
 """
 import numpy as np
 

--- a/examples/bokeh/bokeh_plot_khat.py
+++ b/examples/bokeh/bokeh_plot_khat.py
@@ -1,8 +1,6 @@
 """
 Pareto Shape Plot
 =================
-
-_thumb: .7, .5
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_lm.py
+++ b/examples/bokeh/bokeh_plot_lm.py
@@ -1,8 +1,6 @@
 """
 Regression Plot.
-
 ==========================================
-_thumb: .6, .5
 """
 import xarray as xr
 import numpy as np

--- a/examples/bokeh/bokeh_plot_loo_pit_ecdf.py
+++ b/examples/bokeh/bokeh_plot_loo_pit_ecdf.py
@@ -1,9 +1,6 @@
 """
 LOO-PIT ECDF Plot
 =================
-
-_thumb: .5, .7
-_example_title: Plot LOO predictive ECDF compared to ECDF of uniform distribution to assess predictive calibration.
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_loo_pit_overlay.py
+++ b/examples/bokeh/bokeh_plot_loo_pit_overlay.py
@@ -1,9 +1,6 @@
 """
 LOO-PIT Overlay Plot
 ====================
-
-_thumb: .5, .7
-_example_title: Plot LOO-PIT KDE overlaid on KDEs of uniform samples to assess predictive calibration.
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_mcse.py
+++ b/examples/bokeh/bokeh_plot_mcse.py
@@ -1,8 +1,6 @@
 """
 Quantile Monte Carlo Standard Error Plot
 ========================================
-
-_thumb: .5, .8
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_mcse_errorbar.py
+++ b/examples/bokeh/bokeh_plot_mcse_errorbar.py
@@ -1,8 +1,6 @@
 """
 Quantile MCSE Errobar Plot
 ==========================
-
-_thumb: .6, .4
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_pair.py
+++ b/examples/bokeh/bokeh_plot_pair.py
@@ -1,8 +1,6 @@
 """
 Pair Plot
 =========
-
-_thumb: .2, .5
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_pair_hex.py
+++ b/examples/bokeh/bokeh_plot_pair_hex.py
@@ -1,8 +1,6 @@
 """
 Hexbin PairPlot
 ===============
-
-_thumb: .2, .5
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_pair_kde.py
+++ b/examples/bokeh/bokeh_plot_pair_kde.py
@@ -1,8 +1,6 @@
 """
 KDE Pair Plot
 =============
-
-_thumb: .2, .5
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_pair_kde_hdi.py
+++ b/examples/bokeh/bokeh_plot_pair_kde_hdi.py
@@ -1,9 +1,6 @@
 """
 KDE Pair Plot with HDI Contours
 ===============================
-
-_thumb: .2, .5
-_example_title: KDE Pair Plot with HDI Contours
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_pair_point_estimate.py
+++ b/examples/bokeh/bokeh_plot_pair_point_estimate.py
@@ -1,8 +1,6 @@
 """
 Point Estimate Pairplot
 =======================
-
-_thumb: .2, .5
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_parallel.py
+++ b/examples/bokeh/bokeh_plot_parallel.py
@@ -1,8 +1,6 @@
 """
 Parallel Plot
 =============
-
-_thumb: .2, .5
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_parallel_minmax.py
+++ b/examples/bokeh/bokeh_plot_parallel_minmax.py
@@ -1,8 +1,6 @@
 """
 MinMax Parallel Plot
 ====================
-
-_thumb: .2, .5
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_parallel_normal.py
+++ b/examples/bokeh/bokeh_plot_parallel_normal.py
@@ -1,8 +1,6 @@
 """
 Normal Parallel Plot
 ====================
-
-_thumb: .2, .5
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_parallel_rank.py
+++ b/examples/bokeh/bokeh_plot_parallel_rank.py
@@ -1,8 +1,6 @@
 """
 Rank Parallel Plot
 ==================
-
-_thumb: .2, .5
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_posterior.py
+++ b/examples/bokeh/bokeh_plot_posterior.py
@@ -1,8 +1,6 @@
 """
 Posterior Plot
 ==============
-
-_thumb: .5, .8
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_posterior_combinedims.py
+++ b/examples/bokeh/bokeh_plot_posterior_combinedims.py
@@ -1,8 +1,6 @@
 """
 Posterior Plot (reducing school dimension)
 ==========================================
-
-_thumb: .5, .8
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_ppc.py
+++ b/examples/bokeh/bokeh_plot_ppc.py
@@ -1,8 +1,6 @@
 """
 Posterior Predictive Check Plot
 ===============================
-
-_thumb: .6, .5
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_ppc_cumulative.py
+++ b/examples/bokeh/bokeh_plot_ppc_cumulative.py
@@ -1,8 +1,6 @@
 """
 Posterior Predictive Check Cumulative Plot
 ==========================================
-
-_thumb: .6, .5
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_rank.py
+++ b/examples/bokeh/bokeh_plot_rank.py
@@ -1,8 +1,6 @@
 """
 Rank plot
 =========
-
-_thumb: .1, .8
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_separation.py
+++ b/examples/bokeh/bokeh_plot_separation.py
@@ -1,8 +1,6 @@
 """
 Separation Plot
 ===============
-
-_thumb: .2, .8
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_trace.py
+++ b/examples/bokeh/bokeh_plot_trace.py
@@ -1,8 +1,6 @@
 """
 Traceplot Bokeh
 ===============
-
-_thumb: .1, .8
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_trace_bars.py
+++ b/examples/bokeh/bokeh_plot_trace_bars.py
@@ -1,8 +1,6 @@
 """
 Traceplot rank_bars Bokeh
 =========================
-
-_thumb: .1, .8
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_trace_vlines.py
+++ b/examples/bokeh/bokeh_plot_trace_vlines.py
@@ -1,8 +1,6 @@
 """
 Traceplot rank_vlines Bokeh
 ===========================
-
-_thumb: .1, .8
 """
 import arviz as az
 

--- a/examples/bokeh/bokeh_plot_violin.py
+++ b/examples/bokeh/bokeh_plot_violin.py
@@ -1,8 +1,6 @@
 """
 Violinplot
 ==========
-
-_thumb: .2, .8
 """
 import arviz as az
 

--- a/examples/matplotlib/mpl_plot_autocorr.py
+++ b/examples/matplotlib/mpl_plot_autocorr.py
@@ -1,9 +1,6 @@
 """
 Autocorrelation Plot
 ====================
-
-_thumb: .8, .8
-_example_title: Autocorrelation plot
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_bpv.py
+++ b/examples/matplotlib/mpl_plot_bpv.py
@@ -1,6 +1,6 @@
 """
-Bayesian p-value Posterior plot
-===============================
+Bayesian u-value Plot
+=====================
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_bpv.py
+++ b/examples/matplotlib/mpl_plot_bpv.py
@@ -1,8 +1,6 @@
 """
 Bayesian p-value Posterior plot
 ===============================
-
-_thumb: .6, .5
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_bpv_tstat.py
+++ b/examples/matplotlib/mpl_plot_bpv_tstat.py
@@ -1,8 +1,6 @@
 """
 Bayesian p-value with median T statistic Posterior plot
 =======================================================
-
-_thumb: .6, .5
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_bpv_tstat.py
+++ b/examples/matplotlib/mpl_plot_bpv_tstat.py
@@ -1,6 +1,6 @@
 """
-Bayesian p-value with median T statistic Posterior plot
-=======================================================
+Bayesian p-value with T statistic Plot
+======================================
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_compare.py
+++ b/examples/matplotlib/mpl_plot_compare.py
@@ -1,9 +1,6 @@
 """
 Compare Plot
 ============
-
-_thumb: .5, .5
-_example_title: Comparison plot
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_density.py
+++ b/examples/matplotlib/mpl_plot_density.py
@@ -1,9 +1,6 @@
 """
 Density Plot
 ============
-
-_thumb: .5, .5
-_example_title: Plot density
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_dist.py
+++ b/examples/matplotlib/mpl_plot_dist.py
@@ -1,9 +1,6 @@
 """
 Dist Plot
 =========
-
-_thumb: .2, .8
-_example_title: Plot distribution.
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/matplotlib/mpl_plot_dot.py
+++ b/examples/matplotlib/mpl_plot_dot.py
@@ -1,9 +1,6 @@
 """
 Dot Plot
 =========
-
-_thumb: .2, .8
-_example_title: Plot distribution.
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/matplotlib/mpl_plot_elpd.py
+++ b/examples/matplotlib/mpl_plot_elpd.py
@@ -1,8 +1,6 @@
 """
 ELPD Plot
 =========
-
-_thumb: .6, .5
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_energy.py
+++ b/examples/matplotlib/mpl_plot_energy.py
@@ -1,9 +1,6 @@
 """
 Energy Plot
 ===========
-
-_thumb: .7, .5
-_example_title: Plot energy
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_ess_evolution.py
+++ b/examples/matplotlib/mpl_plot_ess_evolution.py
@@ -1,6 +1,6 @@
 """
-ESS Quantile Plot
-=================
+ESS Evolution Plot
+==================
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_ess_evolution.py
+++ b/examples/matplotlib/mpl_plot_ess_evolution.py
@@ -1,9 +1,6 @@
 """
 ESS Quantile Plot
 =================
-
-_thumb: .2, .8
-_example_title: Plot evolution of Effective Sample Size (ESS)
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_ess_local.py
+++ b/examples/matplotlib/mpl_plot_ess_local.py
@@ -1,9 +1,6 @@
 """
 ESS Local Plot
 ==============
-
-_thumb: .6, .5
-_example_title: Plot local ESS
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_ess_quantile.py
+++ b/examples/matplotlib/mpl_plot_ess_quantile.py
@@ -1,9 +1,6 @@
 """
 ESS Quantile Plot
 =================
-
-_thumb: .4, .5
-_example_title: Plot ESS of quantiles
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_forest.py
+++ b/examples/matplotlib/mpl_plot_forest.py
@@ -1,9 +1,6 @@
 """
 Forest Plot
 ===========
-
-_thumb: .5, .8
-_example_title: Forest plot
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_forest_ridge.py
+++ b/examples/matplotlib/mpl_plot_forest_ridge.py
@@ -1,9 +1,6 @@
 """
 Ridgeplot
 =========
-
-_thumb: .8, .5
-_example_title: Forest plot with individual ridges
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_hdi.py
+++ b/examples/matplotlib/mpl_plot_hdi.py
@@ -1,8 +1,6 @@
 """
 Plot HDI
 ========
-
-_thumb: .8, .8
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/matplotlib/mpl_plot_joint.py
+++ b/examples/matplotlib/mpl_plot_joint.py
@@ -1,9 +1,6 @@
 """
 Joint Plot
 ==========
-
-_thumb: .5, .8
-_example_title: Plot joint distribution
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_kde.py
+++ b/examples/matplotlib/mpl_plot_kde.py
@@ -1,9 +1,6 @@
 """
 KDE Plot
 ========
-
-_thumb: .2, .8
-_example_title: Plot Kernel Density Estimation (KDE)
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/matplotlib/mpl_plot_kde_2d.py
+++ b/examples/matplotlib/mpl_plot_kde_2d.py
@@ -1,9 +1,6 @@
 """
 2d KDE (default style)
 ======================
-
-_thumb: .1, .8
-_example_title: Plot KDE in two dimensions
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/matplotlib/mpl_plot_kde_2d_bis.py
+++ b/examples/matplotlib/mpl_plot_kde_2d_bis.py
@@ -1,8 +1,6 @@
 """
 2d KDE (custom style)
 =====================
-
-_thumb: .1, .8
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/matplotlib/mpl_plot_kde_2d_hdi.py
+++ b/examples/matplotlib/mpl_plot_kde_2d_hdi.py
@@ -1,9 +1,6 @@
 """
 2d KDE with HDI Contours
 ========================
-
-_thumb: .5, .8
-_example_title: 2d KDE with HDI Contours
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/matplotlib/mpl_plot_kde_quantiles.py
+++ b/examples/matplotlib/mpl_plot_kde_quantiles.py
@@ -1,9 +1,6 @@
 """
 KDE quantiles
 =============
-
-_thumb: .2, .8
-_example_title: Plot KDE of quantiles
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/matplotlib/mpl_plot_khat.py
+++ b/examples/matplotlib/mpl_plot_khat.py
@@ -1,9 +1,6 @@
 """
 Pareto Shape Plot
 =================
-
-_thumb: .7, .5
-_example_title: k&#x0302; plot
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_lm.py
+++ b/examples/matplotlib/mpl_plot_lm.py
@@ -1,9 +1,6 @@
 """
 Regression Plot
 ===============
-
-_thumb: .6, .5
-_example_title: Plot regression
 """
 import matplotlib.pyplot as plt
 import xarray as xr

--- a/examples/matplotlib/mpl_plot_loo_pit_ecdf.py
+++ b/examples/matplotlib/mpl_plot_loo_pit_ecdf.py
@@ -2,8 +2,7 @@
 LOO-PIT ECDF Plot
 =================
 
-_thumb: .5, .7
-_example_title: Plot LOO predictive ECDF compared to ECDF of uniform distribution to assess predictive calibration.
+Plot LOO predictive ECDF compared to ECDF of uniform distribution to assess predictive calibration.
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_loo_pit_overlay.py
+++ b/examples/matplotlib/mpl_plot_loo_pit_overlay.py
@@ -1,9 +1,6 @@
 """
 LOO-PIT Overlay Plot
 ====================
-
-_thumb: .5, .7
-_example_title: Plot LOO-PIT KDE overlaid on KDEs of uniform samples to assess predictive calibration.
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_mcse.py
+++ b/examples/matplotlib/mpl_plot_mcse.py
@@ -1,9 +1,6 @@
 """
 Quantile Monte Carlo Standard Error Plot
 ========================================
-
-_thumb: .5, .8
-_example_title: Quantile Monte Carlo Standard Error Plot
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_mcse_errorbar.py
+++ b/examples/matplotlib/mpl_plot_mcse_errorbar.py
@@ -1,9 +1,6 @@
 """
 Quantile MCSE Errobar Plot
 ==========================
-
-_thumb: .6, .4
-_example_title: Quantile MCSE plot with errobars
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_pair.py
+++ b/examples/matplotlib/mpl_plot_pair.py
@@ -1,9 +1,6 @@
 """
 Pair Plot
 =========
-
-_thumb: .2, .5
-_example_title: Pair plot with divergences marked
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_pair_hex.py
+++ b/examples/matplotlib/mpl_plot_pair_hex.py
@@ -1,9 +1,6 @@
 """
 Hexbin PairPlot
 ===============
-
-_thumb: .2, .5
-_example_title: Pair plot on hex grid
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_pair_kde.py
+++ b/examples/matplotlib/mpl_plot_pair_kde.py
@@ -1,9 +1,6 @@
 """
 KDE Pair Plot
 =============
-
-_thumb: .2, .5
-_example_title: KDE pair plot
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_pair_kde_hdi.py
+++ b/examples/matplotlib/mpl_plot_pair_kde_hdi.py
@@ -1,9 +1,6 @@
 """
 KDE Pair Plot with HDI Contours
 ===============================
-
-_thumb: .2, .5
-_example_title: KDE Pair Plot with HDI Contours
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_pair_point_estimate.py
+++ b/examples/matplotlib/mpl_plot_pair_point_estimate.py
@@ -1,9 +1,6 @@
 """
 Point Estimate Pairplot
 =======================
-
-_thumb: .2, .5
-_example_title: Pair plot with point estimate markings
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_parallel.py
+++ b/examples/matplotlib/mpl_plot_parallel.py
@@ -1,9 +1,6 @@
 """
 Parallel Plot
 =============
-
-_thumb: .2, .5
-_example_title: Parallel plot of posterior trace
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_parallel_minmax.py
+++ b/examples/matplotlib/mpl_plot_parallel_minmax.py
@@ -1,9 +1,6 @@
 """
 MinMax Parallel Plot
 ====================
-
-_thumb: .2, .5
-_example_title: Parallel plot with MinMax normalization
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_parallel_normal.py
+++ b/examples/matplotlib/mpl_plot_parallel_normal.py
@@ -1,9 +1,6 @@
 """
 Normal Parallel Plot
 ====================
-
-_thumb: .2, .5
-_example_title: Normalized parallel plot
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_parallel_rank.py
+++ b/examples/matplotlib/mpl_plot_parallel_rank.py
@@ -1,8 +1,6 @@
 """
 Rank Parallel Plot
 ==================
-
-_thumb: .2, .5
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_posterior.py
+++ b/examples/matplotlib/mpl_plot_posterior.py
@@ -1,9 +1,6 @@
 """
 Posterior Plot
 ==============
-
-_thumb: .5, .8
-_example_title: Plot posterior
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_posterior_combinedims.py
+++ b/examples/matplotlib/mpl_plot_posterior_combinedims.py
@@ -1,8 +1,6 @@
 """
 Posterior Plot (reducing school dimension)
 ==========================================
-
-_thumb: .5, .8
 """
 import matplotlib.pyplot as plt
 import arviz as az

--- a/examples/matplotlib/mpl_plot_ppc.py
+++ b/examples/matplotlib/mpl_plot_ppc.py
@@ -1,9 +1,6 @@
 """
 Posterior Predictive Check Plot
 ===============================
-
-_thumb: .6, .5
-_example_title: Plot Posterior Predictive Checks (PPC)
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_ppc_cumulative.py
+++ b/examples/matplotlib/mpl_plot_ppc_cumulative.py
@@ -1,9 +1,6 @@
 """
 Posterior Predictive Check Cumulative Plot
 ==========================================
-
-_thumb: .6, .5
-_example_title: PPC Cumulative distribution plot
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_rank.py
+++ b/examples/matplotlib/mpl_plot_rank.py
@@ -1,9 +1,6 @@
 """
 Rank plot
 =========
-
-_thumb: .1, .8
-_example_title: Rank plot
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_separation.py
+++ b/examples/matplotlib/mpl_plot_separation.py
@@ -1,8 +1,6 @@
 """
 Separation Plot
 ===============
-
-_thumb: .5, .5
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_trace.py
+++ b/examples/matplotlib/mpl_plot_trace.py
@@ -1,9 +1,6 @@
 """
 Traceplot
 =========
-
-_thumb: .1, .8
-_example_title: Plot trace
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_trace_bars.py
+++ b/examples/matplotlib/mpl_plot_trace_bars.py
@@ -1,9 +1,6 @@
 """
 Traceplot rank_bars
 ===================
-
-_thumb: .1, .8
-_example_title: Trace plot with rank bars
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_trace_circ.py
+++ b/examples/matplotlib/mpl_plot_trace_circ.py
@@ -1,8 +1,6 @@
 """
 Traceplot circular variables
 ============================
-
-_thumb: .1, .8
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_trace_vlines.py
+++ b/examples/matplotlib/mpl_plot_trace_vlines.py
@@ -1,9 +1,6 @@
 """
 Traceplot rank_vlines
 =====================
-
-_thumb: .1, .8
-_example_title: Trace plot with vertical lines for ranks
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_plot_violin.py
+++ b/examples/matplotlib/mpl_plot_violin.py
@@ -1,9 +1,6 @@
 """
 Violin plot
 ===========
-
-_thumb: .2, .8
-_example_title: Violin plot
 """
 import matplotlib.pyplot as plt
 

--- a/examples/matplotlib/mpl_styles.py
+++ b/examples/matplotlib/mpl_styles.py
@@ -1,9 +1,6 @@
 """
 Matplotlib styles
 =================
-
-_thumb: .8, .8
-_example_title: Matplotlib styles for ArviZ
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -4,7 +4,7 @@ ipython
 numpydoc
 pydocstyle
 Sphinx>=1.8.3
-pydata_sphinx_theme>=0.6.3
+pydata-sphinx-theme @ git+https://github.com/pydata/pydata-sphinx-theme
 myst-parser
 myst-nb
 sphinx-panels


### PR DESCRIPTION
## Description

Regarding issue #2076 : 
* Move CSS out of `gallery_generator.py` (all custom CSS should go in `custom.css`)
* Convert template `CONTENTS_ENTRY_TEMPLATE` from raw HTML to RST, so it follows sphinx template for creating grid-item-cards ([sphinx documentation](https://sphinx-design.readthedocs.io/en/latest/cards.html))
    * Reformatted toctree and contents a bit by adding `TOCTREE_START` and `CONTENTS_START`, and keeping those separate (instead of joining them together when inserting into `INDEX_TEMPLATE`).
    * **FYI:** Formatting was handled in the CSS. I inserted the `example-gallery` class in each card, so that the CSS only targets objects within that class (i.e. will only affect the Example Gallery page and not others if they are using cards).
* Resized images in example gallery. Instead of using thumbnails, it uses the charts generated by matplotlib.
    * **FYI:** Keeping the ratio intact while making sure images take up the same amount of real estate per card was handled in the CSS (`.example-gallery img.sd-card-img-top` and `.example-gallery .sd-card-body`). This isn't really the normal way to resize images but it works. The more normal would be to create a `<div>` container with fixed height and have the img fill up the container, but I don't think Sphinx has this flexibility.
    * Removed code for generating thumbnail and wherever else thumbnail code was without making the example gallery + subpages worse 🤞 

<img width="400" alt="image" src="https://user-images.githubusercontent.com/20257416/183279540-63b821fe-7384-47f6-bff8-21c14b3fd473.png">

# Questions / Issues:
1. What is the purpose for `sphinxtag` ? I used to be the "example_chart_name" shown in the hover event, which isn't very useful as display text. We could remove it if it's not used.
2. Can I also remove all the `_thumb: .5, .5` related settings from the .py scripts (docstring) in `examples/matplotlib/*` and `examples/bokeh/*`? The gallery generator still has to remove them or else they will appear in the example pages.
3. 2 `_example_title`s in the example gallery are too long (see below). They are `plot_loo_pit_ecdf` and `plot_loo_pit_overlay`. I think there are 2 options:
    * **Option A:** Remove `_example_title` from everything and use the default title in each script. For example, "Plot LOO-PIT KDE overlaid on KDEs of uniform samples to assess predictive calibration." turns into "LOO-PIT Overlay Plot".
    * **Option B:** Change these 2 to a more concise name that can fit up to 3 lines. The card **must be set at a fixed height** (via CSS, which I set at 250px) or else the gallery will look uneven.
    * <img width="400" alt="image" src="https://user-images.githubusercontent.com/20257416/183280238-43805111-35c6-4cf8-849f-a9117d9881ec.png">






<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2087.org.readthedocs.build/en/2087/

<!-- readthedocs-preview arviz end -->