### PR TITLE
fix version and how-to docs

### DIFF
--- a/arviz/__init__.py
+++ b/arviz/__init__.py
@@ -1,6 +1,6 @@
 # pylint: disable=wildcard-import,invalid-name,wrong-import-position
 """ArviZ is a library for exploratory analysis of Bayesian models."""
-__version__ = "0.14.0.dev0"
+__version__ = "0.15.0.dev0"
 
 import logging
 import os

--- a/doc/source/contributing/how_to_release.md
+++ b/doc/source/contributing/how_to_release.md
@@ -9,16 +9,17 @@ ArviZ uses the following process to cut a new release of the library.
    + __version = "0.12.1"
    ```
 
-2. Update the release notes in `CHANGELOG.md`
+2. Update the release notes in `CHANGELOG.md`. Remove any subsections within the released version
+   without any items within them.
 
    ```diff
    - ## v0.x.x Unreleased
    + ## v0.12.1 (2022 May 12)
    ```
 
-   Empty subheadings don't need to be included yet.
+   Empty subheadings for the "unreleased" development version don't need to be included yet.
 
-3. Check versions in `requirements.txt` and `setup.py` files. Arviz aims to follow the recommendations in [SPEC-0](https://scientific-python.org/specs/spec-0000/) from scientific python. 
+3. Check versions in `requirements.txt` and `setup.py` files. Arviz aims to follow the recommendations in [SPEC-0](https://scientific-python.org/specs/spec-0000/) from scientific python.
 
 4. Open a Pull Request including these changes. Make sure all CI tests pass, adding commits if necessary. Even if CI is passing on main, there might be new releases of dependencies that break CI.
 
@@ -26,7 +27,9 @@ ArviZ uses the following process to cut a new release of the library.
 
 6. After the release on Github, the CI system will complete the rest of the steps. Including making any wheels and uploading the new version to PyPI.
 
-7. Add a follow-up PR changing the version string to include the dev flag. Make sure the version string is [PEP 440](https://peps.python.org/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions) compliant.
+7. Add a follow-up PR changing the version string to include the dev flag.
+   Make sure the version string is [PEP 440](https://peps.python.org/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions) compliant.
+   For example, after releasing `v0.12.1` it should be set to `0.13.0.dev0`.
 
 8. Use the following template to add empty subheadings to the `CHANGELOG.md` file in the follow-up PR.
 
@@ -41,5 +44,5 @@ ArviZ uses the following process to cut a new release of the library.
 
    ### Documentation
    ```
-   
+
 9. If the versions were updated in step 3, update also the [conda forge recipe](https://github.com/conda-forge/arviz-feedstock).


### PR DESCRIPTION
`0.14.0.dev0` is similar to `rc1` flags, they are releases that _precede_ 0.14.0.
I have updated the how-to docs to be more clear, I think we have done this for the last
2 releases.


<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2166.org.readthedocs.build/en/2166/

<!-- readthedocs-preview arviz end -->