### PR TITLE
Fix README table column width to resize images

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ python setup.py install
 
 -------------------------------------------------------------------------------
 ## [Gallery](https://python.arviz.org/en/latest/examples/index.html)
-
+<style>table#gallery td {width: 25%;}</style>
 <p>
-<table>
+<table id="gallery">
 <tr>
 
   <td>

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ python setup.py install
 
 -------------------------------------------------------------------------------
 ## [Gallery](https://python.arviz.org/en/latest/examples/index.html)
+
 <style>table#gallery td {width: 25%;}</style>
 <p>
 <table id="gallery">

--- a/README.md
+++ b/README.md
@@ -57,84 +57,14 @@ python setup.py install
 -------------------------------------------------------------------------------
 ## [Gallery](https://python.arviz.org/en/latest/examples/index.html)
 
-<style>table#gallery td {width: 25%;}</style>
 <p>
-<table id="gallery">
+<table>
 <tr>
 
   <td>
   <a href="https://python.arviz.org/en/latest/examples/plot_forest_ridge.html">
   <img alt="Ridge plot"
   src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_forest_ridge.png" />
-  </a>
-  </td>
-
-  <td>
-  <a href="https://python.arviz.org/en/latest/examples/plot_parallel.html">
-  <img alt="Parallel plot"
-  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_parallel.png" />
-  </a>
-  </td>
-
-  <td>
-  <a href="https://python.arviz.org/en/latest/examples/plot_trace.html">
-  <img alt="Trace plot"
-  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_trace.png" />
-  </a>
-  </td>
-
-  <td>
-  <a href="https://python.arviz.org/en/latest/examples/plot_density.html">
-  <img alt="Density plot"
-  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_density.png" />
-  </a>
-  </td>
-
-  </tr>
-  <tr>
-
-  <td>
-  <a href="https://python.arviz.org/en/latest/examples/plot_posterior.html">
-  <img alt="Posterior plot"
-  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_posterior.png" />
-  </a>
-  </td>
-
-  <td>
-  <a href="https://python.arviz.org/en/latest/examples/plot_dot.html">
-  <img alt="Joint plot"
-  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_dot.png" />
-  </a>
-  </td>
-
-  <td>
-  <a href="https://python.arviz.org/en/latest/examples/plot_ppc.html">
-  <img alt="Posterior predictive plot"
-  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_ppc.png" />
-  </a>
-  </td>
-
-  <td>
-  <a href="https://python.arviz.org/en/latest/examples/plot_pair.html">
-  <img alt="Pair plot"
-  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_pair.png" />
-  </a>
-  </td>
-
-  </tr>
-  <tr>
-
-  <td>
-  <a href="https://python.arviz.org/en/latest/examples/plot_energy.html">
-  <img alt="Energy Plot"
-  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_pair_hex.png" />
-  </a>
-  </td>
-
-  <td>
-  <a href="https://python.arviz.org/en/latest/examples/plot_violin.html">
-  <img alt="Violin Plot"
-  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_violin.png" />
   </a>
   </td>
 
@@ -146,9 +76,80 @@ python setup.py install
   </td>
 
   <td>
-  <a href="https://python.arviz.org/en/latest/examples/plot_autocorr.html">
-  <img alt="Autocorrelation Plot"
-  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_autocorr.png" />
+  <a href="https://python.arviz.org/en/latest/examples/plot_violin.html">
+  <img alt="Violin Plot"
+  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_violin.png" />
+  </a>
+  </td>
+
+</tr>
+<tr>
+
+  <td>
+  <a href="https://python.arviz.org/en/latest/examples/plot_ppc.html">
+  <img alt="Posterior predictive plot"
+  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_ppc.png" />
+  </a>
+  </td>
+
+  <td>
+  <a href="https://python.arviz.org/en/latest/examples/plot_dot.html">
+  <img alt="Joint plot"
+  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_dot.png" />
+  </a>
+  </td>
+
+  <td>
+  <a href="https://python.arviz.org/en/latest/examples/plot_posterior.html">
+  <img alt="Posterior plot"
+  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_posterior.png" />
+  </a>
+  </td>
+
+</tr>
+<tr>
+
+  <td>
+  <a href="https://python.arviz.org/en/latest/examples/plot_density.html">
+  <img alt="Density plot"
+  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_density.png" />
+  </a>
+  </td>
+
+  <td>
+  <a href="https://python.arviz.org/en/latest/examples/plot_pair.html">
+  <img alt="Pair plot"
+  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_pair.png" />
+  </a>
+  </td>
+
+  <td>
+  <a href="https://python.arviz.org/en/latest/examples/plot_pair_hex.html">
+  <img alt="Hexbin Pair plot"
+  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_pair_hex.png" />
+  </a>
+  </td>
+
+</tr>
+<tr>
+  <td>
+  <a href="https://python.arviz.org/en/latest/examples/plot_trace.html">
+  <img alt="Trace plot"
+  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_trace.png" />
+  </a>
+  </td>
+
+  <td>
+  <a href="https://python.arviz.org/en/latest/examples/plot_energy.html">
+  <img alt="Energy Plot"
+  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_energy.png" />
+  </a>
+  </td>
+
+  <td>
+  <a href="https://python.arviz.org/en/latest/examples/plot_rank.html">
+  <img alt="Rank Plot"
+  src="https://raw.githubusercontent.com/arviz-devs/arviz/gh-pages/_images/mpl_plot_rank.png" />
   </a>
   </td>
 


### PR DESCRIPTION
After changing the example gallery image sizes (no thumbnail, change `figsize`), the README doesn't look so great right now 😅 Forgot to update while working on this https://github.com/arviz-devs/arviz/pull/2108 

<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2113.org.readthedocs.build/en/2113/

<!-- readthedocs-preview arviz end -->