### PR TITLE
Use Read the Docs action v1

### DIFF
--- a/.github/workflows/rtd_link_description.yaml
+++ b/.github/workflows/rtd_link_description.yaml
@@ -11,6 +11,6 @@ jobs:
   documentation-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: readthedocs/readthedocs-preview@main
+      - uses: readthedocs/actions/preview@v1
         with:
           project-slug: "arviz"


### PR DESCRIPTION
Read the Docs repository was renamed from `readthedocs/readthedocs-preview` to `readthedocs/actions/`. Now, the `preview` action is under `readthedocs/actions/preview` and is tagged as `v1`

<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2091.org.readthedocs.build/en/2091/

<!-- readthedocs-preview arviz end -->