### PR TITLE
Update `plotting_backends.md` with correct path for function

### DIFF
--- a/doc/source/contributing/plotting_backends.md
+++ b/doc/source/contributing/plotting_backends.md
@@ -13,7 +13,7 @@ code in `arviz.plots.backends` perform the backend specific
 keyword argument defaulting and plot behavior.
 
 The convenience function `get_plotting_function` available in
-`arviz.plots.get_plotting_function` should be called to obtain
+`arviz.plots.plot_utils.get_plotting_function` should be called to obtain
 the correct plotting function from the associated backend. If
 adding a new backend follow the pattern provided to programmatically
 call the correct backend.


### PR DESCRIPTION
Change path of function provided in [documentation](https://python.arviz.org/en/latest/contributing/plotting_backends.html) to right path.

## Description
Fixed incorrect path provided for the `get_plotting_function()` provided in [documentation](https://python.arviz.org/en/latest/contributing/plotting_backends.html) as `arviz.plots.get_plotting_function`  to correct path - `arviz.plots.plot_utils.get_plotting_function`

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [ ] New features are properly documented (with an example if appropriate)?
- [ ] Includes new or updated tests to cover the new feature
- [ ] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->


<!-- readthedocs-preview arviz start -->
----
📚 Documentation preview 📚: https://arviz--2364.org.readthedocs.build/en/2364/

<!-- readthedocs-preview arviz end -->