### PR TITLE
Fixed ppcplot-twice observed docstring

### DIFF
--- a/arviz/plots/ppcplot.py
+++ b/arviz/plots/ppcplot.py
@@ -63,7 +63,7 @@ def plot_ppc(
         Defaults to ``True``.
     observed: bool, default True
         Whether or not to plot the observed data.
-    observed: bool, default False
+    observed_rug: bool, default False
         Whether or not to plot a rug plot for the observed data. Only valid if `observed` is
         `True` and for kind `kde` or `cumulative`.
     color: str


### PR DESCRIPTION
## Description
fixed issue #2254 . The docstring contained `observed` twice, the second instance should have been `observed_rug`.
<!-- 
Thank you so much for your PR! To help us review your contribution, please consider the following points:

- The PR title should summarize the changes, for example "Add new group argument for the pair plot".
  Avoid non-descriptive titles such as "Addresses issue #348".

- The description should provide at least 1-2 sentences describing the pull request in detail and
  link to any relevant issues.

- Please prefix the title of incomplete contributions with [WIP] (to indicate a work in
  progress). WIPs may be useful to (1) indicate you are working on something to avoid
  duplicated work, (2) request broad review of functionality or API, or (3) seek collaborators. -->
<!-- 
## Checklist
Feel free to remove check-list items aren't relevant to your change

- [ ] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [ ] New features are properly documented (with an example if appropriate)?
- [ ] Includes new or updated tests to cover the new feature
- [ ] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)
 -->
<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->


<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2256.org.readthedocs.build/en/2256/

<!-- readthedocs-preview arviz end -->