### PR TITLE
Make `from_dict` more flexible, and add `from_pytree`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.x.x Unreleased
 
 ### New features
+- Support for `pytree`s and robust to nested dictionaries. (2291)
 
 ### Maintenance and fixes
 - Fix deprecations introduced in latest pandas and xarray versions, and prepare for numpy 2.0 ones ([2315](https://github.com/arviz-devs/arviz/pull/2315)))

--- a/arviz/data/__init__.py
+++ b/arviz/data/__init__.py
@@ -1,5 +1,5 @@
 """Code for loading and manipulating data structures."""
-from .base import CoordSpec, DimSpec, dict_to_dataset, numpy_to_data_array
+from .base import CoordSpec, DimSpec, dict_to_dataset, numpy_to_data_array, pytree_to_dataset
 from .converters import convert_to_dataset, convert_to_inference_data
 from .datasets import clear_data_home, list_datasets, load_arviz_data
 from .inference_data import InferenceData, concat
@@ -43,6 +43,7 @@ __all__ = [
     "from_pyro",
     "from_numpyro",
     "from_netcdf",
+    "pytree_to_dataset",
     "to_datatree",
     "to_json",
     "to_netcdf",

--- a/arviz/data/__init__.py
+++ b/arviz/data/__init__.py
@@ -7,7 +7,7 @@ from .io_beanmachine import from_beanmachine
 from .io_cmdstan import from_cmdstan
 from .io_cmdstanpy import from_cmdstanpy
 from .io_datatree import from_datatree, to_datatree
-from .io_dict import from_dict
+from .io_dict import from_dict, from_pytree
 from .io_emcee import from_emcee
 from .io_json import from_json, to_json
 from .io_netcdf import from_netcdf, to_netcdf
@@ -38,6 +38,7 @@ __all__ = [
     "from_cmdstanpy",
     "from_datatree",
     "from_dict",
+    "from_pytree",
     "from_json",
     "from_pyro",
     "from_numpyro",

--- a/arviz/data/base.py
+++ b/arviz/data/base.py
@@ -352,7 +352,9 @@ def pytree_to_dataset(
 
     .. ipython::
 
-        dict_to_dataset({'x': np.random.randn(4, 100), 'y': np.random.rand(4, 100)})
+        In [1]: import arviz as az
+           ...: import numpy as np
+           ...: az.dict_to_dataset({'x': np.random.randn(4, 100), 'y': np.random.rand(4, 100)})
 
     Note that unlike the :class:`xarray.Dataset` constructor, ArviZ has added extra
     information to the generated Dataset such as default dimension names for sampled
@@ -362,7 +364,7 @@ def pytree_to_dataset(
 
     .. ipython::
 
-        pytree_to_dataset({'top': {'second': 1.}, 'top2': 1.})
+        In [1]: az.pytree_to_dataset({'top': {'second': 1.}, 'top2': 1.})
 
     which has two variables (as many as leafs) named ``('top', 'second')`` and ``top2``.
 
@@ -370,15 +372,15 @@ def pytree_to_dataset(
 
     .. ipython::
 
-        datadict = {
-            "top": {"a": np.random.randn(100), "b": np.random.randn(1, 100, 10)},
-            "d": np.random.randn(100),
-        }
-        dict_to_dataset(
-            datadict,
-            coords={"c": np.arange(10)},
-            dims={("top", "b"): ["c"]}
-        )
+        In [1]: datadict = {
+           ...:     "top": {"a": np.random.randn(100), "b": np.random.randn(1, 100, 10)},
+           ...:     "d": np.random.randn(100),
+           ...: }
+           ...: az.dict_to_dataset(
+           ...:     datadict,
+           ...:     coords={"c": np.arange(10)},
+           ...:     dims={("top", "b"): ["c"]}
+           ...: )
 
     """
     if dims is None:

--- a/arviz/data/converters.py
+++ b/arviz/data/converters.py
@@ -1,5 +1,6 @@
 """High level conversion functions."""
 import numpy as np
+import tree
 import xarray as xr
 
 from .base import dict_to_dataset
@@ -105,6 +106,8 @@ def convert_to_inference_data(obj, *, group="posterior", coords=None, dims=None,
         dataset = obj.to_dataset()
     elif isinstance(obj, dict):
         dataset = dict_to_dataset(obj, coords=coords, dims=dims)
+    elif tree.is_nested(obj) and not isinstance(obj, (list, tuple)):
+        dataset = dict_to_dataset(obj, coords=coords, dims=dims)
     elif isinstance(obj, np.ndarray):
         dataset = dict_to_dataset({"x": obj}, coords=coords, dims=dims)
     elif isinstance(obj, (list, tuple)) and isinstance(obj[0], str) and obj[0].endswith(".csv"):
@@ -118,6 +121,7 @@ def convert_to_inference_data(obj, *, group="posterior", coords=None, dims=None,
             "xarray dataarray",
             "xarray dataset",
             "dict",
+            "pytree",
             "netcdf filename",
             "numpy array",
             "pystan fit",

--- a/arviz/data/io_dict.py
+++ b/arviz/data/io_dict.py
@@ -458,3 +458,6 @@ def from_dict(
         attrs=attrs,
         **kwargs,
     ).to_inference_data()
+
+
+from_pytree = from_dict

--- a/arviz/plots/backends/matplotlib/pairplot.py
+++ b/arviz/plots/backends/matplotlib/pairplot.py
@@ -333,7 +333,7 @@ def plot_pair(
                     if reference_values:
                         x_name = flat_var_names[i]
                         y_name = flat_var_names[j + not_marginals]
-                        if x_name and y_name not in difference:
+                        if (x_name not in difference) and (y_name not in difference):
                             ax[j, i].plot(
                                 reference_values_copy[x_name],
                                 reference_values_copy[y_name],

--- a/arviz/tests/base_tests/test_data.py
+++ b/arviz/tests/base_tests/test_data.py
@@ -1077,6 +1077,20 @@ def test_dict_to_dataset():
     assert set(dataset.b.coords) == {"chain", "draw", "c"}
 
 
+def test_nested_dict_to_dataset():
+    datadict = {
+        "top": {"a": np.random.randn(100), "b": np.random.randn(1, 100, 10)},
+        "d": np.random.randn(100),
+    }
+    dataset = convert_to_dataset(datadict, coords={"c": np.arange(10)}, dims={("top", "b"): ["c"]})
+    assert set(dataset.data_vars) == {("top", "a"), ("top", "b"), "d"}
+    assert set(dataset.coords) == {"chain", "draw", "c"}
+
+    assert set(dataset[("top", "a")].coords) == {"chain", "draw"}
+    assert set(dataset[("top", "b")].coords) == {"chain", "draw", "c"}
+    assert set(dataset.d.coords) == {"chain", "draw"}
+
+
 def test_dict_to_dataset_event_dims_error():
     datadict = {"a": np.random.randn(1, 100, 10)}
     coords = {"b": np.arange(10), "c": ["x", "y", "z"]}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ numpy>=1.22.0,<2.0
 scipy>=1.8.0
 packaging
 pandas>=1.4.0
+dm-tree>=0.1.8
 xarray>=0.21.0
 h5netcdf>=1.0.2
 typing_extensions>=4.1.0


### PR DESCRIPTION
This also makes `from_dict` work for nested dictionaries. I joined the keys with double underscores because using a `.` would break attribute access (like, it would still work, but you'd use `idata.posterior['var.x.y']`, instead of `idata.posterior.var__x__y`)

Hopefully this is a no-op for most code, but it should make arviz work automatically with namedtuples or dataclasses. 


<!-- readthedocs-preview arviz start -->
----
:books: Documentation preview :books:: https://arviz--2291.org.readthedocs.build/en/2291/

<!-- readthedocs-preview arviz end -->