### PR TITLE
handle python -OO

### DIFF
--- a/arviz/plots/backends/__init__.py
+++ b/arviz/plots/backends/__init__.py
@@ -214,9 +214,9 @@ def _copy_docstring(lib, function):
 
 # TODO: try copying substitutions too, or autoreplace them ourselves
 if output_notebook.__doc__ is not None:  # if run with python -OO, __doc__ is stripped
-    output_notebook.__doc__ += "\n\n" + _copy_docstring("bokeh.plotting", "output_notebook").replace(
-        "|save|", "save"
-    ).replace("|show|", "show")
+    output_notebook.__doc__ += "\n\n" + _copy_docstring(
+        "bokeh.plotting", "output_notebook"
+    ).replace("|save|", "save").replace("|show|", "show")
     output_file.__doc__ += "\n\n" + _copy_docstring("bokeh.plotting", "output_file").replace(
         "|save|", "save"
     ).replace("|show|", "show")

--- a/arviz/plots/backends/__init__.py
+++ b/arviz/plots/backends/__init__.py
@@ -213,10 +213,11 @@ def _copy_docstring(lib, function):
 
 
 # TODO: try copying substitutions too, or autoreplace them ourselves
-output_notebook.__doc__ += "\n\n" + _copy_docstring("bokeh.plotting", "output_notebook").replace(
-    "|save|", "save"
-).replace("|show|", "show")
-output_file.__doc__ += "\n\n" + _copy_docstring("bokeh.plotting", "output_file").replace(
-    "|save|", "save"
-).replace("|show|", "show")
-ColumnDataSource.__doc__ += "\n\n" + _copy_docstring("bokeh.models", "ColumnDataSource")
+if output_notebook.__doc__ is not None:  # if run with python -OO, __doc__ is stripped
+    output_notebook.__doc__ += "\n\n" + _copy_docstring("bokeh.plotting", "output_notebook").replace(
+        "|save|", "save"
+    ).replace("|show|", "show")
+    output_file.__doc__ += "\n\n" + _copy_docstring("bokeh.plotting", "output_file").replace(
+        "|save|", "save"
+    ).replace("|show|", "show")
+    ColumnDataSource.__doc__ += "\n\n" + _copy_docstring("bokeh.models", "ColumnDataSource")


### PR DESCRIPTION
## Description
Resolves the crash described in https://github.com/arviz-devs/arviz/issues/2392, occuring when python -OO strips the  `__doc__` attribute
## Checklist

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)


<!-- readthedocs-preview arviz start -->
----
📚 Documentation preview 📚: https://arviz--2393.org.readthedocs.build/en/2393/

<!-- readthedocs-preview arviz end -->