### PR TITLE
add funding metadata

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+tidelift: "pypi/arviz"
+custom: https://numfocus.org/donate-to-arviz


### PR DESCRIPTION
## Description
It doesn't make much sense to show tidelift in all repos as it is only related to this
one. I will update https://github.com/arviz-devs/.github/blob/master/FUNDING.yml to have only
numfocus so that continues to appear to all repos by default, but here it will be overriden
to show both as it happens now.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format


<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2262.org.readthedocs.build/en/2262/

<!-- readthedocs-preview arviz end -->