### PR TITLE
Fix plot_lm and _z_scale for scipy 1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - plot_bpv smooth discrete data only when computing u_values ([2179](https://github.com/arviz-devs/arviz/pull/2179))
 - Fix bug when beanmachine objects lack some fields ([2154](https://github.com/arviz-devs/arviz/pull/2154))
 - Fix gap for `plot_trace` with option `kind="rank_bars"` ([2180](https://github.com/arviz-devs/arviz/pull/2180))
+- Fix `plot_lm` unsupported usage of `np.tile` ([2186](https://github.com/arviz-devs/arviz/pull/2186))
+- Update `_z_scale` to work with SciPy 1.10 ([2186](https://github.com/arviz-devs/arviz/pull/2186))
 
 ### Deprecation
 

--- a/arviz/plots/lmplot.py
+++ b/arviz/plots/lmplot.py
@@ -1,6 +1,7 @@
 """Plot regression figure."""
 import warnings
 from numbers import Integral
+from itertools import repeat
 
 import xarray as xr
 import numpy as np
@@ -9,6 +10,10 @@ from xarray.core.dataarray import DataArray
 from ..sel_utils import xarray_var_iter
 from ..rcparams import rcParams
 from .plot_utils import default_grid, filter_plotters_list, get_plotting_function
+
+
+def _repeat_flatten_list(lst, n):
+    return [item for sublist in repeat(lst, n) for item in sublist]
 
 
 def plot_lm(
@@ -268,8 +273,8 @@ def plot_lm(
     len_y = len(y)
     len_x = len(x)
     length_plotters = len_x * len_y
-    y = np.tile(y, (len_x, 1))
-    x = np.tile(x, (len_y, 1))
+    y = _repeat_flatten_list(y, len_x)
+    x = _repeat_flatten_list(x, len_y)
 
     # Filter out the required values to generate plotters
     if y_hat is not None:
@@ -289,7 +294,7 @@ def plot_lm(
             )
         ]
 
-        y_hat = np.tile(y_hat, (len_x, 1))
+        y_hat = _repeat_flatten_list(y_hat, len_x)
 
     # Filter out the required values to generate plotters
     if y_model is not None:
@@ -307,7 +312,7 @@ def plot_lm(
                 ),
             )
         ]
-        y_model = np.tile(y_model, (len_x, 1))
+        y_model = _repeat_flatten_list(y_model, len_x)
 
     rows, cols = default_grid(length_plotters)
 

--- a/arviz/stats/diagnostics.py
+++ b/arviz/stats/diagnostics.py
@@ -4,7 +4,9 @@ import warnings
 from collections.abc import Sequence
 
 import numpy as np
+import packaging
 import pandas as pd
+import scipy
 from scipy import stats
 
 from ..data import convert_to_dataset
@@ -538,7 +540,10 @@ def _z_scale(ary):
     np.ndarray
     """
     ary = np.asarray(ary)
-    rank = stats.rankdata(ary, method="average")
+    if packaging.version.parse(scipy.__version__) < packaging.version.parse("1.10.0"):
+        rank = stats.rankdata(ary, method="average")
+    else:
+        rank = stats.rankdata(ary, method="average", nan_policy="omit")  # pylint: disable=unexpected-keyword-arg
     rank = _backtransform_ranks(rank)
     z = stats.norm.ppf(rank)
     z = z.reshape(ary.shape)

--- a/arviz/stats/diagnostics.py
+++ b/arviz/stats/diagnostics.py
@@ -543,9 +543,10 @@ def _z_scale(ary):
     if packaging.version.parse(scipy.__version__) < packaging.version.parse("1.10.0.dev0"):
         rank = stats.rankdata(ary, method="average")
     else:
-        rank = stats.rankdata(
-            ary, method="average", nan_policy="omit"
-        )  # pylint: disable=unexpected-keyword-arg
+        # the .ravel part is only needed to overcom a bug in scipy 1.10.0.rc1
+        rank = stats.rankdata(  # pylint: disable=unexpected-keyword-arg
+            ary.ravel(), method="average", nan_policy="omit"
+        )
     rank = _backtransform_ranks(rank)
     z = stats.norm.ppf(rank)
     z = z.reshape(ary.shape)

--- a/arviz/stats/diagnostics.py
+++ b/arviz/stats/diagnostics.py
@@ -540,10 +540,12 @@ def _z_scale(ary):
     np.ndarray
     """
     ary = np.asarray(ary)
-    if packaging.version.parse(scipy.__version__) < packaging.version.parse("1.10.0"):
+    if packaging.version.parse(scipy.__version__) < packaging.version.parse("1.10.0.dev0"):
         rank = stats.rankdata(ary, method="average")
     else:
-        rank = stats.rankdata(ary, method="average", nan_policy="omit")  # pylint: disable=unexpected-keyword-arg
+        rank = stats.rankdata(
+            ary, method="average", nan_policy="omit"
+        )  # pylint: disable=unexpected-keyword-arg
     rank = _backtransform_ranks(rank)
     z = stats.norm.ppf(rank)
     z = z.reshape(ary.shape)

--- a/arviz/tests/base_tests/test_diagnostics.py
+++ b/arviz/tests/base_tests/test_diagnostics.py
@@ -3,8 +3,10 @@
 import os
 
 import numpy as np
+import packaging
 import pandas as pd
 import pytest
+import scipy
 from numpy.testing import assert_almost_equal
 
 from ...data import from_cmdstan, load_arviz_data
@@ -488,9 +490,11 @@ class TestDiagnostics:
         data[0, 0] = np.nan  #  pylint: disable=unsupported-assignment-operation
         if func == "_mcse_quantile":
             assert np.isnan(_mcse_quantile(data, 0.5)).all(None)
-        else:
+        elif packaging.version.parse(scipy.__version__) < packaging.version.parse("1.10.0"):
             assert not np.isnan(_z_scale(data)).all(None)
             assert not np.isnan(_z_scale(data)).any(None)
+        else:
+            assert np.isnan(_z_scale(data)).sum() == 1
 
     @pytest.mark.parametrize("chains", (None, 1, 2, 3))
     @pytest.mark.parametrize("draws", (2, 3, 100, 101))

--- a/arviz/tests/base_tests/test_diagnostics.py
+++ b/arviz/tests/base_tests/test_diagnostics.py
@@ -490,7 +490,7 @@ class TestDiagnostics:
         data[0, 0] = np.nan  #  pylint: disable=unsupported-assignment-operation
         if func == "_mcse_quantile":
             assert np.isnan(_mcse_quantile(data, 0.5)).all(None)
-        elif packaging.version.parse(scipy.__version__) < packaging.version.parse("1.10.0"):
+        elif packaging.version.parse(scipy.__version__) < packaging.version.parse("1.10.0.dev0"):
             assert not np.isnan(_z_scale(data)).all(None)
             assert not np.isnan(_z_scale(data)).any(None)
         else:


### PR DESCRIPTION
## Description
plot_lm used np.tile on the plotter lists which contain 4 elements, a string, two dicts and an
array, somehow coercing all this into a numpy array while doing some repetition of elements
to match x and y values. This always rose many warnings, it now breaks the code and therefore the
tests.

This PR updates this to use lists and itertools all the way to perform the same type of repetitions,
no array features were really used so I think it makes more sense to use lists.

I have also updated the code in _z_scale to work with scipy 1.10 and higher as the nan policy in rankdata has changed.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Does the PR follow [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format?
- [x] Does the PR include new or updated tests to prevent issue recurrence (using [pytest fixture pattern](https://docs.pytest.org/en/latest/fixture.html#fixture))?
      It does not, tests are already broken due to this so it can't go back.
- [x] Is the code style correct (follows pylint and black guidelines)?
- [x] Is the fix listed in the [Maintenance and fixes](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#maintenance-and-fixes)
      section of the changelog?

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->


<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2186.org.readthedocs.build/en/2186/

<!-- readthedocs-preview arviz end -->