### PR TITLE
Fix typo in docstring for rhat: take square root of ratio of variance estimates

### DIFF
--- a/arviz/stats/diagnostics.py
+++ b/arviz/stats/diagnostics.py
@@ -270,7 +270,7 @@ def rhat(data, *, var_names=None, method="rank", dask_kwargs=None):
     -----
     The diagnostic is computed by:
 
-      .. math:: \hat{R} = \frac{\hat{V}}{W}
+      .. math:: \hat{R} = \sqrt{\frac{\hat{V}}{W}}
 
     where :math:`W` is the within-chain variance and :math:`\hat{V}` is the posterior variance
     estimate for the pooled rank-traces. This is the potential scale reduction factor, which


### PR DESCRIPTION
The docstring for ``rhat`` provides an incorrect formula for $\hat{R}$ which is missing the square root. The expression should be:
$$\hat{R} = \sqrt{\frac{\hat{V}}{W}}.$$
The implementation of the function uses the square root.

This pull request fixes the typo.

## Description
<!--
Thank you so much for your PR! To help us review your contribution, please consider the following points:

- The PR title should summarize the changes, for example "Add new group argument for the pair plot".
  Avoid non-descriptive titles such as "Addresses issue #348".

- The description should provide at least 1-2 sentences describing the pull request in detail and
  link to any relevant issues.

- Please prefix the title of incomplete contributions with [WIP] (to indicate a work in
  progress). WIPs may be useful to (1) indicate you are working on something to avoid
  duplicated work, (2) request broad review of functionality or API, or (3) seek collaborators. -->

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [X] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->


<!-- readthedocs-preview arviz start -->
----
📚 Documentation preview 📚: https://arviz--2355.org.readthedocs.build/en/2355/

<!-- readthedocs-preview arviz end -->