### PR TITLE
Add rope to plots arguments guide

### DIFF
--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -182,20 +182,6 @@ def plot_forest(
         >>>                            figsize=(9, 7))
         >>> axes[0].set_title('Estimated theta for 8 schools models')
 
-    Forestplot with ropes
-
-    .. plot::
-        :context: close-figs
-
-        >>> rope = {'theta': [{'school': 'Choate', 'rope': (2, 4)}], 'mu': [{'rope': (-2, 2)}]}
-        >>> axes = az.plot_forest(non_centered_data,
-        >>>                            rope=rope,
-        >>>                            var_names='~tau',
-        >>>                            combined=True,
-        >>>                            figsize=(9, 7))
-        >>> axes[0].set_title('Estimated theta for 8 schools model')
-
-
     Ridgeplot
 
     .. plot::

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -85,10 +85,10 @@ def plot_forest(
     hdi_prob : float, default 0.94
         Plots highest posterior density interval for chosen percentage of density.
         See :ref:`this section <common_ hdi_prob>` for usage examples.
-    rope : tuple or dictionary of tuples
-        Lower and upper values of the Region Of Practical Equivalence. If a list is provided,
-        its length should match the number of variables. See :ref:`this section <common_rope>`
-        for usage examples.
+    rope : list, tuple or dictionary of tuples
+        A dictionary of tuples with the lower and upper values of the Region Of Practical
+        Equivalence. If a list is provided, its length should match the number of variables.
+        See :ref:`this section <common_rope>` for usage examples.
     quartiles : bool, default True
         Flag for plotting the interquartile range, in addition to the ``hdi_prob`` intervals.
     r_hat : bool, default False

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -86,9 +86,9 @@ def plot_forest(
         Plots highest posterior density interval for chosen percentage of density.
         See :ref:`this section <common_ hdi_prob>` for usage examples.
     rope : tuple or dictionary of tuples
-        Lower and upper values of the Region of Practical Equivalence. If a list with one interval
-        only is provided, the ROPE will be displayed across the y-axis. If more than one
-        interval is provided the length of the list should match the number of variables.
+        Lower and upper values of the Region Of Practical Equivalence. If a list is provided,
+        its length should match the number of variables. See :ref:`this section <common_rope>`
+        for usage examples.
     quartiles : bool, default True
         Flag for plotting the interquartile range, in addition to the ``hdi_prob`` intervals.
     r_hat : bool, default False

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -85,10 +85,9 @@ def plot_forest(
     hdi_prob : float, default 0.94
         Plots highest posterior density interval for chosen percentage of density.
         See :ref:`this section <common_ hdi_prob>` for usage examples.
-    rope : list, tuple or dictionary of tuples
+    rope : list, tuple or dictionary of {str : tuples or lists}, optional
         A dictionary of tuples with the lower and upper values of the Region Of Practical
-        Equivalence. If a list is provided, its length should match the number of variables.
-        See :ref:`this section <common_rope>` for usage examples.
+        Equivalence. See :ref:`this section <common_rope>` for usage examples.
     quartiles : bool, default True
         Flag for plotting the interquartile range, in addition to the ``hdi_prob`` intervals.
     r_hat : bool, default False

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -38,7 +38,7 @@ def plot_posterior(
     show=None,
     **kwargs
 ):
-    """Plot Posterior densities in the style of John K. Kruschke's book.
+    r"""Plot Posterior densities in the style of John K. Kruschke's book.
 
     Parameters
     ----------
@@ -85,7 +85,8 @@ def plot_posterior(
         Specifies which InferenceData group should be plotted. Defaults to 'posterior'.
     rope: tuple or dictionary of tuples
         Lower and upper values of the Region Of Practical Equivalence. If a list is provided, its
-        length should match the number of variables.
+        length should match the number of variables. See :ref:`this section <common_rope>`
+        for usage examples.
     ref_val: float or dictionary of floats
         display the percentage below and above the values in ref_val. Must be None (default),
         a constant, a list or a dictionary like see an example below. If a list is provided, its

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -83,10 +83,9 @@ def plot_posterior(
         Defaults to 'auto' i.e. it falls back to default set in rcParams.
     group: str, optional
         Specifies which InferenceData group should be plotted. Defaults to 'posterior'.
-    rope: list, tuple or dictionary of tuples
+    rope : list, tuple or dictionary of {str: tuples or lists}, optional
         A dictionary of tuples with the lower and upper values of the Region Of Practical
-        Equivalence. If a list is provided, its length should match the number of variables.
-        See :ref:`this section <common_rope>` for usage examples.
+        Equivalence. See :ref:`this section <common_rope>` for usage examples.
     ref_val: float or dictionary of floats
         display the percentage below and above the values in ref_val. Must be None (default),
         a constant, a list or a dictionary like see an example below. If a list is provided, its

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -83,10 +83,10 @@ def plot_posterior(
         Defaults to 'auto' i.e. it falls back to default set in rcParams.
     group: str, optional
         Specifies which InferenceData group should be plotted. Defaults to 'posterior'.
-    rope: tuple or dictionary of tuples
-        Lower and upper values of the Region Of Practical Equivalence. If a list is provided, its
-        length should match the number of variables. See :ref:`this section <common_rope>`
-        for usage examples.
+    rope: list, tuple or dictionary of tuples
+        A dictionary of tuples with the lower and upper values of the Region Of Practical
+        Equivalence. If a list is provided, its length should match the number of variables.
+        See :ref:`this section <common_rope>` for usage examples.
     ref_val: float or dictionary of floats
         display the percentage below and above the values in ref_val. Must be None (default),
         a constant, a list or a dictionary like see an example below. If a list is provided, its

--- a/doc/source/user_guide/plots_arguments_guide.md
+++ b/doc/source/user_guide/plots_arguments_guide.md
@@ -307,19 +307,55 @@ Module {mod}`bokeh.colors`
 (common_rope)=
 ## `rope`
 
-A dictionary of tuples with lower and upper values of the Region Of Practical Equivalence. If a list with
-one interval only is provided, the `ROPE` will be displayed across the `y-axis`. If more than one interval
-is provided the length of the list should match the number of variables.
+The rope argument is used to indicate the lower and upper limits of the Region Of Practical
+Equivalence (ROPE). These limits can be expressed in two ways, depending on whether
+the ROPE is common between all variables or not:
+
+1. A single list. If a single list of two floats is given as `rope` argument,
+   these two provided values will be used as limits of the ROPE in all plotted variables.
+2. A dictionary of lists.
+
+Example of using a single list as `rope`
 
 ```{code-cell} ipython3
-# list of ropes for different schools
-rope={'theta': [{'school': 'Choate',    'rope': (0, 3)},
-                  {'school': 'Phillips Andover', 'rope': (10, 14)},
-                  {'school': 'Hotchkiss', 'rope': (3, 9)},
-                  {'school': "St. Paul's", 'rope': (3, 8)},
-                 ]};
+az.plot_forest(non_centered_eight, var_names="~theta_t", rope=[-1, 2]);
+```
 
-az.plot_forest(non_centered_eight,rope=rope,var_names='theta',combined=True);
+An example of using a dictionary as `rope` to highlight the ROPE for a single variable:
+
+```{code-cell} ipython3
+rope = {'mu': [{"rope": (4, 5)}]}
+
+az.plot_forest(non_centered_eight, rope=rope, var_names='~theta_t', combined=True);
+```
+
+An example of using a dictionary as `rope` to highlight different ROPEs for different variables:
+
+```{code-cell} ipython3
+rope = {
+    "mu": [{"rope": (4, 5)}],
+    "theta": [
+        {"school": "Choate",    "rope": (0, 3)},
+        {"school": "Phillips Andover", "rope": (10, 14)},
+        {"school": "Hotchkiss", "rope": (3, 9)},
+        {"school": "St. Paul's", "rope": (3, 8)},
+    ]
+}
+
+az.plot_forest(non_centered_eight, rope=rope, var_names="~theta_t", combined=True);
+```
+
+Moreover, for multidimensional variables, it is easy to share a common ROPE for all its components
+with a different one for other variables:
+
+```{code-cell} ipython3
+rope = {
+    "mu": [{"rope": (4, 5)}],
+    "theta": [{"rope": (0, 3)}],
+    "tau": [{"rope": (0, 1)}],
+}
+
+az.plot_forest(non_centered_eight, rope=rope, var_names="~theta_t", combined=True);
 ```
 
 (common_legend)=

--- a/doc/source/user_guide/plots_arguments_guide.md
+++ b/doc/source/user_guide/plots_arguments_guide.md
@@ -319,7 +319,7 @@ rope={'theta': [{'school': 'Choate',    'rope': (0, 3)},
                   {'school': "St. Paul's", 'rope': (3, 8)},
                  ]};
 
-az.plot_forest(non_centered_data,rope=rope,var_names='theta',combined=True);
+az.plot_forest(non_centered_eight,rope=rope,var_names='theta',combined=True);
 ```
 
 (common_legend)=

--- a/doc/source/user_guide/plots_arguments_guide.md
+++ b/doc/source/user_guide/plots_arguments_guide.md
@@ -304,6 +304,24 @@ Matplotlib {doc}`mpl:tutorials/colors/colors` tutorial.
 Module {mod}`bokeh.colors`
 :::
 
+(common_rope)=
+## `rope`
+
+A list with lower and upper values of the Region Of Practical Equivalence. If a list with one interval
+only is provided, the `ROPE` will be displayed across the `y-axis`. If more than one interval is
+provided the length of the list should match the number of variables.
+
+```{code-cell} ipython3
+# list of ropes for different schools
+rope={'theta': [{'school': 'Choate',    'rope': (0, 3)},
+                  {'school': 'Phillips Andover', 'rope': (10, 14)},
+                  {'school': 'Hotchkiss', 'rope': (3, 9)},
+                  {'school': "St. Paul's", 'rope': (3, 8)},
+                 ]};
+
+az.plot_forest(non_centered_data,rope=rope,var_names='theta',combined=True);
+```
+
 (common_legend)=
 ## `legend`
 

--- a/doc/source/user_guide/plots_arguments_guide.md
+++ b/doc/source/user_guide/plots_arguments_guide.md
@@ -307,9 +307,9 @@ Module {mod}`bokeh.colors`
 (common_rope)=
 ## `rope`
 
-A list with lower and upper values of the Region Of Practical Equivalence. If a list with one interval
-only is provided, the `ROPE` will be displayed across the `y-axis`. If more than one interval is
-provided the length of the list should match the number of variables.
+A dictionary of tuples with lower and upper values of the Region Of Practical Equivalence. If a list with
+one interval only is provided, the `ROPE` will be displayed across the `y-axis`. If more than one interval
+is provided the length of the list should match the number of variables.
 
 ```{code-cell} ipython3
 # list of ropes for different schools


### PR DESCRIPTION
## Description

Add the `rope` option to the "Plot's arguments guide" page; this option is available in the forest and posterior plots. Added a link to the page in both arguments' documentation.

Additionally, I removed the forest plot with ropes example from its documentation, to add other examples later

## Checklist

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding. If you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->


<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2210.org.readthedocs.build/en/2210/

<!-- readthedocs-preview arviz end -->
