### PR TITLE
Fix for datetime deprecation and standardizing timezone and isoformat (Issue #2327)

### DIFF
--- a/arviz/data/base.py
+++ b/arviz/data/base.py
@@ -422,7 +422,7 @@ def make_attrs(attrs=None, library=None):
         attrs
     """
     default_attrs = {
-        "created_at": datetime.datetime.utcnow().isoformat(),
+        "created_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
         "arviz_version": __version__,
     }
     if library is not None:

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -9,7 +9,7 @@ from collections import OrderedDict, defaultdict
 from collections.abc import MutableMapping, Sequence
 from copy import copy as ccopy
 from copy import deepcopy
-from datetime import datetime
+import datetime
 from html import escape
 from typing import (
     TYPE_CHECKING,
@@ -2083,7 +2083,7 @@ def concat(*args, dim=None, copy=True, inplace=False, reset_dim=True):
             else:
                 return args[0]
 
-    current_time = str(datetime.now())
+    current_time = datetime.datetime.now(datetime.timezone.utc).isoformat()
     combined_attr = defaultdict(list)
     for idata in args:
         for key, val in idata.attrs.items():


### PR DESCRIPTION
Fix for datetime deprecation issue and standardizing timezone(UTC) and format(isoformat) for datetime updates on concatenating InferenceData (issue #2327 )

## Description

The `"created_at"` default attribute in the make_attrs function in `arviz/data/base.py` is updated to avoid deprecation as well as work for Python 3.10, which is still supported by ArviZ. 

The `current_time` variable in the concat function in `arviz/data/inference-data.py` is also updated to use the UTC timezone and is isoformatted. 

<!--
Thank you so much for your PR! To help us review your contribution, please consider the following points:

- The PR title should summarize the changes, for example "Add new group argument for the pair plot".
  Avoid non-descriptive titles such as "Addresses issue #348".

- The description should provide at least 1-2 sentences describing the pull request in detail and
  link to any relevant issues.

- Please prefix the title of incomplete contributions with [WIP] (to indicate a work in
  progress). WIPs may be useful to (1) indicate you are working on something to avoid
  duplicated work, (2) request broad review of functionality or API, or (3) seek collaborators. -->

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [ ] New features are properly documented (with an example if appropriate)?
- [ ] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->


<!-- readthedocs-preview arviz start -->
----
📚 Documentation preview 📚: https://arviz--2329.org.readthedocs.build/en/2329/

<!-- readthedocs-preview arviz end -->