### PR TITLE
Refactor plot_ecdf arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### New features
 -  Use revised Pareto k threshold ([2349](https://github.com/arviz-devs/arviz/pull/2349))
 
+-   Added arguments `eval_points`, `rvs`, and `random_state` to `plot_ecdf` ([2316](https://github.com/arviz-devs/arviz/pull/2316))
+
 ### Maintenance and fixes
 - Ensure support with numpy 2.0 ([2321](https://github.com/arviz-devs/arviz/pull/2321))
 - Update testing strategy to include an environment without optional dependencies and
@@ -15,6 +17,8 @@
 ### Deprecation
 -  Support for arrays and DataArrays in plot_khat has been deprecated. Only ELPDdata will be supported in the future ([2349](https://github.com/arviz-devs/arviz/pull/2349))
 
+
+-   Removed arguments `values2`, `fpr`, `pointwise`, and `pit` in `plot_ecdf` ([2316](https://github.com/arviz-devs/arviz/pull/2316))
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 ### New features
 -  Use revised Pareto k threshold ([2349](https://github.com/arviz-devs/arviz/pull/2349))
 
--   Added arguments `band_prob`, `eval_points`, `rvs`, and `random_state` to `plot_ecdf` ([2316](https://github.com/arviz-devs/arviz/pull/2316))
--   Added rcParam `plot.band_prob` ([2316](https://github.com/arviz-devs/arviz/pull/2316))
+-   Added arguments `ci_prob`, `eval_points`, `rvs`, and `random_state` to `plot_ecdf` ([2316](https://github.com/arviz-devs/arviz/pull/2316))
+-   Added rcParam `stats.ci_prob` ([2316](https://github.com/arviz-devs/arviz/pull/2316))
 
 ### Maintenance and fixes
 - Ensure support with numpy 2.0 ([2321](https://github.com/arviz-devs/arviz/pull/2321))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@
 - Fix deprecation warnings in multiple dependencies ([2329](https://github.com/arviz-devs/arviz/pull/2329),
   [2332](https://github.com/arviz-devs/arviz/pull/2332) and [2333](https://github.com/arviz-devs/arviz/pull/2333))
 
+### Deprecation
+
+-   Removed arguments `values2`, `fpr`, `pointwise`, `npoints`, and `pit` in `plot_ecdf` ([2316](https://github.com/arviz-devs/arviz/pull/2316))
+
+### Documentation
+
 ## v0.17.1 (2024 Mar 13)
 
 ### Maintenance and fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### New features
 -  Use revised Pareto k threshold ([2349](https://github.com/arviz-devs/arviz/pull/2349))
 
--   Added arguments `eval_points`, `rvs`, and `random_state` to `plot_ecdf` ([2316](https://github.com/arviz-devs/arviz/pull/2316))
+-   Added arguments `band_prob`, `eval_points`, `rvs`, and `random_state` to `plot_ecdf` ([2316](https://github.com/arviz-devs/arviz/pull/2316))
+-   Added rcParam `plot.band_prob` ([2316](https://github.com/arviz-devs/arviz/pull/2316))
 
 ### Maintenance and fixes
 - Ensure support with numpy 2.0 ([2321](https://github.com/arviz-devs/arviz/pull/2321))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 -  Use revised Pareto k threshold ([2349](https://github.com/arviz-devs/arviz/pull/2349))
 
 -   Added arguments `ci_prob`, `eval_points`, `rvs`, and `random_state` to `plot_ecdf` ([2316](https://github.com/arviz-devs/arviz/pull/2316))
--   Added rcParam `stats.ci_prob` ([2316](https://github.com/arviz-devs/arviz/pull/2316))
+-   Deprecated rcParam `stats.hdi_prob` and replaced with `stats.ci_prob` ([2316](https://github.com/arviz-devs/arviz/pull/2316))
 
 ### Maintenance and fixes
 - Ensure support with numpy 2.0 ([2321](https://github.com/arviz-devs/arviz/pull/2321))

--- a/arviz/plots/backends/bokeh/ecdfplot.py
+++ b/arviz/plots/backends/bokeh/ecdfplot.py
@@ -13,7 +13,6 @@ def plot_ecdf(
     x_bands,
     lower,
     higher,
-    confidence_bands,
     plot_kwargs,
     fill_kwargs,
     plot_outline_kwargs,
@@ -58,7 +57,7 @@ def plot_ecdf(
         plot_outline_kwargs.setdefault("color", to_hex("C0"))
         plot_outline_kwargs.setdefault("alpha", 0.2)
 
-    if confidence_bands:
+    if x_bands is not None:
         ax.step(x_coord, y_coord, **plot_kwargs)
 
         if fill_band:

--- a/arviz/plots/backends/matplotlib/ecdfplot.py
+++ b/arviz/plots/backends/matplotlib/ecdfplot.py
@@ -13,7 +13,6 @@ def plot_ecdf(
     x_bands,
     lower,
     higher,
-    confidence_bands,
     plot_kwargs,
     fill_kwargs,
     plot_outline_kwargs,
@@ -59,7 +58,7 @@ def plot_ecdf(
 
     ax.step(x_coord, y_coord, **plot_kwargs)
 
-    if confidence_bands:
+    if x_bands is not None:
         if fill_band:
             ax.fill_between(x_bands, lower, higher, **fill_kwargs)
         else:

--- a/arviz/plots/bpvplot.py
+++ b/arviz/plots/bpvplot.py
@@ -80,7 +80,7 @@ def plot_bpv(
     hdi_prob : float, optional
         Probability for the highest density interval for the analytical reference distribution when
         ``kind=u_values``. Should be in the interval (0, 1]. Defaults to the
-        rcParam ``stats.hdi_prob``. See :ref:`this section <common_hdi_prob>` for usage examples.
+        rcParam ``stats.ci_prob``. See :ref:`this section <common_hdi_prob>` for usage examples.
     color : str, optional
         Matplotlib color
     grid : tuple, optional
@@ -202,7 +202,7 @@ def plot_bpv(
         raise TypeError("`reference` argument must be either `analytical`, `samples`, or `None`")
 
     if hdi_prob is None:
-        hdi_prob = rcParams["stats.hdi_prob"]
+        hdi_prob = rcParams["stats.ci_prob"]
     elif not 1 >= hdi_prob > 0:
         raise ValueError("The value of hdi_prob should be in the interval (0, 1]")
 

--- a/arviz/plots/densityplot.py
+++ b/arviz/plots/densityplot.py
@@ -209,7 +209,7 @@ def plot_density(
         )
 
     if hdi_prob is None:
-        hdi_prob = rcParams["stats.hdi_prob"]
+        hdi_prob = rcParams["stats.ci_prob"]
     elif not 1 >= hdi_prob > 0:
         raise ValueError("The value of hdi_prob should be in the interval (0, 1]")
 

--- a/arviz/plots/dotplot.py
+++ b/arviz/plots/dotplot.py
@@ -67,7 +67,7 @@ def plot_dot(
         The shape of the marker. Valid for matplotlib backend.
     hdi_prob : float, optional
         Valid only when point_interval is True. Plots HDI for chosen percentage of density.
-        Defaults to ``stats.hdi_prob`` rcParam. See :ref:`this section <common_hdi_prob>`
+        Defaults to ``stats.ci_prob`` rcParam. See :ref:`this section <common_hdi_prob>`
         for usage examples.
     rotated : bool, default False
         Whether to rotate the dot plot by 90 degrees.
@@ -151,7 +151,7 @@ def plot_dot(
     values.sort()
 
     if hdi_prob is None:
-        hdi_prob = rcParams["stats.hdi_prob"]
+        hdi_prob = rcParams["stats.ci_prob"]
     elif not 1 >= hdi_prob > 0:
         raise ValueError("The value of hdi_prob should be in the interval (0, 1]")
 

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -22,7 +22,7 @@ def plot_ecdf(
     cdf=None,
     difference=False,
     confidence_bands=False,
-    band_prob=None,
+    ci_prob=None,
     num_trials=500,
     rvs=None,
     random_state=None,
@@ -77,7 +77,7 @@ def plot_ecdf(
 
         For simultaneous confidence bands to be correctly calibrated, provide `eval_points` that
         are not dependent on the `values`.
-    band_prob : float, default 0.95
+    ci_prob : float, default 0.95
         The probability that the true ECDF lies within the confidence band. If `confidence_bands`
         is "pointwise", this is the marginal probability instead of the joint probability.
     eval_points : array-like, optional
@@ -127,7 +127,7 @@ def plot_ecdf(
     fpr : float, optional
 
         .. deprecated:: 0.18.0
-           Instead use `band_prob=1-fpr`.
+           Instead use `ci_prob=1-fpr`.
     pit : bool, default False
         If True plots the ECDF or ECDF-diff of PIT of sample.
 
@@ -213,16 +213,16 @@ def plot_ecdf(
 
     if fpr is not None:
         warnings.warn(
-            "`fpr` has been deprecated. Use `band_prob=1-fpr` or set `rcParam['plot.band_prob']` to"
+            "`fpr` has been deprecated. Use `ci_prob=1-fpr` or set `rcParam['stats.ci_prob']` to"
             "`1-fpr`.",
             DeprecationWarning,
         )
-        if band_prob is not None:
-            raise ValueError("Cannot specify both `fpr` and `band_prob`")
-        band_prob = 1 - fpr
+        if ci_prob is not None:
+            raise ValueError("Cannot specify both `fpr` and `ci_prob`")
+        ci_prob = 1 - fpr
 
-    if band_prob is None:
-        band_prob = rcParams["plot.band_prob"]
+    if ci_prob is None:
+        ci_prob = rcParams["stats.ci_prob"]
 
     if values2 is not None:
         if cdf is not None:
@@ -294,7 +294,7 @@ def plot_ecdf(
             eval_points,
             cdf_at_eval_points,
             method=confidence_bands,
-            prob=band_prob,
+            prob=ci_prob,
             num_trials=num_trials,
             rvs=rvs,
             random_state=random_state,

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -162,7 +162,7 @@ def plot_ecdf(
 
         >>> az.plot_ecdf(sample, cdf = distribution.cdf, eval_points = eval_points,
         >>>              confidence_bands = True, difference = True)
-        
+
     Plot an ECDF plot with confidence bands for the probability integral transform (PIT) of a continuous
     sample. If drawn from the reference distribution, the PIT values should be uniformly distributed.
 
@@ -185,7 +185,10 @@ def plot_ecdf(
     """
     if confidence_bands is True:
         if pointwise:
-            warnings.warn("pointwise keyword will be deprecated in a future release. Use `confidence_bands='pointwise'`", FutureWarning)
+            warnings.warn(
+                "pointwise keyword will be deprecated in a future release. Use `confidence_bands='pointwise'`",
+                FutureWarning,
+            )
             confidence_bands = "pointwise"
         else:
             confidence_bands = "simulated"

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -205,7 +205,7 @@ def plot_ecdf(
         if pointwise:
             warnings.warn(
                 "`pointwise` has been deprecated. Use `confidence_bands='pointwise'` instead.",
-                DeprecationWarning,
+                FutureWarning,
             )
             confidence_bands = "pointwise"
         else:
@@ -217,7 +217,7 @@ def plot_ecdf(
         warnings.warn(
             "`fpr` has been deprecated. Use `ci_prob=1-fpr` or set `rcParam['stats.ci_prob']` to"
             "`1-fpr`.",
-            DeprecationWarning,
+            FutureWarning,
         )
         if ci_prob is not None:
             raise ValueError("Cannot specify both `fpr` and `ci_prob`")
@@ -237,7 +237,7 @@ def plot_ecdf(
         warnings.warn(
             "`values2` has been deprecated. Use `cdf=scipy.stats.ecdf(values2).cdf.evaluate` "
             "instead.",
-            DeprecationWarning,
+            FutureWarning,
         )
         cdf = scipy_ecdf(np.ravel(values2)).cdf.evaluate
 
@@ -255,7 +255,7 @@ def plot_ecdf(
     if pit:
         warnings.warn(
             "`pit` has been deprecated. Specify `values=cdf(values)` instead.",
-            DeprecationWarning,
+            FutureWarning,
         )
         values = cdf(values)
         cdf = uniform(0, 1).cdf

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -66,7 +66,7 @@ def plot_ecdf(
           band.
         For simultaneous confidence bands to be correctly calibrated, provide `eval_points` that
         are not dependent on the `values`.
-    band_prob : float, default 0.94
+    band_prob : float, default 0.95
         The probability that the true ECDF lies within the confidence band. If `confidence_bands`
         is "pointwise", this is the marginal probability instead of the joint probability.
     eval_points : array-like, optional

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -57,8 +57,10 @@ def plot_ecdf(
     values : array-like
         Values to plot from an unknown continuous or discrete distribution.
     values2 : array-like, optional
-        deprecated: values to compare to the original sample. Instead use
-        `cdf=scipy.stats.ecdf(values2).cdf.evaluate`.
+        values to compare to the original sample.
+
+        .. deprecated:: 0.18.0
+           Instead use ``cdf=scipy.stats.ecdf(values2).cdf.evaluate``.
     cdf : callable, optional
         Cumulative distribution function of the distribution to compare the original sample.
         The function must take as input a numpy array of draws from the distribution.

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -85,6 +85,8 @@ def plot_ecdf(
         between the data bounds will be used.
     rvs: callable, optional
         A function that takes an integer `ndraws` and optionally the object passed to
+        `random_state` and returns an array of `ndraws` samples from the same distribution
+        as the original dataset. Required if `method` is "simulated" and variable is discrete.
     random_state : int, numpy.random.Generator or numpy.random.RandomState, optional
     num_trials : int, default 500
         The number of random ECDFs to generate for constructing simultaneous confidence bands

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -3,6 +3,7 @@ import warnings
 
 import numpy as np
 from scipy.stats import uniform
+
 try:
     from scipy.stats import ecdf as scipy_ecdf
 except ImportError:

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -118,11 +118,11 @@ def plot_ecdf(
     pointwise : bool, default False
 
         .. deprecated:: 0.18.0
-           Instead use `confidence_bands`.
+           Instead use `confidence_bands="pointwise"`.
     fpr : float, optional
 
         .. deprecated:: 0.18.0
-           Instead use `band_prob`.
+           Instead use `band_prob=1-fpr`.
     pit : bool, default False
         If True plots the ECDF or ECDF-diff of PIT of sample.
 

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -130,18 +130,18 @@ def plot_ecdf(
 
     Examples
     --------
-    Plot ecdf plot for a given sample
+    Plot an ECDF plot for a given sample evaluated at the sample points.
 
     .. plot::
         :context: close-figs
 
         >>> import arviz as az
-        >>> from scipy.stats import uniform, binom, norm
+        >>> from scipy.stats import uniform, norm
 
         >>> sample = norm(0,1).rvs(1000)
-        >>> az.plot_ecdf(sample)
+        >>> az.plot_ecdf(sample, eval_points = np.unique(sample))
 
-    Plot ecdf plot with confidence bands for comparing a given sample w.r.t a given distribution.
+    Plot an ECDF plot with confidence bands for comparing a given sample to a given distribution.
     We manually specify evaluation points independent of the values so that the confidence bands
     are correctly calibrated.
 
@@ -149,46 +149,38 @@ def plot_ecdf(
         :context: close-figs
 
         >>> distribution = norm(0,1)
-        >>> eval_points = distribution.ppf([0.001, 0.999])
-        >>> az.plot_ecdf(sample, eval_points=eval_points, cdf = distribution.cdf, confidence_bands = True)
+        >>> eval_points = np.linspace(*distribution.ppf([0.001, 0.999]), 500)
+        >>> az.plot_ecdf(sample, eval_points = eval_points, cdf = distribution.cdf,
+        >>>              confidence_bands = True)
 
-    Plot ecdf-difference plot with confidence bands for comparing a given sample
-    w.r.t a given distribution
+    Plot an ECDF-difference plot with confidence bands for comparing a given sample
+    to a given distribution.
 
     .. plot::
         :context: close-figs
 
-        >>> az.plot_ecdf(sample, cdf = distribution.cdf, eval_points=eval_points,
+        >>> az.plot_ecdf(sample, cdf = distribution.cdf, eval_points = eval_points,
         >>>              confidence_bands = True, difference = True)
-
-    Plot ecdf plot with confidence bands for PIT of sample for comparing a given sample
-    w.r.t a given distribution
-
-    .. plot::
-        :context: close-figs
-
-        >>> az.plot_ecdf(sample, cdf = distribution.cdf,
-        >>>              confidence_bands = True, pit = True)
-
-    Plot ecdf-difference plot with confidence bands for PIT of sample for comparing a given
-    sample w.r.t a given distribution
+        
+    Plot an ECDF plot with confidence bands for the probability integral transform (PIT) of a continuous
+    sample. If drawn from the reference distribution, the PIT values should be uniformly distributed.
 
     .. plot::
         :context: close-figs
 
-        >>> az.plot_ecdf(sample, cdf = distribution.cdf,
-        >>>              confidence_bands = True, difference = True, pit = True)
+        >>> pit_vals = distribution.cdf(sample)
+        >>> eval_points = np.linspace(0, 1, 501)
+        >>> uniform_dist = uniform(0, 1)
+        >>> az.plot_ecdf(pit_vals, eval_points = eval_points, cdf = uniform_dist.cdf,
+        >>>              rvs = uniform_dist.rvs, confidence_bands = True)
 
-    You could also plot the above w.r.t another sample rather than a given distribution.
-    For eg: Plot ecdf-difference plot with confidence bands for PIT of sample for
-    comparing a given sample w.r.t a given sample
+    Plot an ECDF-difference plot of PIT values.
 
     .. plot::
         :context: close-figs
 
-        >>> sample2 = norm(0,1).rvs(5000)
-        >>> az.plot_ecdf(sample, sample2, confidence_bands = True, difference = True, pit = True)
-
+        >>> az.plot_ecdf(pit_vals, eval_points = eval_points, cdf = uniform_dist.cdf,
+        >>>              rvs = uniform_dist.rvs, confidence_bands = True, difference = True)
     """
     if confidence_bands is True:
         if pointwise:

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -229,6 +229,8 @@ def plot_ecdf(
             raise ValueError("For confidence bands you must specify cdf")
         if difference is True:
             raise ValueError("For ECDF difference plot you must specify cdf")
+        if pit:
+            raise ValueError("For PIT plot you must specify cdf")
 
     values = np.ravel(values)
     values.sort()

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -116,12 +116,18 @@ def plot_ecdf(
         :func:`matplotlib.pyplot.subplots` or :class:`bokeh.plotting.figure`.
         For additional documentation check the plotting method of the backend.
     pointwise : bool, default False
-        deprecated: please see `confidence_bands`.
+
+        .. deprecated:: 0.18.0
+           Instead use `confidence_bands`.
     fpr : float, optional
-        deprecated: please see `band_prob`.
+
+        .. deprecated:: 0.18.0
+           Instead use `band_prob`.
     pit : bool, default False
-        deprecated: If True plots the ECDF or ECDF-diff of PIT of sample.
-        See below example instead.
+        If True plots the ECDF or ECDF-diff of PIT of sample.
+
+        .. deprecated:: 0.18.0
+           See below example instead.
 
     Returns
     -------

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -66,11 +66,14 @@ def plot_ecdf(
         The function must take as input a numpy array of draws from the distribution.
     difference : bool, default False
         If True then plot ECDF-difference plot otherwise ECDF plot.
-    confidence_bands : str or bool, optional
-        - False: No confidence bands are plotted.
+    confidence_bands : str or bool
+
+        - False: No confidence bands are plotted (default).
+        - True: Plot bands computed with the default algorithm (subject to change)
         - "pointwise": Compute the pointwise (i.e. marginal) confidence band.
-        - True or "simulated": Use Monte Carlo simulation to estimate a simultaneous confidence
+        - "simulated": Use Monte Carlo simulation to estimate a simultaneous confidence
           band.
+
         For simultaneous confidence bands to be correctly calibrated, provide `eval_points` that
         are not dependent on the `values`.
     band_prob : float, default 0.95

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -53,7 +53,7 @@ def plot_ecdf(
         Values to plot from an unknown continuous or discrete distribution.
     values2 : array-like, optional
         deprecated: values to compare to the original sample. Instead use
-        `cdf=scipy.stats.ecdf(values2).cdf`.
+        `cdf=scipy.stats.ecdf(values2).cdf.evaluate`.
     cdf : callable, optional
         Cumulative distribution function of the distribution to compare the original sample.
         The function must take as input a numpy array of draws from the distribution.
@@ -212,7 +212,7 @@ def plot_ecdf(
     if values2 is not None:
         warnings.warn(
             "The `values2` argument will be deprecated in a future release. "
-            "Use `cdf=scipy.stats.ecdf(values2).cdf` instead.",
+            "Use `cdf=scipy.stats.ecdf(values2).cdf.evaluate` instead.",
             FutureWarning,
         )
         if cdf is not None:
@@ -221,7 +221,7 @@ def plot_ecdf(
         try:
             from scipy.stats import ecdf as scipy_ecdf
 
-            cdf = scipy_ecdf(values2).cdf
+            cdf = scipy_ecdf(values2).cdf.evaluate
         except ImportError:
             raise ValueError(
                 "The `values2` argument is deprecated and `scipy.stats.ecdf` is not available. "

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -20,8 +20,6 @@ def plot_ecdf(
     eval_points=None,
     cdf=None,
     difference=False,
-    pit=False,
-    npoints=100,
     confidence_bands=False,
     band_prob=None,
     num_trials=500,
@@ -36,8 +34,10 @@ def plot_ecdf(
     show=None,
     backend=None,
     backend_kwargs=None,
+    npoints=100,
     pointwise=False,
     fpr=None,
+    pit=False,
     **kwargs,
 ):
     r"""Plot ECDF or ECDF-Difference Plot with Confidence bands.

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -1,4 +1,5 @@
 """Plot ecdf or ecdf-difference plot with confidence bands."""
+
 import warnings
 
 import numpy as np

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -77,7 +77,7 @@ def plot_ecdf(
 
         For simultaneous confidence bands to be correctly calibrated, provide `eval_points` that
         are not dependent on the `values`.
-    ci_prob : float, default 0.95
+    ci_prob : float, default 0.94
         The probability that the true ECDF lies within the confidence band. If `confidence_bands`
         is "pointwise", this is the marginal probability instead of the joint probability.
     eval_points : array-like, optional

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -216,7 +216,7 @@ def plot_ecdf(
         try:
             from scipy.stats import ecdf as scipy_ecdf
 
-            cdf = scipy_ecdf(values2).cdf.evaluate
+            cdf = scipy_ecdf(np.ravel(values2)).cdf.evaluate
         except ImportError:
             raise ValueError(
                 "The `values2` argument is deprecated and `scipy.stats.ecdf` is not available. "

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -87,16 +87,10 @@ def plot_ecdf(
         for the ecdf or ecdf-difference plots.
     rvs: callable, optional
         A function that takes an integer `ndraws` and optionally the object passed to
-        `random_state` and returns an array of `ndraws` samples from the same distribution
-        as the original dataset. Required if `method` is "simulated" and variable is discrete.
+    random_state : int, numpy.random.Generator or numpy.random.RandomState, optional
     num_trials : int, default 500
         The number of random ECDFs to generate for constructing simultaneous confidence bands
         (if `confidence_bands` is "simulated").
-    random_state : {None, int, `numpy.random.Generator`,
-                    `numpy.random.RandomState`}, optional
-        If `None`, the `numpy.random.RandomState` singleton is used. If an `int`, a new
-        ``numpy.random.RandomState`` instance is used, seeded with seed. If a `RandomState` or
-        `Generator` instance, the instance is used.
     figsize : (float,float), optional
         Figure size. If `None` it will be defined automatically.
     fill_band : bool, default True

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -9,7 +9,7 @@ except ImportError:
     scipy_ecdf = None
 
 from ..rcparams import rcParams
-from ..stats.ecdf_utils import compute_ecdf, ecdf_confidence_band, _get_ecdf_points
+from ..stats.ecdf_utils import ecdf_confidence_band, _get_ecdf_points
 from .plot_utils import get_plotting_function
 
 
@@ -42,8 +42,8 @@ def plot_ecdf(
     r"""Plot ECDF or ECDF-Difference Plot with Confidence bands.
 
     Plots of the empirical cumulative distribution function (ECDF) of an array. Optionally, A `cdf`
-    argument representing a reference CDF may be provided for comparison using a difference ECDF plot
-    and/or confidence bands.
+    argument representing a reference CDF may be provided for comparison using a difference ECDF
+    plot and/or confidence bands.
 
     Alternatively, the PIT for a single dataset may be visualized.
 
@@ -167,8 +167,9 @@ def plot_ecdf(
         >>> az.plot_ecdf(sample, cdf = distribution.cdf, eval_points = eval_points,
         >>>              confidence_bands = True, difference = True)
 
-    Plot an ECDF plot with confidence bands for the probability integral transform (PIT) of a continuous
-    sample. If drawn from the reference distribution, the PIT values should be uniformly distributed.
+    Plot an ECDF plot with confidence bands for the probability integral transform (PIT) of a
+    continuous sample. If drawn from the reference distribution, the PIT values should be uniformly
+    distributed.
 
     .. plot::
         :context: close-figs
@@ -201,7 +202,8 @@ def plot_ecdf(
 
     if fpr is not None:
         warnings.warn(
-            "`fpr` has been deprecated. Use `band_prob=1-fpr` or set `rcParam['plot.band_prob']` to `1-fpr`.",
+            "`fpr` has been deprecated. Use `band_prob=1-fpr` or set `rcParam['plot.band_prob']` to"
+            "`1-fpr`.",
             DeprecationWarning,
         )
         if band_prob is not None:
@@ -214,13 +216,14 @@ def plot_ecdf(
     if values2 is not None:
         if cdf is not None:
             raise ValueError("You cannot specify both `values2` and `cdf`")
-        elif scipy_ecdf is None:
+        if scipy_ecdf is None:
             raise ValueError(
                 "The `values2` argument is deprecated and `scipy.stats.ecdf` is not available. "
                 "Please use `cdf` instead."
             )
         warnings.warn(
-            "`values2` has been deprecated. Use `cdf=scipy.stats.ecdf(values2).cdf.evaluate` instead.",
+            "`values2` has been deprecated. Use `cdf=scipy.stats.ecdf(values2).cdf.evaluate` "
+            "instead.",
             DeprecationWarning,
         )
         cdf = scipy_ecdf(np.ravel(values2)).cdf.evaluate
@@ -248,14 +251,15 @@ def plot_ecdf(
 
     if eval_points is None:
         warnings.warn(
-            "In future versions, if `eval_points` is not provided, then the ECDF will be evaluated at the"
-            " unique values of the sample. To keep the current behavior, provide `eval_points` explicitly.",
+            "In future versions, if `eval_points` is not provided, then the ECDF will be evaluated"
+            " at the unique values of the sample. To keep the current behavior, provide "
+            "`eval_points` explicitly.",
             FutureWarning,
         )
         if confidence_bands == "simulated":
             warnings.warn(
-                "For simultaneous bands to be correctly calibrated, specify `eval_points` independent of"
-                " the `values`"
+                "For simultaneous bands to be correctly calibrated, specify `eval_points` "
+                "independent of the `values`"
             )
         eval_points = np.linspace(values[0], values[-1], npoints)
     else:

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -186,8 +186,8 @@ def plot_ecdf(
     if confidence_bands is True:
         if pointwise:
             warnings.warn(
-                "pointwise keyword will be deprecated in a future release. Use `confidence_bands='pointwise'`",
-                FutureWarning,
+                "`pointwise` has been deprecated. Use `confidence_bands='pointwise'` instead.",
+                DeprecationWarning,
             )
             confidence_bands = "pointwise"
         else:
@@ -197,9 +197,8 @@ def plot_ecdf(
 
     if fpr is not None:
         warnings.warn(
-            "fpr keyword will be deprecated in a future release. Use `band_prob=1-fpr` "
-            "or set rcParam `plot.band_prob` to `1-fpr`",
-            FutureWarning,
+            "`fpr` has been deprecated. Use `band_prob=1-fpr` or set `rcParam['plot.band_prob']` to `1-fpr`.",
+            DeprecationWarning,
         )
         if band_prob is not None:
             raise ValueError("Cannot specify both `fpr` and `band_prob`")
@@ -210,9 +209,8 @@ def plot_ecdf(
 
     if values2 is not None:
         warnings.warn(
-            "The `values2` argument will be deprecated in a future release. "
-            "Use `cdf=scipy.stats.ecdf(values2).cdf.evaluate` instead.",
-            FutureWarning,
+            "`values2` has been deprecated. Use `cdf=scipy.stats.ecdf(values2).cdf.evaluate` instead.",
+            DeprecationWarning,
         )
         if cdf is not None:
             raise ValueError("You cannot specify both `values2` and `cdf`")
@@ -237,8 +235,8 @@ def plot_ecdf(
 
     if pit:
         warnings.warn(
-            "The `pit` argument will be deprecated in a future release. Provide `values=cdf(values)` instead.",
-            FutureWarning,
+            "`pit` has been deprecated. Specify `values=cdf(values)` instead.",
+            DeprecationWarning,
         )
         values = cdf(values)
         cdf = uniform(0, 1).cdf
@@ -248,7 +246,8 @@ def plot_ecdf(
     if eval_points is None:
         warnings.warn(
             "In future versions, if `eval_points` is not provided, then the ECDF will be evaluated at the"
-            " unique values of the sample. To keep the current behavior, provide `eval_points` explicitly."
+            " unique values of the sample. To keep the current behavior, provide `eval_points` explicitly.",
+            FutureWarning,
         )
         if confidence_bands == "simulated":
             warnings.warn(

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -16,9 +16,11 @@ def plot_ecdf(
     difference=False,
     pit=False,
     npoints=100,
-    num_trials=500,
     band_kind=None,
     band_prob=None,
+    num_trials=500,
+    rvs=None,
+    random_state=None,
     figsize=None,
     fill_band=True,
     plot_kwargs=None,
@@ -68,8 +70,18 @@ def plot_ecdf(
     npoints : int, default 100
         This denotes the granularity size of our plot i.e the number of evaluation points
         for the ecdf or ecdf-difference plots.
+    rvs: callable, optional
+        A function that takes an integer `ndraws` and optionally the object passed to
+        `random_state` and returns an array of `ndraws` samples from the same distribution
+        as the original dataset. Required if `method` is "simulated" and variable is discrete.
     num_trials : int, default 500
-        The number of random ECDFs to generate for constructing simultaneous confidence bands.
+        The number of random ECDFs to generate for constructing simultaneous confidence bands
+        (if `band_kind` is "simulated").
+    random_state : {None, int, `numpy.random.Generator`,
+                    `numpy.random.RandomState`}, optional
+        If `None`, the `numpy.random.RandomState` singleton is used. If an `int`, a new
+        ``numpy.random.RandomState`` instance is used, seeded with seed. If a `RandomState` or
+        `Generator` instance, the instance is used.
     figsize : (float,float), optional
         Figure size. If `None` it will be defined automatically.
     fill_band : bool, default True
@@ -238,7 +250,6 @@ def plot_ecdf(
                 cdf_at_eval_points = compute_ecdf(values2, eval_points)
         else:
             cdf_at_eval_points = np.zeros_like(eval_points)
-        rvs = None
 
     x_coord, y_coord = _get_ecdf_points(sample, eval_points, difference)
 
@@ -256,7 +267,7 @@ def plot_ecdf(
             prob=band_prob,
             num_trials=num_trials,
             rvs=rvs,
-            random_state=None,
+            random_state=random_state,
         )
 
         if difference:

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -141,13 +141,16 @@ def plot_ecdf(
         >>> sample = norm(0,1).rvs(1000)
         >>> az.plot_ecdf(sample)
 
-    Plot ecdf plot with confidence bands for comparing a given sample w.r.t a given distribution
+    Plot ecdf plot with confidence bands for comparing a given sample w.r.t a given distribution.
+    We manually specify evaluation points independent of the values so that the confidence bands
+    are correctly calibrated.
 
     .. plot::
         :context: close-figs
 
         >>> distribution = norm(0,1)
-        >>> az.plot_ecdf(sample, cdf = distribution.cdf, confidence_bands = True)
+        >>> eval_points = distribution.ppf([0.001, 0.999])
+        >>> az.plot_ecdf(sample, eval_points=eval_points, cdf = distribution.cdf, confidence_bands = True)
 
     Plot ecdf-difference plot with confidence bands for comparing a given sample
     w.r.t a given distribution
@@ -155,7 +158,7 @@ def plot_ecdf(
     .. plot::
         :context: close-figs
 
-        >>> az.plot_ecdf(sample, cdf = distribution.cdf,
+        >>> az.plot_ecdf(sample, cdf = distribution.cdf, eval_points=eval_points,
         >>>              confidence_bands = True, difference = True)
 
     Plot ecdf plot with confidence bands for PIT of sample for comparing a given sample

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -82,9 +82,6 @@ def plot_ecdf(
     eval_points : array-like, optional
         The points at which to evaluate the ECDF. If None, `npoints` uniformly spaced points
         between the data bounds will be used.
-    npoints : int, default 100
-        This denotes the granularity size of our plot i.e the number of evaluation points
-        for the ecdf or ecdf-difference plots.
     rvs: callable, optional
         A function that takes an integer `ndraws` and optionally the object passed to
     random_state : int, numpy.random.Generator or numpy.random.RandomState, optional
@@ -115,6 +112,13 @@ def plot_ecdf(
         These are kwargs specific to the backend being used, passed to
         :func:`matplotlib.pyplot.subplots` or :class:`bokeh.plotting.figure`.
         For additional documentation check the plotting method of the backend.
+    npoints : int, default 100
+        The number of evaluation points for the ecdf or ecdf-difference plots, if `eval_points` is
+        not provided or `pit` is `True`.
+
+        .. deprecated:: 0.18.0
+           Instead specify ``eval_points=np.linspace(np.min(values), np.max(values), npoints)``
+           unless `pit` is `True`.
     pointwise : bool, default False
 
         .. deprecated:: 0.18.0

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -3,6 +3,10 @@ import warnings
 
 import numpy as np
 from scipy.stats import uniform
+try:
+    from scipy.stats import ecdf as scipy_ecdf
+except ImportError:
+    scipy_ecdf = None
 
 from ..rcparams import rcParams
 from ..stats.ecdf_utils import compute_ecdf, ecdf_confidence_band, _get_ecdf_points
@@ -208,21 +212,18 @@ def plot_ecdf(
         band_prob = rcParams["plot.band_prob"]
 
     if values2 is not None:
-        warnings.warn(
-            "`values2` has been deprecated. Use `cdf=scipy.stats.ecdf(values2).cdf.evaluate` instead.",
-            DeprecationWarning,
-        )
         if cdf is not None:
             raise ValueError("You cannot specify both `values2` and `cdf`")
-        try:
-            from scipy.stats import ecdf as scipy_ecdf
-
-            cdf = scipy_ecdf(np.ravel(values2)).cdf.evaluate
-        except ImportError:
+        elif scipy_ecdf is None:
             raise ValueError(
                 "The `values2` argument is deprecated and `scipy.stats.ecdf` is not available. "
                 "Please use `cdf` instead."
             )
+        warnings.warn(
+            "`values2` has been deprecated. Use `cdf=scipy.stats.ecdf(values2).cdf.evaluate` instead.",
+            DeprecationWarning,
+        )
+        cdf = scipy_ecdf(np.ravel(values2)).cdf.evaluate
 
     if cdf is None:
         if confidence_bands:

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -16,7 +16,6 @@ from ..utils import BehaviourChangeWarning
 from .plot_utils import get_plotting_function
 
 
-
 def plot_ecdf(
     values,
     values2=None,
@@ -153,13 +152,16 @@ def plot_ecdf(
     In a future release, the default behaviour of ``plot_ecdf`` will change.
     To maintain the original behaviour you should do:
 
-    .. plot:: close-figs
+    .. plot::
+        :context: close-figs
 
         >>> import arviz as az
+        >>> import numpy as np
         >>> from scipy.stats import uniform, norm
-
+        >>>
         >>> sample = norm(0,1).rvs(1000)
-        >>> az.plot_ecdf(sample, eval_points = np.linspace(sample.min(), sample.max(), npoints))
+        >>> npoints = 100
+        >>> az.plot_ecdf(sample, eval_points=np.linspace(sample.min(), sample.max(), npoints))
 
     However, seeing this warning isn't an indicator of anything being wrong,
     if you are happy to get different behaviour as ArviZ improves and adds
@@ -177,7 +179,7 @@ def plot_ecdf(
     .. plot::
         :context: close-figs
 
-        >>> az.plot_ecdf(sample, eval_points = np.unique(sample))
+        >>> az.plot_ecdf(sample, eval_points=np.unique(sample))
 
     Plot an ECDF plot with confidence bands for comparing a given sample to a given distribution.
     We manually specify evaluation points independent of the values so that the confidence bands
@@ -187,7 +189,11 @@ def plot_ecdf(
         :context: close-figs
 
         >>> distribution = norm(0,1)
-        >>> az.plot_ecdf(sample, cdf = distribution.cdf, confidence_bands = True)
+        >>> eval_points = np.linspace(*distribution.ppf([0.001, 0.999]), 100)
+        >>> az.plot_ecdf(
+        >>>     sample, eval_points=eval_points,
+        >>>     cdf=distribution.cdf, confidence_bands=True
+        >>> )
 
     Plot an ECDF-difference plot with confidence bands for comparing a given sample
     to a given distribution.
@@ -196,8 +202,8 @@ def plot_ecdf(
         :context: close-figs
 
         >>> az.plot_ecdf(
-        >>>     sample, cdf = distribution.cdf,
-        >>>     confidence_bands = True, difference = True
+        >>>     sample, cdf=distribution.cdf,
+        >>>     confidence_bands=True, difference=True
         >>> )
 
     Plot an ECDF plot with confidence bands for the probability integral transform (PIT) of a
@@ -208,11 +214,10 @@ def plot_ecdf(
         :context: close-figs
 
         >>> pit_vals = distribution.cdf(sample)
-        >>> eval_points = np.linspace(0, 1, 101)
         >>> uniform_dist = uniform(0, 1)
         >>> az.plot_ecdf(
-        >>>     pit_vals, cdf = uniform_dist.cdf,
-        >>>     rvs = uniform_dist.rvs, confidence_bands = True
+        >>>     pit_vals, cdf=uniform_dist.cdf,
+        >>>     rvs=uniform_dist.rvs, confidence_bands=True
         >>> )
 
     Plot an ECDF-difference plot of PIT values.

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -12,7 +12,9 @@ except ImportError:
 
 from ..rcparams import rcParams
 from ..stats.ecdf_utils import ecdf_confidence_band, _get_ecdf_points
+from ..utils import BehaviourChangeWarning
 from .plot_utils import get_plotting_function
+
 
 
 def plot_ecdf(
@@ -148,15 +150,33 @@ def plot_ecdf(
 
     Examples
     --------
-    Plot an ECDF plot for a given sample evaluated at the sample points.
+    In a future release, the default behaviour of ``plot_ecdf`` will change.
+    To maintain the original behaviour you should do:
 
-    .. plot::
-        :context: close-figs
+    .. plot:: close-figs
 
         >>> import arviz as az
         >>> from scipy.stats import uniform, norm
 
         >>> sample = norm(0,1).rvs(1000)
+        >>> az.plot_ecdf(sample, eval_points = np.linspace(sample.min(), sample.max(), npoints))
+
+    However, seeing this warning isn't an indicator of anything being wrong,
+    if you are happy to get different behaviour as ArviZ improves and adds
+    new algorithms you can ignore it like so:
+
+    .. plot::
+        :context: close-figs
+
+        >>> import warnings
+        >>> warnings.filterwarnings("ignore", category=az.utils.BehaviourChangeWarning)
+
+    Plot an ECDF plot for a given sample evaluated at the sample points. This will become
+    the new behaviour when `eval_points` is not provided:
+
+    .. plot::
+        :context: close-figs
+
         >>> az.plot_ecdf(sample, eval_points = np.unique(sample))
 
     Plot an ECDF plot with confidence bands for comparing a given sample to a given distribution.
@@ -167,9 +187,7 @@ def plot_ecdf(
         :context: close-figs
 
         >>> distribution = norm(0,1)
-        >>> eval_points = np.linspace(*distribution.ppf([0.001, 0.999]), 100)
-        >>> az.plot_ecdf(sample, eval_points = eval_points, cdf = distribution.cdf,
-        >>>              confidence_bands = True)
+        >>> az.plot_ecdf(sample, cdf = distribution.cdf, confidence_bands = True)
 
     Plot an ECDF-difference plot with confidence bands for comparing a given sample
     to a given distribution.
@@ -177,8 +195,10 @@ def plot_ecdf(
     .. plot::
         :context: close-figs
 
-        >>> az.plot_ecdf(sample, cdf = distribution.cdf, eval_points = eval_points,
-        >>>              confidence_bands = True, difference = True)
+        >>> az.plot_ecdf(
+        >>>     sample, cdf = distribution.cdf,
+        >>>     confidence_bands = True, difference = True
+        >>> )
 
     Plot an ECDF plot with confidence bands for the probability integral transform (PIT) of a
     continuous sample. If drawn from the reference distribution, the PIT values should be uniformly
@@ -190,16 +210,20 @@ def plot_ecdf(
         >>> pit_vals = distribution.cdf(sample)
         >>> eval_points = np.linspace(0, 1, 101)
         >>> uniform_dist = uniform(0, 1)
-        >>> az.plot_ecdf(pit_vals, eval_points = eval_points, cdf = uniform_dist.cdf,
-        >>>              rvs = uniform_dist.rvs, confidence_bands = True)
+        >>> az.plot_ecdf(
+        >>>     pit_vals, cdf = uniform_dist.cdf,
+        >>>     rvs = uniform_dist.rvs, confidence_bands = True
+        >>> )
 
     Plot an ECDF-difference plot of PIT values.
 
     .. plot::
         :context: close-figs
 
-        >>> az.plot_ecdf(pit_vals, eval_points = eval_points, cdf = uniform_dist.cdf,
-        >>>              rvs = uniform_dist.rvs, confidence_bands = True, difference = True)
+        >>> az.plot_ecdf(
+        >>>     pit_vals, cdf = uniform_dist.cdf, rvs = uniform_dist.rvs,
+        >>>     confidence_bands = True, difference = True
+        >>> )
     """
     if confidence_bands is True:
         if pointwise:
@@ -267,7 +291,7 @@ def plot_ecdf(
             "In future versions, if `eval_points` is not provided, then the ECDF will be evaluated"
             " at the unique values of the sample. To keep the current behavior, provide "
             "`eval_points` explicitly.",
-            FutureWarning,
+            BehaviourChangeWarning,
         )
         if confidence_bands == "simulated":
             warnings.warn(

--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -246,7 +246,7 @@ def plot_forest(
         width_ratios.append(1)
 
     if hdi_prob is None:
-        hdi_prob = rcParams["stats.hdi_prob"]
+        hdi_prob = rcParams["stats.ci_prob"]
     elif not 1 >= hdi_prob > 0:
         raise ValueError("The value of hdi_prob should be in the interval (0, 1]")
 

--- a/arviz/plots/hdiplot.py
+++ b/arviz/plots/hdiplot.py
@@ -42,7 +42,7 @@ def plot_hdi(
     hdi_data : array_like, optional
         Precomputed HDI values to use. Assumed shape is ``(*x.shape, 2)``.
     hdi_prob : float, optional
-        Probability for the highest density interval. Defaults to ``stats.hdi_prob`` rcParam.
+        Probability for the highest density interval. Defaults to ``stats.ci_prob`` rcParam.
         See :ref:`this section <common_ hdi_prob>` for usage examples.
     color : str, default "C1"
         Color used for the limits of the HDI and fill. Should be a valid matplotlib color.
@@ -155,7 +155,7 @@ def plot_hdi(
     else:
         y = np.asarray(y)
         if hdi_prob is None:
-            hdi_prob = rcParams["stats.hdi_prob"]
+            hdi_prob = rcParams["stats.ci_prob"]
         elif not 1 >= hdi_prob > 0:
             raise ValueError("The value of hdi_prob should be in the interval (0, 1]")
         hdi_data = hdi(y, hdi_prob=hdi_prob, circular=circular, multimodal=False, **hdi_kwargs)

--- a/arviz/plots/loopitplot.py
+++ b/arviz/plots/loopitplot.py
@@ -159,7 +159,7 @@ def plot_loo_pit(
     x_vals = None
 
     if hdi_prob is None:
-        hdi_prob = rcParams["stats.hdi_prob"]
+        hdi_prob = rcParams["stats.ci_prob"]
     elif not 1 >= hdi_prob > 0:
         raise ValueError("The value of hdi_prob should be in the interval (0, 1]")
 

--- a/arviz/plots/posteriorplot.py
+++ b/arviz/plots/posteriorplot.py
@@ -237,7 +237,7 @@ def plot_posterior(
         labeller = BaseLabeller()
 
     if hdi_prob is None:
-        hdi_prob = rcParams["stats.hdi_prob"]
+        hdi_prob = rcParams["stats.ci_prob"]
     elif hdi_prob not in (None, "hide"):
         if not 1 >= hdi_prob > 0:
             raise ValueError("The value of hdi_prob should be in the interval (0, 1]")

--- a/arviz/plots/violinplot.py
+++ b/arviz/plots/violinplot.py
@@ -152,7 +152,7 @@ def plot_violin(
     rows, cols = default_grid(len(plotters), grid=grid)
 
     if hdi_prob is None:
-        hdi_prob = rcParams["stats.hdi_prob"]
+        hdi_prob = rcParams["stats.ci_prob"]
     elif not 1 >= hdi_prob > 0:
         raise ValueError("The value of hdi_prob should be in the interval (0, 1]")
 

--- a/arviz/rcparams.py
+++ b/arviz/rcparams.py
@@ -263,7 +263,6 @@ defaultParams = {  # pylint: disable=invalid-name
         "mean",
         _make_validate_choice({"mean", "median", "mode"}, allow_none=True),
     ),
-    "plot.band_prob": (0.95, _validate_probability),
     "plot.bokeh.bounds_x_range": ("auto", _validate_bokeh_bounds),
     "plot.bokeh.bounds_y_range": ("auto", _validate_bokeh_bounds),
     "plot.bokeh.figure.dpi": (60, _validate_positive_int),
@@ -301,6 +300,7 @@ defaultParams = {  # pylint: disable=invalid-name
         lambda x: x,
     ),
     "plot.matplotlib.show": (False, _validate_boolean),
+    "stats.ci_prob": (0.95, _validate_probability),
     "stats.hdi_prob": (0.94, _validate_probability),
     "stats.information_criterion": (
         "loo",

--- a/arviz/rcparams.py
+++ b/arviz/rcparams.py
@@ -344,7 +344,7 @@ class RcParams(MutableMapping):
             version, key_new, fold2new, _ = deprecated_map[key]
             warnings.warn(
                 f"{key} is deprecated since {version}, use {key_new} instead",
-                DeprecationWarning,
+                FutureWarning,
             )
             key = key_new
             val = fold2new(val)
@@ -367,7 +367,7 @@ class RcParams(MutableMapping):
             version, key_new, _, fnew2old = deprecated_map[key]
             warnings.warn(
                 f"{key} is deprecated since {version}, use {key_new} instead",
-                DeprecationWarning,
+                FutureWarning,
             )
             if key not in self._underlying_storage:
                 key = key_new

--- a/arviz/rcparams.py
+++ b/arviz/rcparams.py
@@ -300,7 +300,7 @@ defaultParams = {  # pylint: disable=invalid-name
         lambda x: x,
     ),
     "plot.matplotlib.show": (False, _validate_boolean),
-    "stats.ci_prob": (0.95, _validate_probability),
+    "stats.ci_prob": (0.94, _validate_probability),
     "stats.hdi_prob": (0.94, _validate_probability),
     "stats.information_criterion": (
         "loo",

--- a/arviz/rcparams.py
+++ b/arviz/rcparams.py
@@ -263,7 +263,7 @@ defaultParams = {  # pylint: disable=invalid-name
         "mean",
         _make_validate_choice({"mean", "median", "mode"}, allow_none=True),
     ),
-    "plot.band_prob": (0.94, _validate_probability),
+    "plot.band_prob": (0.95, _validate_probability),
     "plot.bokeh.bounds_x_range": ("auto", _validate_bokeh_bounds),
     "plot.bokeh.bounds_y_range": ("auto", _validate_bokeh_bounds),
     "plot.bokeh.figure.dpi": (60, _validate_positive_int),

--- a/arviz/rcparams.py
+++ b/arviz/rcparams.py
@@ -263,6 +263,7 @@ defaultParams = {  # pylint: disable=invalid-name
         "mean",
         _make_validate_choice({"mean", "median", "mode"}, allow_none=True),
     ),
+    "plot.band_prob": (0.94, _validate_probability),
     "plot.bokeh.bounds_x_range": ("auto", _validate_bokeh_bounds),
     "plot.bokeh.bounds_y_range": ("auto", _validate_bokeh_bounds),
     "plot.bokeh.figure.dpi": (60, _validate_positive_int),

--- a/arviz/stats/ecdf_utils.py
+++ b/arviz/stats/ecdf_utils.py
@@ -25,6 +25,13 @@ def _get_ecdf_points(
     return x, y
 
 
+def _call_rvs(rvs, ndraws, random_state):
+    if random_state is None:
+        return rvs(ndraws)
+    else:
+        return rvs(ndraws, random_state=random_state)
+
+
 def _simulate_ecdf(
     ndraws: int,
     eval_points: np.ndarray,
@@ -32,7 +39,7 @@ def _simulate_ecdf(
     random_state: Optional[Any] = None,
 ) -> np.ndarray:
     """Simulate ECDF at the `eval_points` using the given random variable sampler"""
-    sample = rvs(ndraws, random_state=random_state)
+    sample = _call_rvs(rvs, ndraws, random_state)
     sample.sort()
     return compute_ecdf(sample, eval_points)
 

--- a/arviz/stats/ecdf_utils.py
+++ b/arviz/stats/ecdf_utils.py
@@ -101,11 +101,7 @@ def ecdf_confidence_band(
     num_trials : int, default 500
         The number of random ECDFs to generate for constructing simultaneous confidence bands
         (if `method` is "simulated").
-    random_state : {None, int, `numpy.random.Generator`,
-                    `numpy.random.RandomState`}, optional
-        If `None`, the `numpy.random.RandomState` singleton is used. If an `int`, a new
-        ``numpy.random.RandomState`` instance is used, seeded with seed. If a `RandomState` or
-        `Generator` instance, the instance is used.
+    random_state : int, numpy.random.Generator or numpy.random.RandomState, optional
 
     Returns
     -------

--- a/arviz/stats/ecdf_utils.py
+++ b/arviz/stats/ecdf_utils.py
@@ -91,7 +91,7 @@ def ecdf_confidence_band(
         A function that takes an integer `ndraws` and optionally the object passed to
         `random_state` and returns an array of `ndraws` samples from the same distribution
         as the original dataset. Required if `method` is "simulated" and variable is discrete.
-    num_trials : int, default 1000
+    num_trials : int, default 500
         The number of random ECDFs to generate for constructing simultaneous confidence bands
         (if `method` is "simulated").
     random_state : {None, int, `numpy.random.Generator`,
@@ -132,7 +132,7 @@ def _simulate_simultaneous_ecdf_band_probability(
     cdf_at_eval_points: np.ndarray,
     prob: float = 0.95,
     rvs: Optional[Callable[[int, Optional[Any]], np.ndarray]] = None,
-    num_trials: int = 1000,
+    num_trials: int = 500,
     random_state: Optional[Any] = None,
 ) -> float:
     """Estimate probability for simultaneous confidence band using simulation.

--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -471,7 +471,7 @@ def hdi(
         Refer to documentation of :func:`arviz.convert_to_dataset` for details.
     hdi_prob: float, optional
         Prob for which the highest density interval will be computed. Defaults to
-        ``stats.hdi_prob`` rcParam.
+        ``stats.ci_prob`` rcParam.
     circular: bool, optional
         Whether to compute the hdi taking into account `x` is a circular variable
         (in the range [-np.pi, np.pi]) or not. Defaults to False (i.e non-circular variables).
@@ -553,7 +553,7 @@ def hdi(
 
     """
     if hdi_prob is None:
-        hdi_prob = rcParams["stats.hdi_prob"]
+        hdi_prob = rcParams["stats.ci_prob"]
     elif not 1 >= hdi_prob > 0:
         raise ValueError("The value of hdi_prob should be in the interval (0, 1]")
 
@@ -1337,7 +1337,7 @@ def summary(
     if labeller is None:
         labeller = BaseLabeller()
     if hdi_prob is None:
-        hdi_prob = rcParams["stats.hdi_prob"]
+        hdi_prob = rcParams["stats.ci_prob"]
     elif not 1 >= hdi_prob > 0:
         raise ValueError("The value of hdi_prob should be in the interval (0, 1]")
 

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -1348,31 +1348,31 @@ def test_plot_ecdf_deprecations():
     dist = norm(0, 1)
     data = dist.rvs(1000)
     # base case, no deprecations
-    with does_not_warn(DeprecationWarning):
+    with does_not_warn(FutureWarning):
         axes = plot_ecdf(data, cdf=dist.cdf, confidence_bands=True)
     assert axes is not None
 
     # values2 is deprecated
     data2 = dist.rvs(200)
-    with pytest.deprecated_call():
+    with pytest.warns(FutureWarning):
         axes = plot_ecdf(data, values2=data2, difference=True)
 
     # pit is deprecated
-    with pytest.deprecated_call():
+    with pytest.warns(FutureWarning):
         axes = plot_ecdf(data, cdf=dist.cdf, pit=True)
     assert axes is not None
 
     # fpr is deprecated
-    with does_not_warn(DeprecationWarning):
+    with does_not_warn(FutureWarning):
         axes = plot_ecdf(data, cdf=dist.cdf, ci_prob=0.9)
-    with pytest.deprecated_call():
+    with pytest.warns(FutureWarning):
         axes = plot_ecdf(data, cdf=dist.cdf, confidence_bands=True, fpr=0.1)
     assert axes is not None
 
     # pointwise is deprecated
-    with does_not_warn(DeprecationWarning):
+    with does_not_warn(FutureWarning):
         axes = plot_ecdf(data, cdf=dist.cdf, confidence_bands="pointwise")
-    with pytest.deprecated_call():
+    with pytest.warns(FutureWarning):
         axes = plot_ecdf(data, cdf=dist.cdf, confidence_bands=True, pointwise=True)
 
 

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -1331,8 +1331,8 @@ def test_plot_ecdf_error():
 
     # contradictory band probabilities
     with pytest.raises(ValueError):
-        plot_ecdf(data, cdf=dist.cdf, confidence_bands=True, band_prob=0.9, fpr=0.1)
-    plot_ecdf(data, cdf=dist.cdf, confidence_bands=True, band_prob=0.9)
+        plot_ecdf(data, cdf=dist.cdf, confidence_bands=True, ci_prob=0.9, fpr=0.1)
+    plot_ecdf(data, cdf=dist.cdf, confidence_bands=True, ci_prob=0.9)
     plot_ecdf(data, cdf=dist.cdf, confidence_bands=True, fpr=0.1)
 
     # contradictory reference
@@ -1364,7 +1364,7 @@ def test_plot_ecdf_deprecations():
 
     # fpr is deprecated
     with does_not_warn(DeprecationWarning):
-        axes = plot_ecdf(data, cdf=dist.cdf, band_prob=0.9)
+        axes = plot_ecdf(data, cdf=dist.cdf, ci_prob=0.9)
     with pytest.deprecated_call():
         axes = plot_ecdf(data, cdf=dist.cdf, confidence_bands=True, fpr=0.1)
     assert axes is not None

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -1285,6 +1285,14 @@ def test_plot_ecdf_eval_points():
     assert axes is not None
 
 
+@pytest.mark.parametrize("confidence_bands", [True, "pointwise", "simulated"])
+def test_plot_ecdf_confidence_bands(confidence_bands):
+    """Check that all confidence_bands values correctly accepted"""
+    data = np.random.randn(4, 1000)
+    axes = plot_ecdf(data, confidence_bands=confidence_bands, cdf=norm(0, 1).cdf)
+    assert axes is not None
+
+
 def test_plot_ecdf_values2():
     data = np.random.randn(4, 1000)
     data2 = np.random.randn(4, 1000)

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -1273,6 +1273,18 @@ def test_plot_ecdf_basic():
     assert axes is not None
 
 
+def test_plot_ecdf_eval_points():
+    """Check that FutureWarning is raised if eval_points is not specified."""
+    data = np.random.randn(4, 1000)
+    eval_points = np.linspace(-3, 3, 100)
+    with pytest.warns(FutureWarning):
+        axes = plot_ecdf(data)
+    assert axes is not None
+    with does_not_warn(FutureWarning):
+        axes = plot_ecdf(data, eval_points=eval_points)
+    assert axes is not None
+
+
 def test_plot_ecdf_values2():
     data = np.random.randn(4, 1000)
     data2 = np.random.randn(4, 1000)
@@ -1288,6 +1300,7 @@ def test_plot_ecdf_cdf():
 
 
 def test_plot_ecdf_deprecations():
+    """Check that deprecations are raised correctly."""
     dist = norm(0, 1)
     data = dist.rvs(1000)
     # base case, no deprecations

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -1307,6 +1307,42 @@ def test_plot_ecdf_cdf():
     assert axes is not None
 
 
+def test_plot_ecdf_error():
+    """Check that all error conditions are correctly raised."""
+    dist = norm(0, 1)
+    data = dist.rvs(1000)
+
+    # cdf not specified
+    with pytest.raises(ValueError):
+        plot_ecdf(data, confidence_bands=True)
+    plot_ecdf(data, confidence_bands=True, cdf=dist.cdf)
+    with pytest.raises(ValueError):
+        plot_ecdf(data, difference=True)
+    plot_ecdf(data, difference=True, cdf=dist.cdf)
+    with pytest.raises(ValueError):
+        plot_ecdf(data, pit=True)
+    plot_ecdf(data, pit=True, cdf=dist.cdf)
+
+    # contradictory confidence band types
+    with pytest.raises(ValueError):
+        plot_ecdf(data, cdf=dist.cdf, confidence_bands="simulated", pointwise=True)
+    plot_ecdf(data, cdf=dist.cdf, confidence_bands=True, pointwise=True)
+    plot_ecdf(data, cdf=dist.cdf, confidence_bands="pointwise")
+
+    # contradictory band probabilities
+    with pytest.raises(ValueError):
+        plot_ecdf(data, cdf=dist.cdf, confidence_bands=True, band_prob=0.9, fpr=0.1)
+    plot_ecdf(data, cdf=dist.cdf, confidence_bands=True, band_prob=0.9)
+    plot_ecdf(data, cdf=dist.cdf, confidence_bands=True, fpr=0.1)
+
+    # contradictory reference
+    data2 = dist.rvs(200)
+    with pytest.raises(ValueError):
+        plot_ecdf(data, data2, cdf=dist.cdf, difference=True)
+    plot_ecdf(data, data2, difference=True)
+    plot_ecdf(data, cdf=dist.cdf, difference=True)
+
+
 def test_plot_ecdf_deprecations():
     """Check that deprecations are raised correctly."""
     dist = norm(0, 1)

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -52,6 +52,7 @@ from ...plots.dotplot import wilkinson_algorithm
 from ..helpers import (  # pylint: disable=unused-import
     create_model,
     create_multidimensional_model,
+    does_not_warn,
     eight_schools_params,
     models,
     multidim_models,
@@ -1284,6 +1285,38 @@ def test_plot_ecdf_cdf():
     cdf = norm(0, 1).cdf
     axes = plot_ecdf(data, cdf=cdf)
     assert axes is not None
+
+
+def test_plot_ecdf_deprecations():
+    dist = norm(0, 1)
+    data = dist.rvs(1000)
+    # base case, no deprecations
+    with does_not_warn(DeprecationWarning):
+        axes = plot_ecdf(data, cdf=dist.cdf, confidence_bands=True)
+    assert axes is not None
+
+    # values2 is deprecated
+    data2 = dist.rvs(200)
+    with pytest.deprecated_call():
+        axes = plot_ecdf(data, values2=data2, difference=True)
+
+    # pit is deprecated
+    with pytest.deprecated_call():
+        axes = plot_ecdf(data, cdf=dist.cdf, pit=True)
+    assert axes is not None
+
+    # fpr is deprecated
+    with does_not_warn(DeprecationWarning):
+        axes = plot_ecdf(data, cdf=dist.cdf, band_prob=0.9)
+    with pytest.deprecated_call():
+        axes = plot_ecdf(data, cdf=dist.cdf, confidence_bands=True, fpr=0.1)
+    assert axes is not None
+
+    # pointwise is deprecated
+    with does_not_warn(DeprecationWarning):
+        axes = plot_ecdf(data, cdf=dist.cdf, confidence_bands="pointwise")
+    with pytest.deprecated_call():
+        axes = plot_ecdf(data, cdf=dist.cdf, confidence_bands=True, pointwise=True)
 
 
 @pytest.mark.parametrize(

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -46,7 +46,7 @@ from ...plots import (
 from ...rcparams import rc_context, rcParams
 from ...stats import compare, hdi, loo, waic
 from ...stats.density_utils import kde as _kde
-from ...utils import _cov
+from ...utils import _cov, BehaviourChangeWarning
 from ...plots.plot_utils import plot_point_interval
 from ...plots.dotplot import wilkinson_algorithm
 from ..helpers import (  # pylint: disable=unused-import
@@ -1274,13 +1274,13 @@ def test_plot_ecdf_basic():
 
 
 def test_plot_ecdf_eval_points():
-    """Check that FutureWarning is raised if eval_points is not specified."""
+    """Check that BehaviourChangeWarning is raised if eval_points is not specified."""
     data = np.random.randn(4, 1000)
     eval_points = np.linspace(-3, 3, 100)
-    with pytest.warns(FutureWarning):
+    with pytest.warns(BehaviourChangeWarning):
         axes = plot_ecdf(data)
     assert axes is not None
-    with does_not_warn(FutureWarning):
+    with does_not_warn(BehaviourChangeWarning):
         axes = plot_ecdf(data, eval_points=eval_points)
     assert axes is not None
 

--- a/arviz/tests/base_tests/test_rcparams.py
+++ b/arviz/tests/base_tests/test_rcparams.py
@@ -127,6 +127,20 @@ def test_choice_bad_values(param):
         rcParams[param] = "bad_value"
 
 
+@pytest.mark.parametrize("args", [("stats.hdi_prob", "stats.ci_prob", 0.7, 0.7)])
+def test_deprecated_param(args):
+    """Test value and warning message correctly set for deprecated rcparams."""
+    param_old, param_new, val_old, val_new = args
+    assert param_new in rcParams._underlying_storage
+    assert param_old not in rcParams._underlying_storage
+    assert not np.isclose(rcParams[param_new], val_new)
+    msg = f"{param_old} is deprecated since .*, use {param_new} instead"
+    with pytest.warns(FutureWarning, match=msg):
+        with rc_context(rc={param_old: val_old}):
+            assert param_old not in rcParams._underlying_storage
+            assert np.isclose(rcParams[param_new], val_new)
+
+
 @pytest.mark.parametrize("allow_none", (True, False))
 @pytest.mark.parametrize("typeof", (str, int))
 @pytest.mark.parametrize("args", [("not one", 10), (False, None), (False, 4)])

--- a/arviz/tests/base_tests/test_rcparams.py
+++ b/arviz/tests/base_tests/test_rcparams.py
@@ -131,13 +131,11 @@ def test_choice_bad_values(param):
 def test_deprecated_param(args):
     """Test value and warning message correctly set for deprecated rcparams."""
     param_old, param_new, val_old, val_new = args
-    assert param_new in rcParams._underlying_storage
-    assert param_old not in rcParams._underlying_storage
+    assert param_new in rcParams
     assert not np.isclose(rcParams[param_new], val_new)
     msg = f"{param_old} is deprecated since .*, use {param_new} instead"
     with pytest.warns(FutureWarning, match=msg):
         with rc_context(rc={param_old: val_old}):
-            assert param_old not in rcParams._underlying_storage
             assert np.isclose(rcParams[param_new], val_new)
 
 

--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -6,6 +6,8 @@ import logging
 import os
 import sys
 from typing import Any, Dict, List, Optional, Tuple, Union
+import warnings
+from contextlib import contextmanager
 
 import cloudpickle
 import numpy as np
@@ -27,6 +29,18 @@ class RandomVariableTestClass:
     def __repr__(self):
         """Return argument to constructor as string representation."""
         return self.name
+
+
+@contextmanager
+def does_not_warn(warning=Warning):
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always")
+        yield
+        for w in caught_warnings:
+            if issubclass(w.category, warning):
+                raise AssertionError(
+                    f"Expected no {warning.__name__} but caught warning with message: {w.message}"
+                )
 
 
 @pytest.fixture(scope="module")

--- a/arviz/tests/helpers.py
+++ b/arviz/tests/helpers.py
@@ -656,7 +656,6 @@ def importorskip(
     # if set, missing optional dependencies trigger failed tests.
     if "ARVIZ_REQUIRE_ALL_DEPS" not in os.environ:
         return pytest.importorskip(modname=modname, minversion=minversion, reason=reason)
-    import warnings
 
     compile(modname, "", "eval")  # to catch syntaxerrors
 

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -16,6 +16,8 @@ from .rcparams import rcParams
 
 STATIC_FILES = ("static/html/icons-svg-inline.html", "static/css/style.css")
 
+class BehaviourChangeWarning(Warning):
+    """Custom warning to ease filtering it."""
 
 def _check_tilde_start(x):
     return bool(isinstance(x, str) and x.startswith("~"))

--- a/arviz/utils.py
+++ b/arviz/utils.py
@@ -16,8 +16,10 @@ from .rcparams import rcParams
 
 STATIC_FILES = ("static/html/icons-svg-inline.html", "static/css/style.css")
 
+
 class BehaviourChangeWarning(Warning):
     """Custom warning to ease filtering it."""
+
 
 def _check_tilde_start(x):
     return bool(isinstance(x, str) and x.startswith("~"))

--- a/arvizrc.template
+++ b/arvizrc.template
@@ -48,8 +48,7 @@ plot.matplotlib.show         : false       # call plt.show. One of "true", "fals
 
 ### STATS ###
 # rcParams related with statistical and diagnostic functions
-stats.ci_prob                : 0.94      # Probability used for confidence intervals
-stats.hdi_prob      : 0.94               # Friendly reminder of the arbitrary nature of commonly used values like 95%
+stats.ci_prob                : 0.94      # Friendly reminder of the arbitrary nature of commonly used values like 95%
 stats.information_criterion  : loo       # One of "loo", "waic"
 stats.ic_compare_method      : stacking  # One of "stacking", "bb-pseudo-bma", "pseudo-bma"
 stats.ic_pointwise           : true     # One of "true", "false"

--- a/arvizrc.template
+++ b/arvizrc.template
@@ -23,6 +23,7 @@ plot.backend                 : matplotlib  # One of "bokeh", "matplotlib"
 plot.density_kind            : kde         # One of "kde", "hist"
 plot.max_subplots            : 40          # Maximum number of subplots.
 plot.point_estimate          : mean        # One of "mean", "median", "mode" or "None"
+plot.band_prob                : 0.95       # Probability used for ECDF confidence bands
 
 # bokeh specific rcParams
 plot.bokeh.bounds_x_range    : auto        # either "auto", "None" or tuple of size 2

--- a/arvizrc.template
+++ b/arvizrc.template
@@ -23,7 +23,6 @@ plot.backend                 : matplotlib  # One of "bokeh", "matplotlib"
 plot.density_kind            : kde         # One of "kde", "hist"
 plot.max_subplots            : 40          # Maximum number of subplots.
 plot.point_estimate          : mean        # One of "mean", "median", "mode" or "None"
-plot.band_prob                : 0.95       # Probability used for ECDF confidence bands
 
 # bokeh specific rcParams
 plot.bokeh.bounds_x_range    : auto        # either "auto", "None" or tuple of size 2
@@ -49,6 +48,7 @@ plot.matplotlib.show         : false       # call plt.show. One of "true", "fals
 
 ### STATS ###
 # rcParams related with statistical and diagnostic functions
+stats.ci_prob                : 0.95      # Probability used for confidence intervals
 stats.hdi_prob      : 0.94               # Friendly reminder of the arbitrary nature of commonly used values like 95%
 stats.information_criterion  : loo       # One of "loo", "waic"
 stats.ic_compare_method      : stacking  # One of "stacking", "bb-pseudo-bma", "pseudo-bma"

--- a/arvizrc.template
+++ b/arvizrc.template
@@ -48,7 +48,7 @@ plot.matplotlib.show         : false       # call plt.show. One of "true", "fals
 
 ### STATS ###
 # rcParams related with statistical and diagnostic functions
-stats.ci_prob                : 0.95      # Probability used for confidence intervals
+stats.ci_prob                : 0.94      # Probability used for confidence intervals
 stats.hdi_prob      : 0.94               # Friendly reminder of the arbitrary nature of commonly used values like 95%
 stats.information_criterion  : loo       # One of "loo", "waic"
 stats.ic_compare_method      : stacking  # One of "stacking", "bb-pseudo-bma", "pseudo-bma"

--- a/doc/source/getting_started/Introduction.ipynb
+++ b/doc/source/getting_started/Introduction.ipynb
@@ -142,7 +142,7 @@
    "source": [
     "## ArviZ rcParams\n",
     "\n",
-    "You may have noticed that for both {func}`~arviz.plot_posterior` and {func}`~arviz.plot_forest`, the Highest Density Interval (HDI) is 94%, which you may find weird at first. This particular value is a friendly reminder of the arbitrary nature of choosing any single value without further justification, including common values like 95%, 50% and even our own default, 94%. ArviZ includes default values for a few parameters, you can access them with `az.rcParams`. To change the default HDI value to let's say 90% you can do:"
+    "You may have noticed that for both {func}`~arviz.plot_posterior` and {func}`~arviz.plot_forest`, the Highest Density Interval (HDI) is 94%, which you may find weird at first. This particular value is a friendly reminder of the arbitrary nature of choosing any single value without further justification, including common values like 95%, 50% and even our own default, 94%. ArviZ includes default values for a few parameters, you can access them with `az.rcParams`. To change the default confidence interval (CI) value (including HDI) to let's say 90% you can do:"
    ]
   },
   {
@@ -151,7 +151,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "az.rcParams[\"stats.hdi_prob\"] = 0.90"
+    "az.rcParams[\"stats.ci_prob\"] = 0.90"
    ]
   },
   {

--- a/doc/source/user_guide/plots_arguments_guide.md
+++ b/doc/source/user_guide/plots_arguments_guide.md
@@ -226,7 +226,7 @@ az.plot_forest(
 ## `hdi_prob`
 
 Probability for the highest density interval (HDI).
-Defaults to ``stats.hdi_prob`` rcParam.
+Defaults to ``stats.ci_prob`` rcParam.
 
 Plot the 80% HDI interval of simulated regression data using `y` argument:
 

--- a/examples/matplotlib/mpl_plot_ecdf.py
+++ b/examples/matplotlib/mpl_plot_ecdf.py
@@ -4,6 +4,7 @@ ECDF Plot
 _gallery_category: Distributions
 """
 
+import warnings
 import matplotlib.pyplot as plt
 from scipy.stats import norm
 
@@ -13,6 +14,8 @@ az.style.use("arviz-doc")
 
 sample = norm(0, 1).rvs(1000)
 distribution = norm(0, 1)
+
+warnings.filterwarnings("ignore", category=az.utils.BehaviourChangeWarning)
 
 az.plot_ecdf(sample, cdf=distribution.cdf, confidence_bands=True)
 


### PR DESCRIPTION
## Description
<!--
Thank you so much for your PR! To help us review your contribution, please consider the following points:

- The PR title should summarize the changes, for example "Add new group argument for the pair plot".
  Avoid non-descriptive titles such as "Addresses issue #348".

- The description should provide at least 1-2 sentences describing the pull request in detail and
  link to any relevant issues.

- Please prefix the title of incomplete contributions with [WIP] (to indicate a work in
  progress). WIPs may be useful to (1) indicate you are working on something to avoid
  duplicated work, (2) request broad review of functionality or API, or (3) seek collaborators. -->

This PR introduces new keyword arguments to `plot_ecdf` and deprecates a few existing ones, following suggestions in #2309.

New keywords and features:
- `confidence_bands` now may take string arguments as well as boolean
- `ci_prob` specifies band probability. `stats.ci_prob` is a new rcParam.
- `eval_points` allows the user to specify the evaluation points
- `rvs`, `random_state` can be provided for simulation confidence bands

Deprecated arguments:
- `values2` is now deprecated, in favor of users passing an empirical CDF

Deprecated keywords:
- `pointwise` is now `confidence_bands="pointwise"`
- `fpr` is replaced with `1-ci_prob` for consistency with other plotting functions.
- `pit` is deprecated. We only need this for LOO-PIT, users who need it for something else will probably know how to make the plot, and if we really want to include it, it should be its own plotting function. There's now a documented example of how to plot PIT.
- `npoints`

Deprecated rcparams:
- `stats.hdi_prob` has been deprecated and replaced with `stats.ci_prob`

Additional changes:
- If `eval_points` not provided, there's a warning that in the future `eval_points` will be the unique values of the sample. This would be breaking and is saved for a future release.

None of the changes are breaking.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [x] New features are properly documented (with an example if appropriate)?
- [x] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->


<!-- readthedocs-preview arviz start -->
----
📚 Documentation preview 📚: https://arviz--2316.org.readthedocs.build/en/2316/

<!-- readthedocs-preview arviz end -->