### PR TITLE
Set matplotlib >=3.5 in requirements.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### New features
 
 ### Maintenance and fixes
-Set matplotlib requirements >=3.5
+- Update requirements: matplotlib>=3.5, pandas>=1.4.0, numpy>=1.22.0
 
 ### Deprecation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### New features
 
 ### Maintenance and fixes
+Set matplotlib requirements >=3.5
 
 ### Deprecation
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 setuptools>=60.0.0
 matplotlib>=3.5
-numpy>=1.21.0,<2.0
+numpy>=1.22.0,<2.0
 scipy>=1.8.0
 packaging
-pandas>=1.3.0
+pandas>=1.4.0
 xarray>=0.21.0
 h5netcdf>=1.0.2
 typing_extensions>=4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 setuptools>=60.0.0
-matplotlib>=3.2
+matplotlib>=3.5
 numpy>=1.21.0,<2.0
 scipy>=1.8.0
 packaging


### PR DESCRIPTION
## Description
- set matplotlib >=3.5 in requirements.txt
Since https://github.com/arviz-devs/arviz/pull/2127 `arviz/__init__.py` requires matplotlib >= 3.5 for `mpl.colormaps.register()` otherwise `arviz` fails on import.
- add this change to changelog.md
<!--
Thank you so much for your PR! To help us review your contribution, please consider the following points:

- The PR title should summarize the changes, for example "Add new group argument for the pair plot".
  Avoid non-descriptive titles such as "Addresses issue #348".

- The description should provide at least 1-2 sentences describing the pull request in detail and
  link to any relevant issues.

- Please prefix the title of incomplete contributions with [WIP] (to indicate a work in
  progress). WIPs may be useful to (1) indicate you are working on something to avoid
  duplicated work, (2) request broad review of functionality or API, or (3) seek collaborators. -->

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
