### PR TITLE
Add explicit nopython argument to utils.py

### DIFF
--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -181,7 +181,7 @@ class maybe_numba_fn:  # pylint: disable=invalid-name
         """Memoized compiled function."""
         try:
             numba = importlib.import_module("numba")
-            numba_fn = numba.jit(**self.kwargs)(self.function)
+            numba_fn = numba.jit(nopython=False, **self.kwargs)(self.function)
         except ImportError:
             numba_fn = self.function
         return numba_fn
@@ -258,7 +258,7 @@ def conditional_jit(_func=None, **kwargs):
 
     Notes
     -----
-        If called without arguments  then return wrapped function.
+        If called without arguments then return wrapped function.
 
         @conditional_jit
         def my_func():


### PR DESCRIPTION
include explicit `nopython=False` to L184 of `utils.py` & fixed a small typo in the docstring.

no direct issue related to this, only an effort to fix the following warning:

`~/envs/py311-test/lib/python3.11/site-packages/arviz/utils.py:184: NumbaDeprecationWarning: The 'nopython' keyword argument was not supplied to the 'numba.jit' decorator. The implicit default value for this argument is currently False, but it will be changed to True in Numba 0.59.0. See https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-object-mode-fall-back-behaviour-when-using-jit for details.
  numba_fn = numba.jit(**self.kwargs)(self.function)`


<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2245.org.readthedocs.build/en/2245/

<!-- readthedocs-preview arviz end -->