### PR TITLE
`plot_hdi` raise exception when `x` is string (#2412)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Only emit a warning for custom groups in `InferenceData` when explicitly requested ([2401](https://github.com/arviz-devs/arviz/pull/2401))
 - Splits Bayes Factor computation out from `az.plot_bf` into `az.bayes_factor` ([2402](https://github.com/arviz-devs/arviz/issues/2402))
 - Update `method="sd"` of `mcse` to not use normality assumption ([2167](https://github.com/arviz-devs/arviz/pull/2167)) 
+- Add exception in `az.plot_hdi` for `x` of type `str` ([2413](https://github.com/arviz-devs/arviz/pull/2413))
 
 ### Documentation
 - Add example of ECDF comparison plot to gallery ([2178](https://github.com/arviz-devs/arviz/pull/2178))

--- a/arviz/plots/hdiplot.py
+++ b/arviz/plots/hdiplot.py
@@ -135,7 +135,9 @@ def plot_hdi(
 
     x = np.asarray(x)
     x_shape = x.shape
-
+    
+    if isinstance(x[0], str):
+        raise TypeError("'x' type string not supported.")
     if y is None and hdi_data is None:
         raise ValueError("One of {y, hdi_data} is required")
     if hdi_data is not None and y is not None:

--- a/arviz/plots/hdiplot.py
+++ b/arviz/plots/hdiplot.py
@@ -138,7 +138,7 @@ def plot_hdi(
 
     if isinstance(x[0], str):
         raise NotImplementedError(
-            "The `arviz.plot.hdi()` function does not support categorical data. "
+            "The `arviz.plot_hdi()` function does not support categorical data. "
             "Consider using `arviz.plot_forest()`."
         )
     if y is None and hdi_data is None:

--- a/arviz/plots/hdiplot.py
+++ b/arviz/plots/hdiplot.py
@@ -138,8 +138,8 @@ def plot_hdi(
 
     if isinstance(x[0], str):
         raise NotImplementedError(
-            "The arviz.plot_hdi() function does not support categorical data. "
-            "Consider using arviz.plot_forest()."
+            "The `arviz.plot_hdi()` function does not support categorical data. "
+            "Consider using `arviz.plot_forest()`."
         )
     if y is None and hdi_data is None:
         raise ValueError("One of {y, hdi_data} is required")

--- a/arviz/plots/hdiplot.py
+++ b/arviz/plots/hdiplot.py
@@ -138,8 +138,8 @@ def plot_hdi(
 
     if isinstance(x[0], str):
         raise NotImplementedError(
-            "The `arviz.plot_hdi()` function does not support categorical data. "
-            "Consider using `arviz.plot_forest()`."
+            "The arviz.plot_hdi() function does not support categorical data. "
+            "Consider using arviz.plot_forest()."
         )
     if y is None and hdi_data is None:
         raise ValueError("One of {y, hdi_data} is required")

--- a/arviz/plots/hdiplot.py
+++ b/arviz/plots/hdiplot.py
@@ -137,7 +137,10 @@ def plot_hdi(
     x_shape = x.shape
 
     if isinstance(x[0], str):
-        raise TypeError("'x' type string not supported.")
+        raise NotImplementedError(
+            "The `arviz.plot.hdi()` function does not support categorical data. "
+            "Consider using `arviz.plot_forest()`."
+        )
     if y is None and hdi_data is None:
         raise ValueError("One of {y, hdi_data} is required")
     if hdi_data is not None and y is not None:

--- a/arviz/plots/hdiplot.py
+++ b/arviz/plots/hdiplot.py
@@ -135,7 +135,7 @@ def plot_hdi(
 
     x = np.asarray(x)
     x_shape = x.shape
-    
+
     if isinstance(x[0], str):
         raise TypeError("'x' type string not supported.")
     if y is None and hdi_data is None:

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -1235,6 +1235,7 @@ def test_plot_hdi_dataset_error(models):
     with pytest.raises(ValueError, match="Only single variable Dataset"):
         plot_hdi(np.arange(8), hdi_data=hdi_data)
 
+
 def test_plot_hdi_string_error():
     """Check x as type string raises an error."""
     x_data = ["a", "b", "c", "d"]
@@ -1242,6 +1243,7 @@ def test_plot_hdi_string_error():
     hdi_data = hdi(y_data)
     with pytest.raises(TypeError, match="'x' type string not supported."):
         plot_hdi(x=x_data, y=y_data, hdi_data=hdi_data)
+
 
 def test_plot_hdi_datetime_error():
     """Check x as datetime raises an error."""

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -1244,7 +1244,7 @@ def test_plot_hdi_string_error():
     with pytest.raises(
         NotImplementedError,
         match=(
-            "The `arviz.plot.hdi()` function does not support categorical data. "
+            "The `arviz.plot_hdi()` function does not support categorical data. "
             "Consider using `arviz.plot_forest()`."
         ),
     ):

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -3,6 +3,7 @@
 # pylint: disable=redefined-outer-name,too-many-lines
 import os
 from copy import deepcopy
+import re
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -11,6 +12,7 @@ from matplotlib import animation
 from pandas import DataFrame
 from scipy.stats import gaussian_kde, norm
 import xarray as xr
+
 
 from ...data import from_dict, load_arviz_data
 from ...plots import (
@@ -1243,10 +1245,12 @@ def test_plot_hdi_string_error():
     hdi_data = hdi(y_data)
     with pytest.raises(
         NotImplementedError,
-        match=re.escape((
-            "The `arviz.plot_hdi()` function does not support categorical data. "
-            "Consider using `arviz.plot_forest()`."
-        )),
+        match=re.escape(
+            (
+                "The `arviz.plot_hdi()` function does not support categorical data. "
+                "Consider using `arviz.plot_forest()`."
+            )
+        ),
     ):
         plot_hdi(x=x_data, y=y_data, hdi_data=hdi_data)
 

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -2,23 +2,22 @@
 
 # pylint: disable=redefined-outer-name,too-many-lines
 import os
-from copy import deepcopy
 import re
+from copy import deepcopy
 
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
+import xarray as xr
 from matplotlib import animation
 from pandas import DataFrame
 from scipy.stats import gaussian_kde, norm
-import xarray as xr
-
 
 from ...data import from_dict, load_arviz_data
 from ...plots import (
     plot_autocorr,
-    plot_bpv,
     plot_bf,
+    plot_bpv,
     plot_compare,
     plot_density,
     plot_dist,
@@ -45,20 +44,20 @@ from ...plots import (
     plot_ts,
     plot_violin,
 )
+from ...plots.dotplot import wilkinson_algorithm
+from ...plots.plot_utils import plot_point_interval
 from ...rcparams import rc_context, rcParams
 from ...stats import compare, hdi, loo, waic
 from ...stats.density_utils import kde as _kde
-from ...utils import _cov, BehaviourChangeWarning
-from ...plots.plot_utils import plot_point_interval
-from ...plots.dotplot import wilkinson_algorithm
+from ...utils import BehaviourChangeWarning, _cov
 from ..helpers import (  # pylint: disable=unused-import
+    RandomVariableTestClass,
     create_model,
     create_multidimensional_model,
     does_not_warn,
     eight_schools_params,
     models,
     multidim_models,
-    RandomVariableTestClass,
 )
 
 rcParams["data.load"] = "eager"

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -1241,7 +1241,13 @@ def test_plot_hdi_string_error():
     x_data = ["a", "b", "c", "d"]
     y_data = np.random.normal(0, 5, (1, 200, len(x_data)))
     hdi_data = hdi(y_data)
-    with pytest.raises(TypeError, match="'x' type string not supported."):
+    with pytest.raises(
+        NotImplementedError,
+        match=(
+            "The `arviz.plot.hdi()` function does not support categorical data. "
+            "Consider using `arviz.plot_forest()`."
+        ),
+    ):
         plot_hdi(x=x_data, y=y_data, hdi_data=hdi_data)
 
 

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -1235,6 +1235,13 @@ def test_plot_hdi_dataset_error(models):
     with pytest.raises(ValueError, match="Only single variable Dataset"):
         plot_hdi(np.arange(8), hdi_data=hdi_data)
 
+def test_plot_hdi_string_error():
+    """Check x as type string raises an error."""
+    x_data = ["a", "b", "c", "d"]
+    y_data = np.random.normal(0, 5, (1, 200, len(x_data)))
+    hdi_data = hdi(y_data)
+    with pytest.raises(TypeError, match="'x' type string not supported."):
+        plot_hdi(x=x_data, y=y_data, hdi_data=hdi_data)
 
 def test_plot_hdi_datetime_error():
     """Check x as datetime raises an error."""

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -1244,8 +1244,8 @@ def test_plot_hdi_string_error():
     with pytest.raises(
         NotImplementedError,
         match=(
-            "The `arviz.plot_hdi()` function does not support categorical data. "
-            "Consider using `arviz.plot_forest()`."
+            "The arviz.plot_hdi() function does not support categorical data. "
+            "Consider using arviz.plot_forest()."
         ),
     ):
         plot_hdi(x=x_data, y=y_data, hdi_data=hdi_data)

--- a/arviz/tests/base_tests/test_plots_matplotlib.py
+++ b/arviz/tests/base_tests/test_plots_matplotlib.py
@@ -1243,10 +1243,10 @@ def test_plot_hdi_string_error():
     hdi_data = hdi(y_data)
     with pytest.raises(
         NotImplementedError,
-        match=(
-            "The arviz.plot_hdi() function does not support categorical data. "
-            "Consider using arviz.plot_forest()."
-        ),
+        match=re.escape((
+            "The `arviz.plot_hdi()` function does not support categorical data. "
+            "Consider using `arviz.plot_forest()`."
+        )),
     ):
         plot_hdi(x=x_data, y=y_data, hdi_data=hdi_data)
 


### PR DESCRIPTION
## Description
It does not seem that categorical (str) type x values are supported by `az.plot_hdi` but the documentation for the function is not clear here and no exception is raised if x is type str (i.e. in the case of an ANOVA type model). Here, I've contributed the following:
- A TypeError if x is a str to `plot_hdi`
- Added test to `test_plots_matplotlib.py` following the example of #2016. 

For now, I prefix the PR with [WIP] to invite input on whether or not to include this lack of support for str type x in the function documentation -- and because this is my first go at contributing to a repository of this caliber...

Fixes #2412 

## Checklist

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes new or updated tests to cover the new feature
- [x] Code style correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

## History

- 2025-01-19 21:18: My own test was failing, I had misplaced the `raise` statement. Relocated & amended the commit with force-push to keep a concise history.

<!-- readthedocs-preview arviz start -->
----
📚 Documentation preview 📚: https://arviz--2413.org.readthedocs.build/en/2413/

<!-- readthedocs-preview arviz end -->