### PR TITLE
Downgrade matplotlib dependency to 3.2 and fix numerous pylint issues

### DIFF
--- a/.azure-pipelines/azure-pipelines-external.yml
+++ b/.azure-pipelines/azure-pipelines-external.yml
@@ -95,9 +95,9 @@ jobs:
       python -m pip freeze
     displayName: 'Print packages'
 
-  # - script: |
-  #     python -m pylint arviz
-  #   displayName: 'pylint'
+  - script: |
+      python -m pylint arviz
+    displayName: 'pylint'
 
   - script: |
       python -m pydocstyle arviz

--- a/.azure-pipelines/azure-pipelines-external.yml
+++ b/.azure-pipelines/azure-pipelines-external.yml
@@ -95,9 +95,9 @@ jobs:
       python -m pip freeze
     displayName: 'Print packages'
 
-  - script: |
-      python -m pylint arviz
-    displayName: 'pylint'
+  # - script: |
+  #     python -m pylint arviz
+  #   displayName: 'pylint'
 
   - script: |
       python -m pydocstyle arviz

--- a/.pylintrc
+++ b/.pylintrc
@@ -75,7 +75,8 @@ disable=missing-docstring,
         consider-using-with,
         consider-using-f-string,
         # TODO: Remove this once update the code base.
-        unnecessary-lambda-assignment
+        unnecessary-lambda-assignment,
+        use-dict-literal
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -678,7 +678,7 @@ class InferenceData(Mapping[str, xr.Dataset]):
             for df in dfs_tail:
                 dfs = dfs.merge(df, how="outer", copy=False)
         else:
-            (dfs,) = dfs.values()
+            (dfs,) = dfs.values() # pylint: disable=unbalanced-dict-unpacking
         return dfs
 
     def to_zarr(self, store=None):

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -678,7 +678,7 @@ class InferenceData(Mapping[str, xr.Dataset]):
             for df in dfs_tail:
                 dfs = dfs.merge(df, how="outer", copy=False)
         else:
-            (dfs,) = dfs.values() # pylint: disable=unbalanced-dict-unpacking
+            (dfs,) = dfs.values()  # pylint: disable=unbalanced-dict-unpacking
         return dfs
 
     def to_zarr(self, store=None):

--- a/arviz/plots/elpdplot.py
+++ b/arviz/plots/elpdplot.py
@@ -133,7 +133,7 @@ def plot_elpd(
     coord_labels = format_coords_as_labels(pointwise_data[0]) if xlabels else None
 
     if numvars < 2:
-        raise Exception("Number of models to compare must be 2 or greater.")
+        raise ValueError("Number of models to compare must be 2 or greater.")
 
     elpd_plot_kwargs = dict(
         ax=ax,

--- a/arviz/tests/base_tests/test_rcparams.py
+++ b/arviz/tests/base_tests/test_rcparams.py
@@ -288,18 +288,18 @@ def test_stats_information_criterion(models):
 
 def test_http_type_request(monkeypatch):
     def _urlretrive(url, _):
-        raise Exception(f"URL Retrieved: {url}")
+        raise ValueError(f"URL Retrieved: {url}")
 
     # Hijack url retrieve to inspect url passed
     monkeypatch.setattr(datasets, "urlretrieve", _urlretrive)
 
     # Test HTTPS default
-    with pytest.raises(Exception) as error:
+    with pytest.raises(ValueError) as error:
         datasets.load_arviz_data("radon")
         assert "https://" in str(error)
 
     # Test HTTP setting
-    with pytest.raises(Exception) as error:
+    with pytest.raises(ValueError) as error:
         rcParams["data.http_protocol"] = "http"
         datasets.load_arviz_data("radon")
         assert "http://" in str(error)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 setuptools>=60.0.0
-matplotlib>=3.5
+matplotlib~=3.2
 numpy>=1.20.0
 scipy>=1.8.0
 packaging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 setuptools>=60.0.0
-matplotlib~=3.2
+matplotlib>=3.2
 numpy>=1.20.0
 scipy>=1.8.0
 packaging


### PR DESCRIPTION
Testing to see what happens if we lower the matplotlib dependency. This is for google colab update

<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2201.org.readthedocs.build/en/2201/

<!-- readthedocs-preview arviz end -->