### PR TITLE
copy coords before modifying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Fix issue in dim generation when default dims are present in user inputed dims ([2138](https://github.com/arviz-devs/arviz/pull/2138))
 * Save InferenceData level attrs to netcdf and zarr ([2131](https://github.com/arviz-devs/arviz/pull/2131))
 * Update tests and docs for updated example data ([2137](https://github.com/arviz-devs/arviz/pull/2137))
+* Copy coords before modifying in ppcplot ([2160](https://github.com/arviz-devs/arviz/pull/2160))
 
 ### Deprecation
 * Removed `fill_last`, `contour` and `plot_kwargs` arguments from `plot_pair` function ([2085](https://github.com/arviz-devs/arviz/pull/2085))

--- a/arviz/plots/ppcplot.py
+++ b/arviz/plots/ppcplot.py
@@ -273,6 +273,8 @@ def plot_ppc(
 
     if coords is None:
         coords = {}
+    else:
+        coords = coords.copy()
 
     if labeller is None:
         labeller = BaseLabeller()


### PR DESCRIPTION
## Description
Make a copy of the dictionary coords, so the input parameter coords is not modified.

This PR is to fix the issue mentioned in issue #2047



<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2160.org.readthedocs.build/en/2160/

<!-- readthedocs-preview arviz end -->