### PR TITLE
fix doc requirementts

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -4,7 +4,7 @@ ipython
 numpydoc
 pydocstyle
 Sphinx>=1.8.3
-pydata-sphinx-theme @ git+https://github.com/pydata/pydata-sphinx-theme
+pydata-sphinx-theme>=0.10.0
 myst-parser
 myst-nb
 sphinx-panels


### PR DESCRIPTION
We forgot to unset the theme requirement to the github version.

<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2111.org.readthedocs.build/en/2111/

<!-- readthedocs-preview arviz end -->