### PR TITLE
Correctly (re)order dimensions for bfmi and plot_energy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
   ([2096](https://github.com/arviz-devs/arviz/pull/2096) and [2105](https://github.com/arviz-devs/arviz/pull/2105))
 * Bokeh kde contour plots started to use `contourpy` package ([2104](https://github.com/arviz-devs/arviz/pull/2104))
 * Update default Bokeh markers for rcparams ([2104](https://github.com/arviz-devs/arviz/pull/2104))
-* Correctly (re)order dimensions for bfmi ([2126](https://github.com/arviz-devs/arviz/pull/2126))
+* Correctly (re)order dimensions for `bfmi` and `plot_energy` ([2126](https://github.com/arviz-devs/arviz/pull/2126))
 
 ### Deprecation
 * Removed `fill_last`, `contour` and `plot_kwargs` arguments from `plot_pair` function ([2085](https://github.com/arviz-devs/arviz/pull/2085))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   ([2096](https://github.com/arviz-devs/arviz/pull/2096) and [2105](https://github.com/arviz-devs/arviz/pull/2105))
 * Bokeh kde contour plots started to use `contourpy` package ([2104](https://github.com/arviz-devs/arviz/pull/2104))
 * Update default Bokeh markers for rcparams ([2104](https://github.com/arviz-devs/arviz/pull/2104))
+* Correctly (re)order dimensions for bfmi ([2126](https://github.com/arviz-devs/arviz/pull/2126))
 
 ### Deprecation
 * Removed `fill_last`, `contour` and `plot_kwargs` arguments from `plot_pair` function ([2085](https://github.com/arviz-devs/arviz/pull/2085))

--- a/arviz/plots/energyplot.py
+++ b/arviz/plots/energyplot.py
@@ -97,7 +97,7 @@ def plot_energy(
         >>> az.plot_energy(data, kind='hist')
 
     """
-    energy = convert_to_dataset(data, group="sample_stats").energy.values
+    energy = convert_to_dataset(data, group="sample_stats").energy.transpose("chain", "draw").values
 
     if kind == "histogram":
         warnings.warn(

--- a/arviz/stats/diagnostics.py
+++ b/arviz/stats/diagnostics.py
@@ -65,7 +65,7 @@ def bfmi(data):
     dataset = convert_to_dataset(data, group="sample_stats")
     if not hasattr(dataset, "energy"):
         raise TypeError("Energy variable was not found.")
-    return _bfmi(dataset.energy.transpose('chain', 'draw'))
+    return _bfmi(dataset.energy.transpose("chain", "draw"))
 
 
 def ess(

--- a/arviz/stats/diagnostics.py
+++ b/arviz/stats/diagnostics.py
@@ -65,7 +65,7 @@ def bfmi(data):
     dataset = convert_to_dataset(data, group="sample_stats")
     if not hasattr(dataset, "energy"):
         raise TypeError("Energy variable was not found.")
-    return _bfmi(dataset.energy)
+    return _bfmi(dataset.energy.transpose('chain', 'draw'))
 
 
 def ess(

--- a/arviz/tests/base_tests/test_diagnostics.py
+++ b/arviz/tests/base_tests/test_diagnostics.py
@@ -52,6 +52,13 @@ class TestDiagnostics:
         with pytest.raises(TypeError):
             bfmi(data)
 
+    def test_bfmi_correctly_transposed(self):
+        data = load_arviz_data("centered_eight")
+        vals1 = bfmi(data)
+        data.sample_stats["energy"] = data.sample_stats["energy"].T
+        vals2 = bfmi(data)
+        assert_almost_equal(vals1, vals2)
+
     def test_deterministic(self):
         """
         Test algorithm against posterior (R) convergence functions.

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -383,12 +383,14 @@ def test_plot_energy_bad(models):
     with pytest.raises(ValueError):
         plot_energy(models.model_1, kind="bad_kind")
 
+
 def test_plot_energy_correctly_transposed():
     idata = load_arviz_data("centered_eight")
     idata.sample_stats["energy"] = idata.sample_stats.energy.T
     ax = plot_energy(idata)
     # legend has one entry for each KDE and 1 BFMI for each chain
     assert len(ax.legend_.texts) == 2 + len(idata.sample_stats.chain)
+
 
 def test_plot_parallel_raises_valueerror(df_trace):  # pylint: disable=invalid-name
     with pytest.raises(ValueError):

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -383,6 +383,12 @@ def test_plot_energy_bad(models):
     with pytest.raises(ValueError):
         plot_energy(models.model_1, kind="bad_kind")
 
+def test_plot_energy_correctly_transposed():
+    idata = load_arviz_data("centered_eight")
+    idata.sample_stats["energy"] = idata.sample_stats.energy.T
+    ax = plot_energy(idata)
+    # legend has one entry for each KDE and 1 BFMI for each chain
+    assert len(ax.legend_.texts) == 2 + len(idata.sample_stats.chain)
 
 def test_plot_parallel_raises_valueerror(df_trace):  # pylint: disable=invalid-name
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Description

This PR ensures that `bfmi` and `plot_energy` compute the same thing if the named dimensions `(chain, draw)` are instead ordered as `(draw, chain)` and adds a test.

Addresses part of https://github.com/arviz-devs/arviz/issues/2102#issuecomment-1229416637

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Does the PR follow [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist)
      PR format?
- [x] Does the PR include new or updated tests to prevent issue recurrence (using [pytest fixture pattern](
      https://docs.pytest.org/en/latest/fixture.html#fixture))?
- [x] Is the code style correct (follows pylint and black guidelines)?
- [x] Is the fix listed in the [Maintenance and fixes](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#maintenance-and-fixes)
      section of the changelog?

<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2126.org.readthedocs.build/en/2126/

<!-- readthedocs-preview arviz end -->