### PR TITLE
remove extra copy of log-likelihood in NumPyroConverter

### DIFF
--- a/arviz/data/io_numpyro.py
+++ b/arviz/data/io_numpyro.py
@@ -194,7 +194,7 @@ class NumPyroConverter:
             )
             for obs_name, log_like in log_likelihood_dict.items():
                 shape = (self.nchains, self.ndraws) + log_like.shape[1:]
-                data[obs_name] = np.reshape(log_like.copy(), shape)
+                data[obs_name] = np.reshape(np.asarray(log_like), shape)
         return dict_to_dataset(
             data,
             library=self.numpyro,


### PR DESCRIPTION
Removes extra copy to reduce memory requirements for large models/datasets.   If the copy is desirable for a reason I missed feel free to delete this.  Let me know if any changes are needed

As a side note the default automatic numpyro log-likelihood calculation was a bit of a surprise (as far as unexpected memory explosions go).

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Code style  correct (follows pylint and black guidelines)


<!-- readthedocs-preview arviz start -->
----
📚 Documentation preview 📚: https://arviz--2347.org.readthedocs.build/en/2347/

<!-- readthedocs-preview arviz end -->