### PR TITLE
rename arviz-doc to arviz-docgrid and make arviz-doc a non-grid style

### DIFF
--- a/arviz/plots/styles/arviz-doc.mplstyle
+++ b/arviz/plots/styles/arviz-doc.mplstyle
@@ -31,7 +31,14 @@ axes.edgecolor:         .33         # axes edge color
 axes.linewidth:         0.8         # edge line width
 
 axes.grid:              False        # do not show grid
+# axes.grid.axis:         y        # which axis the grid should apply to
+axes.grid.which:        major       # grid lines at {major, minor, both} ticks
 axes.axisbelow:         True        # keep grid layer in the back
+
+grid.color:             .8          # grid color
+grid.linestyle:         -           # solid
+grid.linewidth:         0.8         # in points
+grid.alpha:             1.0         # transparency, between 0.0 and 1.0
 
 lines.solid_capstyle:   round
 

--- a/arviz/plots/styles/arviz-docgrid.mplstyle
+++ b/arviz/plots/styles/arviz-docgrid.mplstyle
@@ -30,8 +30,15 @@ axes.facecolor:         white
 axes.edgecolor:         .33         # axes edge color
 axes.linewidth:         0.8         # edge line width
 
-axes.grid:              False        # do not show grid
+axes.grid:              True        # show grid
+# axes.grid.axis:         y        # which axis the grid should apply to
+axes.grid.which:        major       # grid lines at {major, minor, both} ticks
 axes.axisbelow:         True        # keep grid layer in the back
+
+grid.color:             .8          # grid color
+grid.linestyle:         -           # solid
+grid.linewidth:         0.8         # in points
+grid.alpha:             1.0         # transparency, between 0.0 and 1.0
 
 lines.solid_capstyle:   round
 

--- a/examples/matplotlib/mpl_styles.py
+++ b/examples/matplotlib/mpl_styles.py
@@ -31,6 +31,7 @@ style_list = [
     ["arviz-white", "arviz-viridish"],
     ["arviz-white", "arviz-plasmish"],
     "arviz-doc",
+    "arviz-docgrid",
 ]
 
 fig = plt.figure(figsize=(20, 10))


### PR DESCRIPTION


<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2157.org.readthedocs.build/en/2157/

<!-- readthedocs-preview arviz end -->