### PR TITLE
make dm-tree optional

### DIFF
--- a/arviz/data/converters.py
+++ b/arviz/data/converters.py
@@ -1,8 +1,11 @@
 """High level conversion functions."""
 
 import numpy as np
-import tree
 import xarray as xr
+try:
+    from tree import is_nested
+except ImportError:
+    is_nested = lambda obj: False
 
 from .base import dict_to_dataset
 from .inference_data import InferenceData
@@ -107,7 +110,7 @@ def convert_to_inference_data(obj, *, group="posterior", coords=None, dims=None,
         dataset = obj.to_dataset()
     elif isinstance(obj, dict):
         dataset = dict_to_dataset(obj, coords=coords, dims=dims)
-    elif tree.is_nested(obj) and not isinstance(obj, (list, tuple)):
+    elif is_nested(obj) and not isinstance(obj, (list, tuple)):
         dataset = dict_to_dataset(obj, coords=coords, dims=dims)
     elif isinstance(obj, np.ndarray):
         dataset = dict_to_dataset({"x": obj}, coords=coords, dims=dims)
@@ -122,7 +125,7 @@ def convert_to_inference_data(obj, *, group="posterior", coords=None, dims=None,
             "xarray dataarray",
             "xarray dataset",
             "dict",
-            "pytree",
+            "pytree (if 'dm-tree' is installed)",
             "netcdf filename",
             "numpy array",
             "pystan fit",

--- a/arviz/data/converters.py
+++ b/arviz/data/converters.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import xarray as xr
+
 try:
     from tree import is_nested
 except ImportError:

--- a/arviz/tests/base_tests/test_data.py
+++ b/arviz/tests/base_tests/test_data.py
@@ -44,6 +44,10 @@ from ..helpers import (  # pylint: disable=unused-import
     models,
 )
 
+# Check if dm-tree is installed
+dm_tree_installed = importlib.util.find_spec("tree") is not None  # pylint: disable=invalid-name
+skip_tests = (not dm_tree_installed) and ("ARVIZ_REQUIRE_ALL_DEPS" not in os.environ)
+
 
 @pytest.fixture(autouse=True)
 def no_remote_data(monkeypatch, tmpdir):
@@ -1076,6 +1080,7 @@ def test_dict_to_dataset():
     assert set(dataset.b.coords) == {"chain", "draw", "c"}
 
 
+@pytest.mark.skipif(skip_tests, reason="test requires dm-tree which is not installed")
 def test_nested_dict_to_dataset():
     datadict = {
         "top": {"a": np.random.randn(100), "b": np.random.randn(1, 100, 10)},

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -15,3 +15,4 @@ sphinx_design
 sphinx-codeautolink>=0.9.0
 jupyter-sphinx
 sphinxcontrib-youtube
+dm-tree>=0.1.8

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -6,3 +6,4 @@ ujson
 dask[distributed]
 zarr>=2.5.0,<3
 xarray-datatree
+dm-tree>=0.1.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ numpy>=1.23.0
 scipy>=1.9.0
 packaging
 pandas>=1.5.0
-dm-tree>=0.1.8
 xarray>=2022.6.0
 h5netcdf>=1.0.2
 typing_extensions>=4.1.0


### PR DESCRIPTION
## Description
`dm-tree` dependency is only used to support pytree objects like nested dicts which 
is not very common and is also very localized in the codebase, being only used via
either `dict_to_dataset` or `from_dict` (both also having the dict->pytree alternative naming).

I would like to keep dependencies for base functionality to something more basic so
we can for example use arviz via pyodide. Also in preparation to `arviz-xyz` refactoring
where anything not required throughout the library is an optional dependency.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [ ] New features are properly documented (with an example if appropriate)?
- [ ] Includes new or updated tests to cover the new feature
- [ ] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->


<!-- readthedocs-preview arviz start -->
----
📚 Documentation preview 📚: https://arviz--2379.org.readthedocs.build/en/2379/

<!-- readthedocs-preview arviz end -->