### PR TITLE
Allow custom groups without warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## Unreleased
 
+### New features
+
 ### Maintenance and fixes
 - Make `arviz.data.generate_dims_coords` handle `dims` and `default_dims` consistently ([2395](https://github.com/arviz-devs/arviz/pull/2395))
+- Only emit a warning for custom groups in `InferenceData` when explicitly requested ([2401](https://github.com/arviz-devs/arviz/pull/2401))
+
+### Documentation
 
 ## v0.20.0 (2024 Sep 28)
 

--- a/arviz/tests/base_tests/test_data.py
+++ b/arviz/tests/base_tests/test_data.py
@@ -938,7 +938,7 @@ class TestInferenceData:  # pylint: disable=too-many-public-methods
         data = np.random.normal(size=(4, 500, 8))
         idata = data_random
         with pytest.warns(UserWarning, match="The group.+not defined in the InferenceData scheme"):
-            idata.add_groups({"new_group": idata.posterior})
+            idata.add_groups({"new_group": idata.posterior}, warn_on_custom_groups=True)
         with pytest.warns(UserWarning, match="the default dims.+will be added automatically"):
             idata.add_groups(constant_data={"a": data[..., 0], "b": data})
         assert idata.new_group.equals(idata.posterior)

--- a/arviz/tests/base_tests/test_data.py
+++ b/arviz/tests/base_tests/test_data.py
@@ -3,6 +3,7 @@
 
 import importlib
 import os
+import warnings
 from collections import namedtuple
 from copy import deepcopy
 from html import escape
@@ -979,8 +980,8 @@ class TestInferenceData:  # pylint: disable=too-many-public-methods
         with pytest.raises(ValueError, match="join must be either"):
             idata.extend(idata2, join="outer")
         idata2.add_groups(new_group=idata2.prior)
-        with pytest.warns(UserWarning):
-            idata.extend(idata2)
+        with pytest.warns(UserWarning, match="new_group"):
+            idata.extend(idata2, warn_on_custom_groups=True)
 
 
 class TestNumpyToDataArray:
@@ -1173,11 +1174,17 @@ def test_bad_inference_data():
         InferenceData(posterior=[1, 2, 3])
 
 
-def test_inference_data_other_groups():
+@pytest.mark.parametrize("warn", [True, False])
+def test_inference_data_other_groups(warn):
     datadict = {"a": np.random.randn(100), "b": np.random.randn(1, 100, 10)}
     dataset = convert_to_dataset(datadict, coords={"c": np.arange(10)}, dims={"b": ["c"]})
-    with pytest.warns(UserWarning, match="not.+in.+InferenceData scheme"):
-        idata = InferenceData(other_group=dataset)
+    if warn:
+        with pytest.warns(UserWarning, match="not.+in.+InferenceData scheme"):
+            idata = InferenceData(other_group=dataset, warn_on_custom_groups=True)
+    else:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            idata = InferenceData(other_group=dataset, warn_on_custom_groups=False)
     fails = check_multiple_attrs({"other_group": ["a", "b"]}, idata)
     assert not fails
 


### PR DESCRIPTION
## Description
Only emit a warning for custom groups when explicitly requested.

As InferenceData gets more uses, data related to the model but not specifically defined
in the schema is also stored as independent groups, which is perfectly fine and doesn't break
anything but it is annoying to get all the warnings or having to silence them constantly.
Moreover, this is set to not happen in `arviz-base` so it will also align behaviour.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [ ] New features are properly documented (with an example if appropriate)?
- [ ] Includes new or updated tests to cover the new feature
- [ ] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->


<!-- readthedocs-preview arviz start -->
----
📚 Documentation preview 📚: https://arviz--2401.org.readthedocs.build/en/2401/

<!-- readthedocs-preview arviz end -->