### PR TITLE
change the second instance 'observed' to 'observed_rug' in the doc string of plot_ppc

### DIFF
--- a/arviz/plots/ppcplot.py
+++ b/arviz/plots/ppcplot.py
@@ -63,7 +63,7 @@ def plot_ppc(
         Defaults to ``True``.
     observed: bool, default True
         Whether or not to plot the observed data.
-    observed: bool, default False
+    observed_rug: bool, default False
         Whether or not to plot a rug plot for the observed data. Only valid if `observed` is
         `True` and for kind `kde` or `cumulative`.
     color: str


### PR DESCRIPTION
Changed the plot_ppc docstring second instance 'observed' to 'observed_rug'

<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2255.org.readthedocs.build/en/2255/

<!-- readthedocs-preview arviz end -->