### PR TITLE
Fix dimension ordering for traceplot with divergences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## v0.x.x Unreleased
+
+### New features
+
+### Maintenance and fixes
+
+### Deprecation
+
+### Documentation
+
 ## v0.13.0 (2022 Oct 22)
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 ### Maintenance and fixes
+- Fix dimension ordering for `plot_trace` with divergences ([2151](https://github.com/arviz-devs/arviz/pull/2151))
 
 ### Deprecation
 

--- a/arviz/plots/traceplot.py
+++ b/arviz/plots/traceplot.py
@@ -174,7 +174,9 @@ def plot_trace(
         divergences = "top" if rug else "bottom"
     if divergences:
         try:
-            divergence_data = convert_to_dataset(data, group="sample_stats").diverging
+            divergence_data = convert_to_dataset(data, group="sample_stats").diverging.transpose(
+                "chain", "draw"
+            )
         except (ValueError, AttributeError):  # No sample_stats, or no `.diverging`
             divergences = None
 

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -294,6 +294,12 @@ def test_plot_trace_invalid_varname_warning(models, kwargs):
     assert axes.shape
 
 
+def test_plot_trace_diverging_correctly_transposed():
+    idata = load_arviz_data("centered_eight")
+    idata.sample_stats["diverging"] = idata.sample_stats.diverging.T
+    plot_trace(idata, diverging=True)
+
+
 @pytest.mark.parametrize(
     "bad_kwargs", [{"var_names": ["mu", "tau"], "lines": [("mu", {}, ["hey"])]}]
 )

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -297,7 +297,7 @@ def test_plot_trace_invalid_varname_warning(models, kwargs):
 def test_plot_trace_diverging_correctly_transposed():
     idata = load_arviz_data("centered_eight")
     idata.sample_stats["diverging"] = idata.sample_stats.diverging.T
-    plot_trace(idata, diverging=True)
+    plot_trace(idata, divergences="bottom")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description
Fixes #2150 by internally reordering dimensions of `diverging` as expected in `plot_trace`.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Does the PR follow [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist)
      PR format?
- [x] Does the PR include new or updated tests to prevent issue recurrence (using [pytest fixture pattern](
      https://docs.pytest.org/en/latest/fixture.html#fixture))?
- [x] Is the code style correct (follows pylint and black guidelines)?
- [x] Is the fix listed in the [Maintenance and fixes](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#maintenance-and-fixes)
      section of the changelog?

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->


<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2151.org.readthedocs.build/en/2151/

<!-- readthedocs-preview arviz end -->