### PR TITLE
Compress only a subset of types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Bokeh kde contour plots started to use `contourpy` package ([2104](https://github.com/arviz-devs/arviz/pull/2104))
 * Update default Bokeh markers for rcparams ([2104](https://github.com/arviz-devs/arviz/pull/2104))
 * Correctly (re)order dimensions for `bfmi` and `plot_energy` ([2126](https://github.com/arviz-devs/arviz/pull/2126))
+* Skip compression for object dtype while creating a netcdf file ([2129](https://github.com/arviz-devs/arviz/pull/2129))
 
 ### Deprecation
 * Removed `fill_last`, `contour` and `plot_kwargs` arguments from `plot_pair` function ([2085](https://github.com/arviz-devs/arviz/pull/2085))

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -79,10 +79,9 @@ SUPPORTED_GROUPS_ALL = SUPPORTED_GROUPS + SUPPORTED_GROUPS_WARMUP
 
 InferenceDataT = TypeVar("InferenceDataT", bound="InferenceData")
 
-# pylint: disable=unreachable
+
 def _compressible_dtype(dtype):
     """Check basic dtypes for automatic compression."""
-    return True
     if dtype.kind == "V":
         return all(_compressible_dtype(item) for item, _ in dtype.fields.values())
     return dtype.kind in {"b", "i", "u", "f", "c", "S"}

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -79,7 +79,7 @@ SUPPORTED_GROUPS_ALL = SUPPORTED_GROUPS + SUPPORTED_GROUPS_WARMUP
 
 InferenceDataT = TypeVar("InferenceDataT", bound="InferenceData")
 
-def _compressable_dtype(dtype):
+def _compressible_dtype(dtype):
     """Check basic dtypes for automatic compression."""
     if dtype.kind == "V":
         return all(_compressable_dtype(item) for item, _ in dtype.fields.values()))
@@ -430,7 +430,7 @@ class InferenceData(Mapping[str, xr.Dataset]):
                     kwargs["encoding"] = {
                         var_name: {"zlib": True}
                         for var_name, values in data.variables.items()
-                        if _compressable_dtype(values.dtype)
+                        if _compressible_dtype(values.dtype)
                     }
                 data.to_netcdf(filename, mode=mode, group=group, **kwargs)
                 data.close()

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -80,6 +80,7 @@ SUPPORTED_GROUPS_ALL = SUPPORTED_GROUPS + SUPPORTED_GROUPS_WARMUP
 InferenceDataT = TypeVar("InferenceDataT", bound="InferenceData")
 
 def _compressable_dtype(dtype):
+    """Check basic dtypes for automatic compression."""
     if dtype.kind == "V":
         return all(_compressable_dtype(item) for item, _ in dtype.fields.values()))
     return dtype.kind in {"b", "i", "u", "f", "c", "S"}
@@ -429,7 +430,7 @@ class InferenceData(Mapping[str, xr.Dataset]):
                     kwargs["encoding"] = {
                         var_name: {"zlib": True}
                         for var_name, values in data.variables.items()
-                        if _compressable_dtype(values)
+                        if _compressable_dtype(values.dtype)
                     }
                 data.to_netcdf(filename, mode=mode, group=group, **kwargs)
                 data.close()

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -422,7 +422,11 @@ class InferenceData(Mapping[str, xr.Dataset]):
                 data = getattr(self, group)
                 kwargs = {}
                 if compress:
-                    kwargs["encoding"] = {var_name: {"zlib": True} for var_name in data.variables}
+                    kwargs["encoding"] = {
+                        var_name: {"zlib": True}
+                        for var_name, values in data.variables.items()
+                        if not values.dtype.hasobject
+                    }
                 data.to_netcdf(filename, mode=mode, group=group, **kwargs)
                 data.close()
                 mode = "a"

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -79,12 +79,14 @@ SUPPORTED_GROUPS_ALL = SUPPORTED_GROUPS + SUPPORTED_GROUPS_WARMUP
 
 InferenceDataT = TypeVar("InferenceDataT", bound="InferenceData")
 
+# pylint: disable=unreachable
 def _compressible_dtype(dtype):
     return True
     """Check basic dtypes for automatic compression."""
     if dtype.kind == "V":
-        return all(_compressable_dtype(item) for item, _ in dtype.fields.values()))
+        return all(_compressable_dtype(item) for item, _ in dtype.fields.values())
     return dtype.kind in {"b", "i", "u", "f", "c", "S"}
+
 
 class InferenceData(Mapping[str, xr.Dataset]):
     """Container for inference data storage using xarray.

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -80,6 +80,7 @@ SUPPORTED_GROUPS_ALL = SUPPORTED_GROUPS + SUPPORTED_GROUPS_WARMUP
 InferenceDataT = TypeVar("InferenceDataT", bound="InferenceData")
 
 def _compressible_dtype(dtype):
+    return True
     """Check basic dtypes for automatic compression."""
     if dtype.kind == "V":
         return all(_compressable_dtype(item) for item, _ in dtype.fields.values()))

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -81,10 +81,10 @@ InferenceDataT = TypeVar("InferenceDataT", bound="InferenceData")
 
 # pylint: disable=unreachable
 def _compressible_dtype(dtype):
-    return True
     """Check basic dtypes for automatic compression."""
+    return True
     if dtype.kind == "V":
-        return all(_compressable_dtype(item) for item, _ in dtype.fields.values())
+        return all(_compressible_dtype(item) for item, _ in dtype.fields.values())
     return dtype.kind in {"b", "i", "u", "f", "c", "S"}
 
 

--- a/arviz/tests/base_tests/test_data.py
+++ b/arviz/tests/base_tests/test_data.py
@@ -1253,7 +1253,7 @@ class TestDataNetCDF:
         assert not os.path.exists(filepath)
 
     @pytest.mark.parametrize("groups_arg", [False, True])
-    @pytest.mark.parametrize("compress": [True, False])
+    @pytest.mark.parametrize("compress", [True, False])
     def test_io_method(self, data, eight_schools_params, groups_arg, compress):
         # create InferenceData and check it has been properly created
         inference_data = self.get_inference_data(  # pylint: disable=W0612
@@ -1278,7 +1278,9 @@ class TestDataNetCDF:
         assert not os.path.exists(filepath)
         # InferenceData method
         inference_data.to_netcdf(
-            filepath, groups=("posterior", "observed_data") if groups_arg else None, compres=compress,
+            filepath,
+            groups=("posterior", "observed_data") if groups_arg else None,
+            compres=compress,
         )
 
         # assert file has been saved correctly

--- a/arviz/tests/base_tests/test_data.py
+++ b/arviz/tests/base_tests/test_data.py
@@ -1280,7 +1280,7 @@ class TestDataNetCDF:
         inference_data.to_netcdf(
             filepath,
             groups=("posterior", "observed_data") if groups_arg else None,
-            compres=compress,
+            compress=compress,
         )
 
         # assert file has been saved correctly

--- a/arviz/tests/base_tests/test_data.py
+++ b/arviz/tests/base_tests/test_data.py
@@ -1215,7 +1215,7 @@ class TestDataNetCDF:
             prior_predictive=data.obj,
             sample_stats_prior=data.obj,
             observed_data=eight_schools_params,
-            coords={"school": np.arange(8)},
+            coords={"school": np.array(["a" * i for i in range(8)], dtype="U")},
             dims={"theta": ["school"], "eta": ["school"]},
         )
 
@@ -1253,7 +1253,8 @@ class TestDataNetCDF:
         assert not os.path.exists(filepath)
 
     @pytest.mark.parametrize("groups_arg", [False, True])
-    def test_io_method(self, data, eight_schools_params, groups_arg):
+    @pytest.mark.parametrize("compress": [True, False])
+    def test_io_method(self, data, eight_schools_params, groups_arg, compress):
         # create InferenceData and check it has been properly created
         inference_data = self.get_inference_data(  # pylint: disable=W0612
             data, eight_schools_params
@@ -1277,7 +1278,7 @@ class TestDataNetCDF:
         assert not os.path.exists(filepath)
         # InferenceData method
         inference_data.to_netcdf(
-            filepath, groups=("posterior", "observed_data") if groups_arg else None
+            filepath, groups=("posterior", "observed_data") if groups_arg else None, compres=compress,
         )
 
         # assert file has been saved correctly


### PR DESCRIPTION
Fixes #2079 

## Description

Filter out object dtype from compression.

## Checklist

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)
