### PR TITLE
WIP: Add kwargs to InferenceData.to_netcdf()

### DIFF
--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -505,10 +505,10 @@ class InferenceData(Mapping[str, xr.Dataset]):
                 filename, mode=mode, engine=engine, group=base_group
             )
             mode = "a"
-        
+
         # add items to kwargs corresponding directly to parameters of this method
         kwargs["engine"] = engine
-        
+    
         # get encoding dict that may have been passed in
         try:
             encoding_kw2 = kwargs["encoding"]
@@ -523,7 +523,7 @@ class InferenceData(Mapping[str, xr.Dataset]):
 
             for group in groups:
                 data = getattr(self, group)
-                
+
                 # define encoding kwargs according to compress
                 # but only for compressible dtypes
                 if compress:
@@ -534,7 +534,7 @@ class InferenceData(Mapping[str, xr.Dataset]):
                     }
                 else:
                     encoding_kw1 = {}
-                
+
                 # merge the two dicts-of-dicts
                 encoding_kw_merged = {}
                 for var_name, kw1 in encoding_kw1.items():

--- a/arviz/tests/base_tests/test_data.py
+++ b/arviz/tests/base_tests/test_data.py
@@ -1482,6 +1482,15 @@ class TestDataNetCDF:
         assert os.path.exists(filepath)
         os.remove(filepath)
         assert not os.path.exists(filepath)
+        
+    def test_to_netcdf_kwargs(self):
+        """Tests to verify that passing kwargs to `InferenceData.to_netcdf()`
+        works as intended"""
+        pass # TODO
+        # 1) define an InferenceData object (e.g. from file)
+        # 2) define different sets of `**kwargs` to pass
+        # 3) use inference_data.to_netcdf(filepath,**kwargs)
+        # 4) test these make it through to `data.to_netcdf()` as intended - TODO how?
 
 
 class TestJSON:

--- a/arviz/tests/base_tests/test_data.py
+++ b/arviz/tests/base_tests/test_data.py
@@ -1482,11 +1482,11 @@ class TestDataNetCDF:
         assert os.path.exists(filepath)
         os.remove(filepath)
         assert not os.path.exists(filepath)
-        
+
     def test_to_netcdf_kwargs(self):
         """Tests to verify that passing kwargs to `InferenceData.to_netcdf()`
         works as intended"""
-        pass # TODO
+        True # TODO
         # 1) define an InferenceData object (e.g. from file)
         # 2) define different sets of `**kwargs` to pass
         # 3) use inference_data.to_netcdf(filepath,**kwargs)


### PR DESCRIPTION
Relates to #2298, with solution broadly along the lines of that sketched out in the issue.

Added `**kwargs` to `InferenceData.to_netcdf()` method, to allow any of the parameters that can be passed to [`xarray.Dataset.to_netcdf()`](https://docs.xarray.dev/en/latest/generated/xarray.Dataset.to_netcdf.html) to get passed through.

E.g. for my usage case I define an `encoding={'var_A' : {"dtype": "int16", "scale_factor" : 0.1}}` dict, so that `var_A` samples get stored via 16-bit integers and to 1 decimal place precision, to economise on file size but with an inconsequential loss of precision. Note this would be done for `var_A` in any group in which it appears, e.g. both `posterior` and `prior` groups if present.

I've put in a placeholder for where a new unittest could be added, but am not so confident in defining this. What I envisage, which I've tested via a seperate script my end, is the following:
* Load data to define an `InferenceData` instance, reading from `netcdf` file as I can see other unittests do already
* Define some customisation e.g. `encoding` settings for a couple of the RVs in the model to which the data relates
* Write to a new `netcdf` file but passing `encoding` (and/or other params that would alter the behaviour of `Dataset.to_netcdf`)
* Read back in from the 2nd file and verify that approximately the same data is recovered but with the expected loss of precision

Help welcome in setting up the latter! It would also be worthwhile verifying via tests that the handling code I've included (populating the `kwargs` dict based on `compress` and `engine` parameters per previous) is working as intended and in a backwards compatible manner; it should! Perhaps existing tests are adequate to prove this though?

## Checklist

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [n/a] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [n/a] New features are properly documented (with an example if appropriate)?
- [ ] Includes new or updated tests to cover the new feature
- [ ] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)


<!-- readthedocs-preview arviz start -->
----
📚 Documentation preview 📚: https://arviz--2410.org.readthedocs.build/en/2410/

<!-- readthedocs-preview arviz end -->