### PR TITLE
Clean up references to deprecated Numpy type aliases

### DIFF
--- a/arviz/data/io_pyro.py
+++ b/arviz/data/io_pyro.py
@@ -129,7 +129,7 @@ class PyroConverter:
     def sample_stats_to_xarray(self):
         """Extract sample_stats from Pyro posterior."""
         divergences = self.posterior.diagnostics()["divergences"]
-        diverging = np.zeros((self.nchains, self.ndraws), dtype=np.bool)
+        diverging = np.zeros((self.nchains, self.ndraws), dtype=bool)
         for i, k in enumerate(sorted(divergences)):
             diverging[i, divergences[k]] = True
         data = {"diverging": diverging}

--- a/arviz/stats/density_utils.py
+++ b/arviz/stats/density_utils.py
@@ -303,7 +303,7 @@ def _check_custom_lims(custom_lims, x_min, x_max):
     if custom_lims[1] is None:
         custom_lims[1] = x_max
 
-    all_numeric = all(isinstance(i, (int, float, np.integer, float)) for i in custom_lims)
+    all_numeric = all(isinstance(i, (int, float, np.integer, np.number)) for i in custom_lims)
     if not all_numeric:
         raise TypeError(
             "Elements of `custom_lims` must be numeric or None.\nAt least one of them is not."

--- a/arviz/stats/density_utils.py
+++ b/arviz/stats/density_utils.py
@@ -303,7 +303,7 @@ def _check_custom_lims(custom_lims, x_min, x_max):
     if custom_lims[1] is None:
         custom_lims[1] = x_max
 
-    all_numeric = all(isinstance(i, (int, float, np.integer, np.float)) for i in custom_lims)
+    all_numeric = all(isinstance(i, (int, float, np.integer, float)) for i in custom_lims)
     if not all_numeric:
         raise TypeError(
             "Elements of `custom_lims` must be numeric or None.\nAt least one of them is not."

--- a/arviz/stats/diagnostics.py
+++ b/arviz/stats/diagnostics.py
@@ -836,7 +836,7 @@ def _mcse_sd(ary):
         return np.nan
     ess = _ess_sd(ary)
     if _numba_flag:
-        sd = np.float(_sqrt(svar(np.ravel(ary), ddof=1), np.zeros(1)))
+        sd = float(_sqrt(svar(np.ravel(ary), ddof=1), np.zeros(1)))
     else:
         sd = np.std(ary, ddof=1)
     fac_mcse_sd = np.sqrt(np.exp(1) * (1 - 1 / ess) ** (ess - 1) - 1)
@@ -905,7 +905,7 @@ def _mc_error(ary, batches=5, circular=False):
                 else:
                     std = stats.circstd(ary, high=np.pi, low=-np.pi)
             elif _numba_flag:
-                std = np.float(_sqrt(svar(ary), np.zeros(1)))
+                std = float(_sqrt(svar(ary), np.zeros(1)))
             else:
                 std = np.std(ary)
             return std / np.sqrt(len(ary))


### PR DESCRIPTION
closes #2194 - Clean up references to deprecated NumPy type aliases
Deprecated numpy type aliases were replaced (np.float to float, np.bool to bool) according to the recommendations made in NumPy 1.20.0 Release Notes: https://numpy.org/devdocs/release/1.20.0-notes.html

<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2204.org.readthedocs.build/en/2204/

<!-- readthedocs-preview arviz end -->