### PR TITLE
use constant gap for rank plots

### DIFF
--- a/arviz/plots/backends/matplotlib/rankplot.py
+++ b/arviz/plots/backends/matplotlib/rankplot.py
@@ -71,7 +71,7 @@ def plot_rank(
         all_counts = np.empty((len(ranks), len(bin_ary) - 1))
         for idx, row in enumerate(ranks):
             _, all_counts[idx], _ = histogram(row, bins=bin_ary)
-        gap = all_counts.max() * 1.05
+        gap = 2 / ranks.size
         width = bin_ary[1] - bin_ary[0]
 
         bar_kwargs.setdefault("width", width)

--- a/arviz/plots/backends/matplotlib/traceplot.py
+++ b/arviz/plots/backends/matplotlib/traceplot.py
@@ -192,6 +192,8 @@ def plot_trace(
     fill_kwargs = matplotlib_kwarg_dealiaser(fill_kwargs, "fill_between")
     rug_kwargs = matplotlib_kwarg_dealiaser(rug_kwargs, "scatter")
     rank_kwargs = matplotlib_kwarg_dealiaser(rank_kwargs, "bar")
+    if compact:
+        rank_kwargs.setdefault("bar_kwargs", {"alpha": 0.2})
 
     textsize = plot_kwargs.pop("textsize", 10)
 


### PR DESCRIPTION
## Description

Fix #2177.  That issue is a good example of where we will benefit from decoupling computation from plotting. Currently, we compute the ranks, use the values to set the space between chains and plot that. And repeat for the next dimension of the variable.

In the meantime, this PR takes a simpler approach and set a constant gap, of two times the expected height of the uniform distribution. When the rank plot is fine this gap should be enough to make the plots looks nice. Although it will allow overlaps between bars from different chains when the rank deviates more than 2 times the expected uniform distribution. I think that's fine, because if you have such overlap then, you have bigger issues than aesthetics :-)


## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [ ] New features are properly documented (with an example if appropriate)?
- [ ] Includes new or updated tests to cover the new feature
- [ ] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
