### PR TITLE
add contributing webinar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Documentation
 - Add PyMC and CmdStanPy sampling wrapper examples ([2158](https://github.com/arviz-devs/arviz/pull/2158))
 - Fix docstring for plot_trace chain_prop and compact_prop parameters ([2176](https://github.com/arviz-devs/arviz/pull/2176))
+- Add video of contributing to ArviZ webinar in contributing guide ([2184](https://github.com/arviz-devs/arviz/pull/2184))
 
 ## v0.14.0 (2022 Nov 15)
 

--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -8,7 +8,7 @@
 }
 
 .supportbutton a {
-color: var(--pst-color-sidebar-link-active);
+  color: var(--pst-color-link);
 }
 
 .navbar-brand {
@@ -155,7 +155,7 @@ html[data-theme="dark"] {
   }
   .support-arviz-img-donate-responsive img {
     display: block;
-  } 
+  }
 }
 
 /* -------------------- HOMEPAGE + EXAMPLE GALLERY -------------------- */

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -59,6 +59,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_codeautolink",
     "jupyter_sphinx",
+    "sphinxcontrib.youtube",
 ]
 
 # codeautolink
@@ -191,7 +192,7 @@ html_theme_options = {
     ],
     "navbar_start": ["navbar-logo", "navbar-version"],
     "header_links_before_dropdown": 7,
-    "page_sidebar_items": ["page-toc", "edit-this-page", "donate"],
+    "secondary_sidebar_items": ["page-toc", "searchbox", "edit-this-page", "sourcelink", "donate"],
     "use_edit_page_button": True,
     "google_analytics_id": "G-W1G68W77YV",
     "external_links": [

--- a/doc/source/contributing/index.md
+++ b/doc/source/contributing/index.md
@@ -30,13 +30,19 @@ if you want to contribute to the project but you are not sure where you can cont
 Historically, the most common way of contributing to the project is
 sending pull requests on the main [ArviZ Github repository](https://github.com/arviz-devs/arviz),
 but there are many other ways to help the project.
+
+Each subsection within this section gives an overview of common contribution types
+to ArviZ. If you prefer video instead of written form, jump to the next section:
+{ref}`contributing_webinar` for a recording of an ArviZ core contributor
+on both technical and social aspects of contributing to the library.
+
 You can contribute to ArviZ in the following ways:
 
 ### Create an issue
 [Submit issues](https://github.com/arviz-devs/arviz/issues/new/choose) for existing bugs or desired enhancements. Check  {ref}`issue_reports` for details on how to write an issue.
 
 ### Translate ArviZ website
-You can {ref}`translate <translate>` our website to languages other than english.
+You can {ref}`translate <translate>` our website to languages other than English.
 
 ### Review PRs
 {ref}`Review pull requests <review_prs>` to ensure that the contributions are well tested and documented.
@@ -68,6 +74,12 @@ To fix bugs or add new features, do the following:
 2. Understand the {ref}`development process <dev_summary>` and code conventions.
 3. Understand the basic workflow for opening a {ref}`pull request <pr_tutorial>` and {ref}`reviewing <review_prs>` changes.
 4. Review and test your code.
+
+(contributing_webinar)=
+## Contributing to ArviZ webinar
+
+:::{youtube} 457ZTes4xOI
+:::
 
 ```{toctree}
 :hidden:

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -15,3 +15,4 @@ contourpy
 sphinx_design
 sphinx-codeautolink>=0.9.0
 jupyter-sphinx
+sphinxcontrib-youtube


### PR DESCRIPTION
## Description
This adds an embedding of the webinar I recently gave about
contributing to ArviZ to the contributing overview page.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)


<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2184.org.readthedocs.build/en/2184/

<!-- readthedocs-preview arviz end -->