### PR TITLE
fix handling of default dims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Fix bug with the dimension order dependency ([2103](https://github.com/arviz-devs/arviz/pull/2103))
 * Add testing module for labeller classes ([2095](https://github.com/arviz-devs/arviz/pull/2095))
 * Skip compression for object dtype while creating a netcdf file ([2129](https://github.com/arviz-devs/arviz/pull/2129))
+* Fix issue in dim generation when default dims are present in user inputed dims ([2138](https://github.com/arviz-devs/arviz/pull/2138))
 
 ### Deprecation
 * Removed `fill_last`, `contour` and `plot_kwargs` arguments from `plot_pair` function ([2085](https://github.com/arviz-devs/arviz/pull/2085))

--- a/arviz/data/base.py
+++ b/arviz/data/base.py
@@ -228,10 +228,6 @@ def numpy_to_data_array(
     else:
         ary = utils.one_de(ary)
 
-    print(default_dims)
-    print(dims)
-    print(coords)
-    print(ary.shape)
     dims, coords = generate_dims_coords(
         ary.shape[len(default_dims) :],
         var_name,
@@ -241,9 +237,6 @@ def numpy_to_data_array(
         index_origin=index_origin,
         skip_event_dims=skip_event_dims,
     )
-    print("---")
-    print(dims)
-    print(coords)
 
     # reversed order for default dims: 'chain', 'draw'
     if "draw" not in dims and "draw" in default_dims:

--- a/arviz/data/base.py
+++ b/arviz/data/base.py
@@ -147,7 +147,8 @@ def generate_dims_coords(
                 dims = dims[:i]
                 break
 
-    for idx, dim_len in enumerate(shape):
+    for i, dim_len in enumerate(shape):
+        idx = i + len([dim for dim in default_dims if dim in dims])
         if len(dims) < idx + 1:
             dim_name = f"{var_name}_dim_{idx}"
             dims.append(dim_name)
@@ -227,6 +228,10 @@ def numpy_to_data_array(
     else:
         ary = utils.one_de(ary)
 
+    print(default_dims)
+    print(dims)
+    print(coords)
+    print(ary.shape)
     dims, coords = generate_dims_coords(
         ary.shape[len(default_dims) :],
         var_name,
@@ -236,6 +241,9 @@ def numpy_to_data_array(
         index_origin=index_origin,
         skip_event_dims=skip_event_dims,
     )
+    print("---")
+    print(dims)
+    print(coords)
 
     # reversed order for default dims: 'chain', 'draw'
     if "draw" not in dims and "draw" in default_dims:

--- a/arviz/tests/base_tests/test_data.py
+++ b/arviz/tests/base_tests/test_data.py
@@ -155,7 +155,9 @@ def test_dims_coords():
     assert len(coords["x_dim_2"]) == 5
 
 
-@pytest.mark.parametrize("in_dims", (["dim1", "dim2"], ["draw", "dim1", "dim2"], ["chain", "draw", "dim1", "dim2"]))
+@pytest.mark.parametrize(
+    "in_dims", (["dim1", "dim2"], ["draw", "dim1", "dim2"], ["chain", "draw", "dim1", "dim2"])
+)
 def test_dims_coords_default_dims(in_dims):
     shape = 4, 7
     var_name = "x"

--- a/arviz/tests/base_tests/test_data.py
+++ b/arviz/tests/base_tests/test_data.py
@@ -155,20 +155,21 @@ def test_dims_coords():
     assert len(coords["x_dim_2"]) == 5
 
 
-def test_dims_coords_default_dims():
+@pytest.mark.parametrize("in_dims", (["dim1", "dim2"], ["draw", "dim1", "dim2"], ["chain", "draw", "dim1", "dim2"]))
+def test_dims_coords_default_dims(in_dims):
     shape = 4, 7
     var_name = "x"
     dims, coords = generate_dims_coords(
         shape,
         var_name,
-        dims=["dim1", "dim2"],
+        dims=in_dims,
         coords={"chain": ["a", "b", "c"]},
         default_dims=["chain", "draw"],
     )
     assert "dim1" in dims
     assert "dim2" in dims
-    assert "chain" not in dims
-    assert "draw" not in dims
+    assert ("chain" in dims) == ("chain" in in_dims)
+    assert ("draw" in dims) == ("draw" in in_dims)
     assert len(coords["dim1"]) == 4
     assert len(coords["dim2"]) == 7
     assert len(coords["chain"]) == 3


### PR DESCRIPTION
## Description
We have the concept of `default_dims` in dict_to_dataset and related functions,
which are dimensions that come at the beginning and can be omitted from the
dims list _but they can also be there_. This fixes a bug for the case
where the default_dims are present in the dims list (which is necessary
when the default dims are not chain and draw).

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Does the PR follow [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format?
- [x] Does the PR include new or updated tests to prevent issue recurrence (using [pytest fixture pattern](https://docs.pytest.org/en/latest/fixture.html#fixture))?
- [x] Is the code style correct (follows pylint and black guidelines)?
- [x] Is the fix listed in the [Maintenance and fixes](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#maintenance-and-fixes) section of the changelog?


<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2138.org.readthedocs.build/en/2138/

<!-- readthedocs-preview arviz end -->