### PR TITLE
add 3.11 to CI

### DIFF
--- a/.azure-pipelines/azure-pipelines-base.yml
+++ b/.azure-pipelines/azure-pipelines-base.yml
@@ -10,6 +10,10 @@ jobs:
   timeoutInMinutes: 360
   strategy:
     matrix:
+      Python_311:
+        python.version: "3.11"
+        PyPIGithub: false
+        name: "Python 3.11"
       Python_310:
         python.version: "3.10"
         PyPIGithub: false

--- a/README.md
+++ b/README.md
@@ -156,12 +156,12 @@ python setup.py install
 </tr>
 </table>
 <div>
-  
+
   <a href="https://python.arviz.org/en/latest/examples/index.html">And more...</a>
 </div>
 ## Dependencies
 
-ArviZ is tested on Python 3.7, 3.8 and 3.9, and depends on NumPy, SciPy, xarray, and Matplotlib.
+ArviZ is tested on Python 3.9, 3.10 and 3.11, and depends on NumPy, SciPy, xarray, and Matplotlib.
 
 
 ## Citation

--- a/asv_benchmarks/asv.conf.json
+++ b/asv_benchmarks/asv.conf.json
@@ -46,7 +46,7 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["3.8"],
+    // "pythons": ["3.10"],
 
     // The list of conda channel names to be searched for benchmark
     // dependency packages in the specified order

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     long_description=get_long_description(),
     long_description_content_type="text/markdown",
     include_package_data=True,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Framework :: Matplotlib",
@@ -67,7 +67,6 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
## Description
Add 3.11 to CI so we test again with 3 python versions. Also drop support for 3.8 (which hasn't been tested for a while)


<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2240.org.readthedocs.build/en/2240/

<!-- readthedocs-preview arviz end -->