### PR TITLE
Fixing unreasonable memory usage when creating an InferenceData object from an emcee sampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## v0.x.x Unreleased
+
+### Maintenance and fixes
+- Fix memory usage and improve efficiency for `io_emcee.posterior_to_xarray`.
+
 ## v0.15.0 (2023 Feb 19)
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.x.x Unreleased
 
 ### Maintenance and fixes
-- Fix memory usage and improve efficiency for `io_emcee.posterior_to_xarray`.
+- Fix memory usage and improve efficiency in `from_emcee`.
 
 ## v0.15.0 (2023 Feb 19)
 

--- a/arviz/data/io_emcee.py
+++ b/arviz/data/io_emcee.py
@@ -115,15 +115,14 @@ class EmceeConverter:
 
     def posterior_to_xarray(self):
         """Convert the posterior to an xarray dataset."""
-        # A chain object is created outside of the dictionary to avoid a spike in memory usage
         # Use emcee3 syntax, else use emcee2
         if hasattr(self.sampler, "get_chain"):
-            chain = self.sampler.get_chain().swapaxes(0, 1)
+            samples_ary = self.sampler.get_chain().swapaxes(0, 1)
         else:
-            chain = self.sampler.chain
+            samples_ary = self.sampler.chain
 
         data = {
-            var_name: (chain[(..., idx)])
+            var_name: (samples_ary[(..., idx)])
             for idx, var_name in zip(self.slices, self.var_names)
         }
         return dict_to_dataset(

--- a/arviz/data/io_emcee.py
+++ b/arviz/data/io_emcee.py
@@ -116,12 +116,14 @@ class EmceeConverter:
     def posterior_to_xarray(self):
         """Convert the posterior to an xarray dataset."""
         # Use emcee3 syntax, else use emcee2
+        # A chain object is created outside of the dictionary to avoid a spike in memory usage
+        if hasattr(self.sampler, "get_chain"):
+            chain = self.sampler.get_chain().swapaxes(0, 1)
+        else:
+            chain = self.sampler.chain
+
         data = {
-            var_name: (
-                self.sampler.get_chain()[(..., idx)].swapaxes(0, 1)
-                if hasattr(self.sampler, "get_chain")
-                else self.sampler.chain[(..., idx)]
-            )
+            var_name: (chain[(..., idx)])
             for idx, var_name in zip(self.slices, self.var_names)
         }
         return dict_to_dataset(

--- a/arviz/data/io_emcee.py
+++ b/arviz/data/io_emcee.py
@@ -115,8 +115,8 @@ class EmceeConverter:
 
     def posterior_to_xarray(self):
         """Convert the posterior to an xarray dataset."""
-        # Use emcee3 syntax, else use emcee2
         # A chain object is created outside of the dictionary to avoid a spike in memory usage
+        # Use emcee3 syntax, else use emcee2
         if hasattr(self.sampler, "get_chain"):
             chain = self.sampler.get_chain().swapaxes(0, 1)
         else:


### PR DESCRIPTION
## Description

The goal of this change is to prevent large memory consumption during the creation of an InferenceData object from emcee. The change also improves efficiency.

Previously, the full chain was initialized once for each of the variables, leading to long initialization time and a spike in memory usage (my 2.5Gb chain with ~30 dimensions led to 60+Gb of allocated memory, crashing the python process).


## Checklist
- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] New features are properly documented (with an example if appropriate)?
- [x] Code style correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)


<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2215.org.readthedocs.build/en/2215/

<!-- readthedocs-preview arviz end -->