### PR TITLE
Add weight_predictions function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## v0.xx.x
+
+### New features
+* Add `weight_predictions` function to allow generation of weighted predictions from two or more InfereceData with `posterior_predictive` groups and a set of weights ([2147](https://github.com/arviz-devs/arviz/pull/2147))
+
+### Maintenance and fixes
+
+### Deprecation
+
+### Documentation
+
+
 ## v0.13.0 (2022 Oct 22)
 
 ### New features

--- a/arviz/stats/__init__.py
+++ b/arviz/stats/__init__.py
@@ -20,6 +20,7 @@ __all__ = [
     "r2_score",
     "summary",
     "waic",
+    "weight_predictions",
     "ELPDData",
     "ess",
     "rhat",

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -2098,7 +2098,7 @@ def weight_predictions(idatas, weights=None):
     ]
 
     if not all(len_idatas):
-        raise ValueError("at least one of your idatas has 0 samples")
+        raise ValueError("At least one of your idatas has 0 samples")
 
     new_samples = (np.min(len_idatas) * weights).astype(int)
 

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -2053,7 +2053,7 @@ def weight_predictions(idatas, weights=None):
 
     Parameters
     ---------
-    idatas : list[InfereneData]
+    idatas : list[InferenceData]
         List of :class:`arviz.InferenceData` objects containing the groups `posterior_predictive`
         and `observed_data`. Observations should be the same for all InferenceData objects.
     weights : array-like, optional
@@ -2089,13 +2089,16 @@ def weight_predictions(idatas, weights=None):
             "The number of weights should be the same as the number of InferenceData objects"
         )
 
-    weights = np.asarray(weights, dtype=float)
+    weights = np.array(weights, dtype=float)
     weights /= weights.sum()
 
     len_idatas = [
-        len(idata.posterior_predictive.chain) * len(idata.posterior_predictive.draw)
+        idata.posterior_predictive.dims["chain"] * idata.posterior_predictive.dims["draw"]
         for idata in idatas
     ]
+
+    if not all(len_idatas):
+        raise ValueError("at least one of your idatas has 0 samples")
 
     new_samples = (np.min(len_idatas) * weights).astype(int)
 


### PR DESCRIPTION
This function will take a list of idatas with `posterior_predictive` groups and a list of model weights (computed using `az.compare` or something else) and it will return a new inference data with a `posterior_predictive` group composed of weighted samples from the input idatas. 

@zaxtax maybe we can focus on this and forgot about `pm.sample_posterior_predictive_w`

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2147.org.readthedocs.build/en/2147/

<!-- readthedocs-preview arviz end -->