### PR TITLE
Add default nopython kwarg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@
 - Bayes Factor plot: Use arviz's kde instead of the one from scipy ([2237](https://github.com/arviz-devs/arviz/pull/2237))
 
 ### Maintenance and fixes
-
+- Fix numba deprecation warning ([2246](https://github.com/arviz-devs/arviz/pull/2246))
 - Fixes for creating numpy object array ([2233](https://github.com/arviz-devs/arviz/pull/2233) and [2239](https://github.com/arviz-devs/arviz/pull/2239))
+
 
 ### Deprecation
 

--- a/arviz/tests/base_tests/test_utils_numba.py
+++ b/arviz/tests/base_tests/test_utils_numba.py
@@ -48,7 +48,7 @@ def test_conditional_jit_numba_decorator_keyword(monkeypatch):
 
     # pylint: disable=unpacking-non-sequence
     function_results, wrapper_result = placeholder_func()
-    assert wrapper_result == {"keyword_argument": "A keyword argument"}
+    assert wrapper_result == {"keyword_argument": "A keyword argument", "nopython": False}
     assert function_results == "output"
 
 

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -174,6 +174,7 @@ class maybe_numba_fn:  # pylint: disable=invalid-name
     def __init__(self, function, **kwargs):
         """Wrap a function and save compilation keywords."""
         self.function = function
+        kwargs.setdefault("nopython", False)
         self.kwargs = kwargs
 
     @lazy_property


### PR DESCRIPTION
## Description
Fix deprecation warning with numba jit.

## Checklist

- [ ] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2246.org.readthedocs.build/en/2246/

<!-- readthedocs-preview arviz end -->