### PR TITLE
remove workaround ravel

### DIFF
--- a/arviz/stats/diagnostics.py
+++ b/arviz/stats/diagnostics.py
@@ -545,7 +545,7 @@ def _z_scale(ary):
     else:
         # the .ravel part is only needed to overcom a bug in scipy 1.10.0.rc1
         rank = stats.rankdata(  # pylint: disable=unexpected-keyword-arg
-            ary.ravel(), method="average", nan_policy="omit"
+            ary, method="average", nan_policy="omit"
         )
     rank = _backtransform_ranks(rank)
     z = stats.norm.ppf(rank)


### PR DESCRIPTION
## Description
There was an issue with scipy 1.10 rc1, so I added this ravel to
get CI green quickly. It should be fixed already in rc2 so there
is no need to keep it.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Does the PR follow [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist)
      PR format?
- [x] Is the code style correct (follows pylint and black guidelines)?


<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2187.org.readthedocs.build/en/2187/

<!-- readthedocs-preview arviz end -->