### PR TITLE
Add a close method to InferenceData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add new example data `rugby_field` and update `rugby` example data ([2322](https://github.com/arviz-devs/arviz/pull/2322))
 - Support for `pytree`s and robust to nested dictionaries. ([2291](https://github.com/arviz-devs/arviz/pull/2291))
+- Add `.close` method to `InferenceData` ([2338](https://github.com/arviz-devs/arviz/pull/2338))
 
 
 ### Maintenance and fixes

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -1689,6 +1689,7 @@ class InferenceData(Mapping[str, xr.Dataset]):
     compute = _extend_xr_method(xr.Dataset.compute)
     persist = _extend_xr_method(xr.Dataset.persist)
     quantile = _extend_xr_method(xr.Dataset.quantile)
+    close = _extend_xr_method(xr.Dataset.close)
 
     # The following lines use methods on xr.Dataset that are dynamically defined and attached.
     # As a result mypy cannot see them, so we have to suppress the resulting mypy errors.

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -266,6 +266,9 @@ class InferenceData(Mapping[str, xr.Dataset]):
             raise KeyError(key)
         return getattr(self, key)
 
+    def __del__(self) -> None:
+        self.close()
+
     def groups(self) -> List[str]:
         """Return all groups present in InferenceData object."""
         return self._groups_all

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -266,9 +266,6 @@ class InferenceData(Mapping[str, xr.Dataset]):
             raise KeyError(key)
         return getattr(self, key)
 
-    def __del__(self) -> None:
-        self.close()
-
     def groups(self) -> List[str]:
         """Return all groups present in InferenceData object."""
         return self._groups_all

--- a/doc/source/api/inference_data.rst
+++ b/doc/source/api/inference_data.rst
@@ -36,6 +36,7 @@ IO / Conversion
   InferenceData.from_zarr
   InferenceData.to_zarr
   InferenceData.chunk
+  InferenceData.close
   InferenceData.compute
   InferenceData.load
   InferenceData.persist


### PR DESCRIPTION
Closes #2337 

## Description
Adds a `close` method to `arviz.InferenceData` that simply extends from `xarray.Dataset.close`.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [ ] New features are properly documented (with an example if appropriate)?
- [ ] Includes new or updated tests to cover the new feature
- [ ] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->


<!-- readthedocs-preview arviz start -->
----
📚 Documentation preview 📚: https://arviz--2338.org.readthedocs.build/en/2338/

<!-- readthedocs-preview arviz end -->