### PR TITLE
Allow numpyro converter to work with namedtuples

### DIFF
--- a/arviz/data/io_numpyro.py
+++ b/arviz/data/io_numpyro.py
@@ -86,6 +86,9 @@ class NumPyroConverter:
 
         if posterior is not None:
             samples = jax.device_get(self.posterior.get_samples(group_by_chain=True))
+            if hasattr(samples, "_asdict"):
+                # In case it is easy to convert to a dictionary, as in the case of namedtuples
+                samples = samples._asdict()
             if not isinstance(samples, dict):
                 # handle the case we run MCMC with a general potential_fn
                 # (instead of a NumPyro model) whose args is not a dictionary
@@ -183,6 +186,8 @@ class NumPyroConverter:
         data = {}
         if self.observations is not None:
             samples = self.posterior.get_samples(group_by_chain=False)
+            if hasattr(samples, "_asdict"):
+                samples = samples._asdict()
             log_likelihood_dict = self.numpyro.infer.log_likelihood(
                 self.model, samples, *self._args, **self._kwargs
             )

--- a/arviz/tests/external_tests/test_data_numpyro.py
+++ b/arviz/tests/external_tests/test_data_numpyro.py
@@ -1,4 +1,6 @@
 # pylint: disable=no-member, invalid-name, redefined-outer-name
+from collections import namedtuple
+from unicodedata import name
 import numpy as np
 import pytest
 
@@ -67,6 +69,20 @@ class TestDataNumPyro:
             dims={"theta": ["school"], "eta": ["school"], "obs": ["school"]},
             pred_dims={"theta": ["school_pred"], "eta": ["school_pred"], "obs": ["school_pred"]},
         )
+
+    def test_inference_data_namedtuple(self, data):
+        samples = data.obj.get_samples()
+        Samples = namedtuple("Samples", samples)
+        data_namedtuple = Samples(**samples)
+        _old_fn = data.obj.get_samples
+        data.obj.get_samples = lambda *args, **kwargs: data_namedtuple
+        inference_data = from_numpyro(
+            posterior=data.obj,
+        )
+        assert isinstance(data.obj.get_samples(), Samples)
+        data.obj.get_samples = _old_fn
+        for key in samples:
+            assert key in inference_data.posterior
 
     def test_inference_data(self, data, eight_schools_params, predictions_data, predictions_params):
         inference_data = self.get_inference_data(

--- a/arviz/tests/external_tests/test_data_numpyro.py
+++ b/arviz/tests/external_tests/test_data_numpyro.py
@@ -1,6 +1,5 @@
 # pylint: disable=no-member, invalid-name, redefined-outer-name
 from collections import namedtuple
-from unicodedata import name
 import numpy as np
 import pytest
 

--- a/arviz/tests/external_tests/test_data_pymc.py
+++ b/arviz/tests/external_tests/test_data_pymc.py
@@ -230,7 +230,9 @@ class TestDataPyMC3:
         df_data = pd.DataFrame(columns=["date"]).set_index("date")
         dates = pd.date_range(start="2020-05-01", end="2020-05-20")
         for city, mu in {"Berlin": 15, "San Marino": 18, "Paris": 16}.items():
-            df_data[city] = np.random.normal(loc=mu, size=len(dates))
+            df_data[city] = np.random.normal(  # pylint: disable=unsupported-assignment-operation
+                loc=mu, size=len(dates)
+            )
         df_data.index = dates
         df_data.index.name = "date"
 


### PR DESCRIPTION
Small change to allow numpyro's converter to also grab names from a namedtuple (the current behavior will name variables of a named tuple `Param:0`, `Param:1`, ...) 



<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2121.org.readthedocs.build/en/2121/

<!-- readthedocs-preview arviz end -->