### PR TITLE
Fix deprecation of matplotlib.pyplot.register_cmap

### DIFF
--- a/arviz/__init__.py
+++ b/arviz/__init__.py
@@ -6,7 +6,8 @@ import logging
 import os
 
 from matplotlib.colors import LinearSegmentedColormap
-from matplotlib.pyplot import register_cmap, style
+from matplotlib.pyplot import style
+import matplotlib as mpl
 
 
 class Logger(logging.Logger):
@@ -314,7 +315,7 @@ _linear_grey_10_95_c0 = [
 
 def _mpl_cm(name, colorlist):
     cmap = LinearSegmentedColormap.from_list(name, colorlist, N=256)
-    register_cmap("cet_" + name, cmap=cmap)
+    mpl.colormaps.register(cmap, name="cet_" + name)
 
 
 _mpl_cm("gray", _linear_grey_10_95_c0)
@@ -322,4 +323,4 @@ _mpl_cm("gray_r", list(reversed(_linear_grey_10_95_c0)))
 
 
 # clean namespace
-del os, logging, register_cmap, LinearSegmentedColormap, Logger
+del os, logging, LinearSegmentedColormap, Logger, mpl


### PR DESCRIPTION
## Description

Hi, the `matplotlib.pyplot.register_cmap` function was [deprecated in Matplotlib 3.6](https://matplotlib.org/stable/api/cm_api.html#matplotlib.cm.register_cmap), for `matplotlib.colormaps.register`. I just made this change, which also works for Matplotlib 3.5 as far as I can tell.

<!--
Thank you so much for your PR! To help us review your contribution, please consider the following points:

- The PR title should summarize the changes, for example "Add new group argument for the pair plot".
  Avoid non-descriptive titles such as "Addresses issue #348".

- The description should provide at least 1-2 sentences describing the pull request in detail and
  link to any relevant issues.

- Please prefix the title of incomplete contributions with [WIP] (to indicate a work in
  progress). WIPs may be useful to (1) indicate you are working on something to avoid
  duplicated work, (2) request broad review of functionality or API, or (3) seek collaborators. -->

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->


<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2127.org.readthedocs.build/en/2127/

<!-- readthedocs-preview arviz end -->