### PR TITLE
replaced pkg_resources with importlib.resources

### DIFF
--- a/arviz/data/base.py
+++ b/arviz/data/base.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union
 
 import numpy as np
-import pkg_resources
+import importlib.resources
 import xarray as xr
 
 try:
@@ -339,13 +339,12 @@ def make_attrs(attrs=None, library=None):
         library_name = library.__name__
         default_attrs["inference_library"] = library_name
         try:
-            version = pkg_resources.get_distribution(library_name).version
+            version = importlib.metadata.version(library_name)
             default_attrs["inference_library_version"] = version
-        except pkg_resources.DistributionNotFound:
+        except importlib.metadata.PackageNotFoundError:
             if hasattr(library, "__version__"):
                 version = library.__version__
                 default_attrs["inference_library_version"] = version
-
     if attrs is not None:
         default_attrs.update(attrs)
     return default_attrs

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -8,7 +8,7 @@ from functools import lru_cache
 
 import matplotlib.pyplot as plt
 import numpy as np
-import pkg_resources
+import importlib.resources
 from numpy import newaxis
 
 from .rcparams import rcParams
@@ -658,7 +658,7 @@ def _load_static_files():
 
     Clone from xarray.core.formatted_html_template.
     """
-    return [pkg_resources.resource_string("arviz", fname).decode("utf8") for fname in STATIC_FILES]
+    return [importlib.resources.read_text("arviz", fname) for fname in STATIC_FILES]
 
 
 class HtmlTemplate:

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -658,7 +658,7 @@ def _load_static_files():
 
     Clone from xarray.core.formatted_html_template.
     """
-    return [importlib.resources.read_text("arviz", fname) for fname in STATIC_FILES]
+    return [importlib.resources.files("arviz").joinpath(fname).read_text() for fname in STATIC_FILES]
 
 
 class HtmlTemplate:


### PR DESCRIPTION
## Description
Replacement of deprecated pkg_resources, now arviz will use importlib.resources 
which will allow to use more strict testing policy in packages importing arviz ( previously because of pkg_resources 
failing test on warning was not possible, because each import of arviz was warning about deprecation of pkg_resources)


<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2232.org.readthedocs.build/en/2232/

<!-- readthedocs-preview arviz end -->