### PR TITLE
Fixes #2117: Modified transform parameter in plot_forest to accept dictionary values

### DIFF
--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -2086,3 +2086,21 @@ def test_plot_bf():
     bf_dict1, _ = plot_bf(idata, prior=np.random.normal(0, 10, 5000), var_name="a", ref_val=0)
     assert bf_dict0["BF10"] > bf_dict0["BF01"]
     assert bf_dict1["BF10"] < bf_dict1["BF01"]
+
+
+def test_plot_forest_with_transform():
+    """Test if plot_forest runs successfully with a transform dictionary."""
+    data = xr.Dataset(
+        {
+            "var1": (["chain", "draw"], np.array([[1, 2, 3], [4, 5, 6]])),
+            "var2": (["chain", "draw"], np.array([[7, 8, 9], [10, 11, 12]])),
+        },
+        coords={"chain": [0, 1], "draw": [0, 1, 2]},
+    )
+    transform_dict = {
+        "var1": lambda x: x + 1,
+        "var2": lambda x: x * 2,
+    }
+
+    axes = plot_forest(data, transform=transform_dict, show=False)
+    assert axes is not None

--- a/examples/matplotlib/mpl_plot_forest_transform.py
+++ b/examples/matplotlib/mpl_plot_forest_transform.py
@@ -1,0 +1,38 @@
+"""Forest Plot with transforms
+==============================
+_gallery_category: Distributions
+"""
+
+import arviz as az
+import matplotlib.pyplot as plt
+import numpy as np
+
+non_centered_data = az.load_arviz_data("non_centered_eight")
+
+
+def log_transform(data):
+    """Apply log transformation, avoiding log(0)."""
+    return np.log(np.maximum(data, 1e-8))
+
+
+def exp_transform(data):
+    """Apply exponential transformation."""
+    return np.exp(data)
+
+
+def center_data(data):
+    """Center the data by subtracting the mean."""
+    return data - np.mean(data)
+
+
+axes = az.plot_forest(
+    non_centered_data,
+    kind="forestplot",
+    var_names=["theta", "mu", "tau"],
+    filter_vars=None,
+    combined=True,
+    figsize=(9, 7),
+    transform={"theta": center_data, "mu": exp_transform, "tau": log_transform},
+)
+axes[0].set_title("Estimated theta for 8 schools model")
+plt.show()


### PR DESCRIPTION
Closes #2117 

#### Key Features:  
- **Callable `transform`**: Applies a single transformation to all variables.  
  ```python
  az.plot_forest(data, transform=lambda x: x ** 2)
- **Dictionary `transform`**:   Allows variable-specific transformations.
  ```python
  az.plot_forest(data, transform={"theta": np.exp, "mu": np.log})

#### Additional Changes:

- Added test cases to validate the feature.
- Documentation updated to follow the NumPy style guide.
- Example script added to demonstrate usage
