### PR TITLE
Add optimized simultaneous ECDF bands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.x.x Unreleased
 
 ### New features
+- Add optimized simultaneous ECDF confidence bands ([2368](https://github.com/arviz-devs/arviz/pull/2368))
 
 ### Maintenance and fixes
 

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -73,6 +73,7 @@ def plot_ecdf(
         - False: No confidence bands are plotted (default).
         - True: Plot bands computed with the default algorithm (subject to change)
         - "pointwise": Compute the pointwise (i.e. marginal) confidence band.
+        - "optimized": Use optimization to estimate a simultaneous confidence band.
         - "simulated": Use Monte Carlo simulation to estimate a simultaneous confidence
           band.
 
@@ -238,9 +239,10 @@ def plot_ecdf(
             )
             confidence_bands = "pointwise"
         else:
-            confidence_bands = "simulated"
-    elif confidence_bands == "simulated" and pointwise:
-        raise ValueError("Cannot specify both `confidence_bands='simulated'` and `pointwise=True`")
+            confidence_bands = "optimized"
+        # if pointwise especified, confidence_bands must be a bool or 'pointwise'
+    elif confidence_bands not in [False, "pointwise"] and pointwise:
+        raise ValueError(f"Cannot specify both `confidence_bands='{confidence_bands}'` and `pointwise=True`")
 
     if fpr is not None:
         warnings.warn(
@@ -298,7 +300,7 @@ def plot_ecdf(
             "`eval_points` explicitly.",
             BehaviourChangeWarning,
         )
-        if confidence_bands == "simulated":
+        if confidence_bands in ["optimized", "simulated"]:
             warnings.warn(
                 "For simultaneous bands to be correctly calibrated, specify `eval_points` "
                 "independent of the `values`"

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -217,8 +217,7 @@ def plot_ecdf(
         >>> pit_vals = distribution.cdf(sample)
         >>> uniform_dist = uniform(0, 1)
         >>> az.plot_ecdf(
-        >>>     pit_vals, cdf=uniform_dist.cdf,
-        >>>     rvs=uniform_dist.rvs, confidence_bands=True
+        >>>     pit_vals, cdf=uniform_dist.cdf, confidence_bands=True,
         >>> )
 
     Plot an ECDF-difference plot of PIT values.
@@ -227,8 +226,8 @@ def plot_ecdf(
         :context: close-figs
 
         >>> az.plot_ecdf(
-        >>>     pit_vals, cdf = uniform_dist.cdf, rvs = uniform_dist.rvs,
-        >>>     confidence_bands = True, difference = True
+        >>>     pit_vals, cdf = uniform_dist.cdf, confidence_bands = True,
+        >>>     difference = True
         >>> )
     """
     if confidence_bands is True:

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -242,7 +242,9 @@ def plot_ecdf(
             confidence_bands = "optimized"
         # if pointwise especified, confidence_bands must be a bool or 'pointwise'
     elif confidence_bands not in [False, "pointwise"] and pointwise:
-        raise ValueError(f"Cannot specify both `confidence_bands='{confidence_bands}'` and `pointwise=True`")
+        raise ValueError(
+            f"Cannot specify both `confidence_bands='{confidence_bands}'` and `pointwise=True`"
+        )
 
     if fpr is not None:
         warnings.warn(

--- a/arviz/plots/ecdfplot.py
+++ b/arviz/plots/ecdfplot.py
@@ -238,8 +238,8 @@ def plot_ecdf(
             )
             confidence_bands = "pointwise"
         else:
-            confidence_bands = "optimized"
-        # if pointwise especified, confidence_bands must be a bool or 'pointwise'
+            confidence_bands = "auto"
+        # if pointwise specified, confidence_bands must be a bool or 'pointwise'
     elif confidence_bands not in [False, "pointwise"] and pointwise:
         raise ValueError(
             f"Cannot specify both `confidence_bands='{confidence_bands}'` and `pointwise=True`"
@@ -322,6 +322,11 @@ def plot_ecdf(
 
     if confidence_bands:
         ndraws = len(values)
+        if confidence_bands == "auto":
+            if ndraws < 200 or num_trials >= 250 * np.sqrt(ndraws):
+                confidence_bands = "optimized"
+            else:
+                confidence_bands = "simulated"
         x_bands = eval_points
         lower, higher = ecdf_confidence_band(
             ndraws,

--- a/arviz/stats/ecdf_utils.py
+++ b/arviz/stats/ecdf_utils.py
@@ -12,10 +12,10 @@ try:
     from numba import jit, vectorize
 except ImportError:
 
-    def jit(*args, **kwargs):
+    def jit(*args, **kwargs):  # pylint: disable=unused-argument
         return lambda f: f
 
-    def vectorize(*args, **kwargs):
+    def vectorize(*args, **kwargs):  # pylint: disable=unused-argument
         return lambda f: f
 
 

--- a/arviz/stats/ecdf_utils.py
+++ b/arviz/stats/ecdf_utils.py
@@ -145,7 +145,8 @@ def _update_ecdf_band_interior_probabilities(
     cdf_right: float,
     ndraws: int,
 ) -> np.ndarray:
-    """Update the probability that an ECDF has been within the envelope including at the current point.
+    """Update the probability that an ECDF has been within the envelope including at the current
+    point.
 
     Arguments
     ---------
@@ -204,10 +205,10 @@ def _ecdf_band_optimization_objective(
 
 def _optimize_simultaneous_ecdf_band_probability(
     ndraws: int,
-    eval_points: np.ndarray,
+    eval_points: np.ndarray,  # pylint: disable=unused-argument
     cdf_at_eval_points: np.ndarray,
     prob: float = 0.95,
-    **kwargs,
+    **kwargs,  # pylint: disable=unused-argument
 ):
     """Estimate probability for simultaneous confidence band using optimization.
 

--- a/arviz/stats/ecdf_utils.py
+++ b/arviz/stats/ecdf_utils.py
@@ -187,28 +187,21 @@ def _update_ecdf_band_interior_probabilities(
     return prob_right
 
 
-@jit(nopython=True)
-def _lbinom(n, k):
-    k = min(k, n - k)  # Take advantage of symmetry
-    if k < 0:
-        return 0.0
-    if k == 0:
-        return 1.0
-    return math.lgamma(n + 1) - math.lgamma(k + 1) - math.lgamma(n - k + 1)
-
-
 @vectorize(["float64(int64, int64, float64, int64)"])
 def _binom_pmf(k, n, p, loc):
     k -= loc
-    if k == 0:
-        return (1 - p) ** n
-    if k == n:
-        return p**k
+    if k < 0 or k > n:
+        return 0.0
     if p == 0:
         return 1.0 if k == 0 else 0.0
     if p == 1:
         return 1.0 if k == n else 0.0
-    return np.exp(_lbinom(n, k) + k * np.log(p) + (n - k) * np.log1p(-p))
+    if k == 0:
+        return (1 - p) ** n
+    if k == n:
+        return p**n
+    lbinom = math.lgamma(n + 1) - math.lgamma(k + 1) - math.lgamma(n - k + 1)
+    return np.exp(lbinom + k * np.log(p) + (n - k) * np.log1p(-p))
 
 
 @jit(nopython=True)

--- a/arviz/stats/ecdf_utils.py
+++ b/arviz/stats/ecdf_utils.py
@@ -74,7 +74,7 @@ def ecdf_confidence_band(
     eval_points: np.ndarray,
     cdf_at_eval_points: np.ndarray,
     prob: float = 0.95,
-    method="simulated",
+    method="optimized",
     **kwargs,
 ) -> Tuple[np.ndarray, np.ndarray]:
     """Compute the `prob`-level confidence band for the ECDF.

--- a/arviz/stats/ecdf_utils.py
+++ b/arviz/stats/ecdf_utils.py
@@ -126,7 +126,9 @@ def ecdf_confidence_band(
             ndraws, eval_points, cdf_at_eval_points, prob=prob, **kwargs
         )
     else:
-        raise ValueError(f"Unknown method {method}. Valid options are 'pointwise', 'optimized', or 'simulated'.")
+        raise ValueError(
+            f"Unknown method {method}. Valid options are 'pointwise', 'optimized', or 'simulated'."
+        )
 
     prob_lower, prob_upper = _get_pointwise_confidence_band(
         prob_pointwise, ndraws, cdf_at_eval_points
@@ -150,9 +152,9 @@ def _update_ecdf_band_interior_probabilities(
     prob_left : np.ndarray
         For each point in the interior at the previous point, the joint probability that it and all
         points before are in the interior.
-    interval_left : np.ndarray 
+    interval_left : np.ndarray
         The set of points in the interior at the previous point.
-    interval_right : np.ndarray 
+    interval_right : np.ndarray
         The set of points in the interior at the current point.
     cdf_left : float
         The CDF at the previous point.
@@ -169,9 +171,7 @@ def _update_ecdf_band_interior_probabilities(
     """
     z_tilde = (cdf_right - cdf_left) / (1 - cdf_left)
     interval_left = interval_left[:, np.newaxis]
-    prob_conditional = binom.pmf(
-        interval_right, ndraws - interval_left, z_tilde, loc=interval_left
-    )
+    prob_conditional = binom.pmf(interval_right, ndraws - interval_left, z_tilde, loc=interval_left)
     prob_right = prob_left.dot(prob_conditional)
     return prob_right
 

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -1286,9 +1286,10 @@ def test_plot_ecdf_eval_points():
 
 
 @pytest.mark.parametrize("confidence_bands", [True, "pointwise", "optimized", "simulated"])
-def test_plot_ecdf_confidence_bands(confidence_bands):
+@pytest.mark.parametrize("ndraws", [100, 10_000])
+def test_plot_ecdf_confidence_bands(confidence_bands, ndraws):
     """Check that all confidence_bands values correctly accepted"""
-    data = np.random.randn(4, 1000)
+    data = np.random.randn(4, ndraws // 4)
     axes = plot_ecdf(data, confidence_bands=confidence_bands, cdf=norm(0, 1).cdf)
     assert axes is not None
 

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -1285,7 +1285,7 @@ def test_plot_ecdf_eval_points():
     assert axes is not None
 
 
-@pytest.mark.parametrize("confidence_bands", [True, "pointwise", "simulated"])
+@pytest.mark.parametrize("confidence_bands", [True, "pointwise", "optimized", "simulated"])
 def test_plot_ecdf_confidence_bands(confidence_bands):
     """Check that all confidence_bands values correctly accepted"""
     data = np.random.randn(4, 1000)
@@ -1326,6 +1326,8 @@ def test_plot_ecdf_error():
     # contradictory confidence band types
     with pytest.raises(ValueError):
         plot_ecdf(data, cdf=dist.cdf, confidence_bands="simulated", pointwise=True)
+    with pytest.raises(ValueError):
+        plot_ecdf(data, cdf=dist.cdf, confidence_bands="optimized", pointwise=True)
     plot_ecdf(data, cdf=dist.cdf, confidence_bands=True, pointwise=True)
     plot_ecdf(data, cdf=dist.cdf, confidence_bands="pointwise")
 

--- a/arviz/tests/base_tests/test_stats_ecdf_utils.py
+++ b/arviz/tests/base_tests/test_stats_ecdf_utils.py
@@ -10,6 +10,13 @@ from ...stats.ecdf_utils import (
     _get_pointwise_confidence_band,
 )
 
+try:
+    import numba
+
+    numba_options = [True, False]
+except ImportError:
+    numba_options = [False]
+
 
 def test_compute_ecdf():
     """Test compute_ecdf function."""
@@ -110,8 +117,14 @@ def test_get_pointwise_confidence_band(dist, prob, ndraws, num_trials=1_000, see
 )
 @pytest.mark.parametrize("ndraws", [10_000])
 @pytest.mark.parametrize("method", ["pointwise", "optimized", "simulated"])
-def test_ecdf_confidence_band(dist, rvs, prob, ndraws, method, num_trials=1_000, seed=57):
+@pytest.mark.parametrize("use_numba", numba_options)
+def test_ecdf_confidence_band(
+    dist, rvs, prob, ndraws, method, use_numba, num_trials=1_000, seed=57
+):
     """Test test_ecdf_confidence_band."""
+    if use_numba and method != "optimized":
+        pytest.skip("Numba only used in optimized method")
+
     eval_points = np.linspace(*dist.interval(0.99), 10)
     cdf_at_eval_points = dist.cdf(eval_points)
     random_state = np.random.default_rng(seed)

--- a/arviz/tests/base_tests/test_stats_ecdf_utils.py
+++ b/arviz/tests/base_tests/test_stats_ecdf_utils.py
@@ -11,7 +11,7 @@ from ...stats.ecdf_utils import (
 )
 
 try:
-    import numba   # pylint: disable=unused-import
+    import numba  # pylint: disable=unused-import
 
     numba_options = [True, False]
 except ImportError:

--- a/arviz/tests/base_tests/test_stats_ecdf_utils.py
+++ b/arviz/tests/base_tests/test_stats_ecdf_utils.py
@@ -109,7 +109,7 @@ def test_get_pointwise_confidence_band(dist, prob, ndraws, num_trials=1_000, see
     ids=["continuous", "continuous default rvs", "discrete"],
 )
 @pytest.mark.parametrize("ndraws", [10_000])
-@pytest.mark.parametrize("method", ["pointwise", "simulated"])
+@pytest.mark.parametrize("method", ["pointwise", "optimized", "simulated"])
 def test_ecdf_confidence_band(dist, rvs, prob, ndraws, method, num_trials=1_000, seed=57):
     """Test test_ecdf_confidence_band."""
     eval_points = np.linspace(*dist.interval(0.99), 10)

--- a/arviz/tests/base_tests/test_stats_ecdf_utils.py
+++ b/arviz/tests/base_tests/test_stats_ecdf_utils.py
@@ -11,7 +11,7 @@ from ...stats.ecdf_utils import (
 )
 
 try:
-    import numba
+    import numba   # pylint: disable=unused-import
 
     numba_options = [True, False]
 except ImportError:


### PR DESCRIPTION
## Description

This pull request adds the optimization method from https://doi.org/10.1007/s11222-022-10090-6 for computing simultaneous ECDF bands and ~switches to using it as the default approach~ uses it as the default approach sometimes based on a heuristic. 

Part of #2309. The changes are non-breaking, since the docstring of `plot_ecdf` intentionally does not document which method is the default.

## Example

```python
import numpy as np
import scipy.stats

import matplotlib.pyplot as plt
import arviz as az

np.random.seed(0)

dist = scipy.stats.expon()
x = dist.rvs(1000)

eval_points = np.linspace(0, 10, 100)

fig, axs = plt.subplots(2, 1, figsize=(8, 5))
%time az.plot_ecdf(x, ax=axs[0], eval_points=eval_points, confidence_bands=True, cdf=dist.cdf, difference=True)
%time az.plot_ecdf(x, ax=axs[1], eval_points=eval_points, confidence_bands='simulated', cdf=dist.cdf, difference=True)
axs[0].set_title('Optimized confidence bands')
axs[1].set_title('Simulated confidence bands')
plt.tight_layout()
```

```
CPU times: user 261 ms, sys: 116 μs, total: 261 ms
Wall time: 261 ms
CPU times: user 96.2 ms, sys: 32 μs, total: 96.3 ms
Wall time: 96.3 ms
```

![tmp](https://github.com/user-attachments/assets/dc04e632-40b0-48bf-97ba-50536acbc6f0)

Note that while optimized confidence bands are more stable than simulated, with this implementation they are not necessarily faster. Perhaps that can be improved using Numba.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Does the PR follow [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist)
      PR format?
- [x] Has included a sample plot to visually illustrate the changes? (only for plot-related functions)
- [x] Is the new feature properly documented with an example?
- [x] Does the PR include new or updated tests to cover the new feature (using [pytest fixture pattern](
      https://docs.pytest.org/en/latest/fixture.html#fixture))?
- [x] Is the code style correct (follows pylint and black guidelines)?
- [x] Is the new feature listed in the [New features](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#new-features)
      section of the changelog?

<!-- readthedocs-preview arviz start -->
----
📚 Documentation preview 📚: https://arviz--2368.org.readthedocs.build/en/2368/

<!-- readthedocs-preview arviz end -->