### PR TITLE
Add None for fields not used in beanmachine converter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Maintenance and fixes
 - Fix `reloo` outdated usage of `ELPDData` ([2158](https://github.com/arviz-devs/arviz/pull/2158))
+- Fix bug when beanmachine objects lack some fields ([2154](https://github.com/arviz-devs/arviz/pull/2154))
 
 ### Deprecation
 

--- a/arviz/data/io_beanmachine.py
+++ b/arviz/data/io_beanmachine.py
@@ -24,15 +24,23 @@ class BMConverter:
 
         if "posterior" in self.sampler.namespaces:
             self.posterior = self.sampler.namespaces["posterior"].samples
+        else:
+            self.posterior = None
 
         if "posterior_predictive" in self.sampler.namespaces:
             self.posterior_predictive = self.sampler.namespaces["posterior_predictive"].samples
+        else:
+            self.posterior_predictive = None
 
         if self.sampler.log_likelihoods is not None:
             self.log_likelihoods = self.sampler.log_likelihoods
+        else:
+            self.log_likelihoods = None
 
         if self.sampler.observations is not None:
             self.observations = self.sampler.observations
+        else:
+            self.observations = None
 
     @requires("posterior")
     def posterior_to_xarray(self):

--- a/arviz/tests/external_tests/test_data_beanmachine.py
+++ b/arviz/tests/external_tests/test_data_beanmachine.py
@@ -11,7 +11,7 @@ from ..helpers import (  # pylint: disable=unused-import, wrong-import-position
     load_cached_models,
 )
 
-# Skip all tests if pyro or pytorch not installed
+# Skip all tests if beanmachine or pytorch not installed
 torch = importorskip("torch")
 bm = importorskip("beanmachine.ppl")
 dist = torch.distributions

--- a/arviz/tests/external_tests/test_data_beanmachine.py
+++ b/arviz/tests/external_tests/test_data_beanmachine.py
@@ -5,7 +5,6 @@ import pytest
 from ...data.io_beanmachine import from_beanmachine  # pylint: disable=wrong-import-position
 from ..helpers import (  # pylint: disable=unused-import, wrong-import-position
     chains,
-    check_multiple_attrs,
     draws,
     eight_schools_params,
     importorskip,

--- a/arviz/tests/external_tests/test_data_beanmachine.py
+++ b/arviz/tests/external_tests/test_data_beanmachine.py
@@ -22,7 +22,7 @@ class TestDataBeanMachine:
     @pytest.fixture(scope="class")
     def data(self, eight_schools_params, draws, chains):
         class Data:
-            model, obj = load_cached_models(
+            model, prior, obj = load_cached_models(
                 eight_schools_params,
                 draws,
                 chains,
@@ -71,14 +71,7 @@ class TestDataBeanMachine:
 
     def test_inference_data_no_posterior(self, data):
         model = data.model
-        prior = bm.GlobalNoUTurnSampler().infer(
-            queries=[model.mu(), model.tau(), model.eta()],
-            observations={},
-            num_samples=100,
-            num_adaptive_samples=100,
-            num_chains=2,
-        )
         # only prior
-        inference_data = from_beanmachine(prior)
+        inference_data = from_beanmachine(data.prior)
         assert not model.obs() in inference_data.posterior
         assert "observed_data" not in inference_data

--- a/arviz/tests/external_tests/test_data_beanmachine.py
+++ b/arviz/tests/external_tests/test_data_beanmachine.py
@@ -1,0 +1,92 @@
+# pylint: disable=no-member, invalid-name, redefined-outer-name
+import numpy as np
+import packaging
+import pytest
+
+from ...data.io_beanmachine import from_beanmachine  # pylint: disable=wrong-import-position
+from ..helpers import (  # pylint: disable=unused-import, wrong-import-position
+    chains,
+    check_multiple_attrs,
+    draws,
+    eight_schools_params,
+    importorskip,
+    load_cached_models,
+)
+
+# Skip all tests if pyro or pytorch not installed
+torch = importorskip("torch")
+bm = importorskip("beanmachine.ppl")
+dist = torch.distributions
+
+
+class TestDataBeanMachine:
+    @pytest.fixture(scope="class")
+    def data(self, eight_schools_params, draws, chains):
+        class Data:
+            model, obj = load_cached_models(eight_schools_params, draws, chains, "beanmachine")["beanmachine"]
+
+        return Data
+
+    @pytest.fixture(scope="class")
+    def predictions_params(self):
+        """Predictions data for eight schools."""
+        return {
+            "J": 8,
+            "sigma": torch.tensor([5.0, 7.0, 12.0, 4.0, 6.0, 10.0, 3.0, 9.0]),
+        }
+
+    @pytest.fixture(scope="class")
+    def predictions_data(self, data, predictions_params):
+        """Generate predictions for predictions_params"""
+        posterior_samples = data.obj
+        model = data.model
+        predictions = bm.inference.predictive.simulate([model.obs()], posterior_samples)
+        return predictions
+
+    def get_inference_data(self, data, eight_schools_params, predictions_data):
+        posterior_samples = data.obj
+        model = data.model
+        predictions = predictions_data
+        return from_beanmachine(
+            sampler=predictions,
+            coords={
+                "school": np.arange(eight_schools_params["J"]),
+                "school_pred": np.arange(eight_schools_params["J"]),
+            },
+        )
+
+    def test_inference_data(self, data, eight_schools_params, predictions_data):
+        inference_data = self.get_inference_data(data, eight_schools_params, predictions_data)
+        mu = data.model.mu()
+        tau = data.model.tau()
+        eta = data.model.eta()
+        obs = data.model.obs()
+
+        assert mu in inference_data.posterior
+        assert tau in inference_data.posterior
+        assert eta in inference_data.posterior
+        assert obs in inference_data.posterior_predictive
+
+    def test_inference_data_has_log_likelihood_and_observed_data(self, data):
+        idata = from_beanmachine(data.obj)
+        obs = data.model.obs()
+
+        assert obs in idata.log_likelihood
+        assert obs in idata.observed_data
+
+    def test_inference_data_no_posterior(
+        self, data, eight_schools_params, predictions_data, predictions_params
+    ):
+        posterior_samples = data.obj
+        model = data.model
+        prior = bm.GlobalNoUTurnSampler().infer(
+            queries=[model.mu(), model.tau(), model.eta()],
+            observations={},
+            num_samples=100,
+            num_adaptive_samples=100,
+            num_chains=2,
+        )
+        # only prior
+        inference_data = from_beanmachine(prior)
+        assert not model.obs() in inference_data.posterior
+        assert "observed_data" not in inference_data

--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -486,6 +486,43 @@ def pystan_noncentered_schools(data, draws, chains):
     return stan_model, fit
 
 
+def bm_schools_model(data, draws, chains):
+    import beanmachine.ppl as bm
+    import torch
+    import torch.distributions as dist
+
+    class EightSchools:
+        @bm.random_variable
+        def mu(self):
+            return dist.Normal(0, 5)
+
+        @bm.random_variable
+        def tau(self):
+            return dist.HalfCauchy(5)
+
+        @bm.random_variable
+        def eta(self):
+            return dist.Normal(0, 1).expand((data["J"],))
+
+        @bm.functional
+        def theta(self):
+            return self.mu() + self.tau() * self.eta()
+
+        @bm.random_variable
+        def obs(self):
+            return dist.Normal(self.theta(), torch.from_numpy(data["sigma"]).float())
+
+    model = EightSchools()
+    posterior = bm.GlobalNoUTurnSampler().infer(
+        queries=[model.mu(), model.tau(), model.eta()],
+        observations={model.obs(): torch.from_numpy(data["y"]).float()},
+        num_samples=draws,
+        num_adaptive_samples=500,
+        num_chains=chains,
+    )
+    return model, posterior
+
+
 def library_handle(library):
     """Import a library and return the handle."""
     if library == "pystan":
@@ -506,6 +543,7 @@ def load_cached_models(eight_schools_data, draws, chains, libs=None):
         ("emcee", emcee_schools_model),
         ("pyro", pyro_noncentered_schools),
         ("numpyro", numpyro_schools_model),
+        ("beanmachine", bm_schools_model),
     )
     data_directory = os.path.join(here, "saved_models")
     models = {}

--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -513,6 +513,15 @@ def bm_schools_model(data, draws, chains):
             return dist.Normal(self.theta(), torch.from_numpy(data["sigma"]).float())
 
     model = EightSchools()
+
+    prior = bm.GlobalNoUTurnSampler().infer(
+        queries=[model.mu(), model.tau(), model.eta()],
+        observations={},
+        num_samples=draws,
+        num_adaptive_samples=500,
+        num_chains=chains,
+    )
+
     posterior = bm.GlobalNoUTurnSampler().infer(
         queries=[model.mu(), model.tau(), model.eta()],
         observations={model.obs(): torch.from_numpy(data["y"]).float()},
@@ -520,7 +529,7 @@ def bm_schools_model(data, draws, chains):
         num_adaptive_samples=500,
         num_chains=chains,
     )
-    return model, posterior
+    return model, prior, posterior
 
 
 def library_handle(library):


### PR DESCRIPTION
## Description
This is a bug fix to handle when observations and posterior_predictive is missing from the MonteCarloSamples object

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [ ] New features are properly documented (with an example if appropriate)?
- [x] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->


<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2154.org.readthedocs.build/en/2154/

<!-- readthedocs-preview arviz end -->