### PR TITLE
Refactored stats_refitting.py for better robustness and readability

### DIFF
--- a/arviz/stats/stats_refitting.py
+++ b/arviz/stats/stats_refitting.py
@@ -13,6 +13,20 @@ __all__ = ["reloo"]
 _log = logging.getLogger(__name__)
 
 
+def _get_scale_value(scale):
+    """Convert a scale string into its corresponding numeric factor."""
+    scale = scale.lower()
+    mapping = {
+        "deviance": -2,
+        "log": 1,
+        "negative_log": -1,
+    }
+    try:
+        return mapping[scale]
+    except KeyError:
+        raise ValueError(f"Unsupported scale '{scale}'. Valid options are: {list(mapping.keys())}")
+
+
 def reloo(wrapper, loo_orig=None, k_thresh=0.7, scale=None, verbose=True):
     """Recalculate exact Leave-One-Out cross validation refitting where the approximation fails.
 
@@ -72,46 +86,52 @@ def reloo(wrapper, loo_orig=None, k_thresh=0.7, scale=None, verbose=True):
     Sampling wrappers are an experimental feature in a very early stage. Please use them
     with caution.
     """
+    # Ensure the wrapper implements all required methods
     required_methods = ("sel_observations", "sample", "get_inference_data", "log_likelihood__i")
-    not_implemented = wrapper.check_implemented_methods(required_methods)
-    if not_implemented:
+    missing_methods = wrapper.check_implemented_methods(required_methods)
+    if missing_methods:
         raise TypeError(
             "Passed wrapper instance does not implement all methods required for reloo "
-            f"to work. Check the documentation of SamplingWrapper. {not_implemented} must be "
-            "implemented and were not found."
+            f"to work. Missing implementations: {missing_methods}"
         )
+
+
     if loo_orig is None:
         loo_orig = loo(wrapper.idata_orig, pointwise=True, scale=scale)
+
     loo_refitted = loo_orig.copy()
     khats = loo_refitted.pareto_k
     loo_i = loo_refitted.loo_i
-    scale = loo_orig.scale
+    scale = loo_orig.scale 
+    scale_value = _get_scale_value(scale)
 
-    if scale.lower() == "deviance":
-        scale_value = -2
-    elif scale.lower() == "log":
-        scale_value = 1
-    elif scale.lower() == "negative_log":
-        scale_value = -1
+
     lppd_orig = loo_orig.p_loo + loo_orig.elpd_loo / scale_value
     n_data_points = loo_orig.n_data_points
 
     if verbose:
         warnings.warn("reloo is an experimental and untested feature", UserWarning)
 
-    if np.any(khats > k_thresh):
-        for idx in np.argwhere(khats.values > k_thresh):
+    #find the indices where the Pareto k exceeds the threshold
+    problematic_indices = np.flatnonzero(khats.values > k_thresh)
+    if problematic_indices.size:
+        for idx in problematic_indices:
             if verbose:
                 _log.info("Refitting model excluding observation %d", idx)
+            #exclude the problematic observation and sample with the new dataset
             new_obs, excluded_obs = wrapper.sel_observations(idx)
             fit = wrapper.sample(new_obs)
             idata_idx = wrapper.get_inference_data(fit)
-            log_like_idx = wrapper.log_likelihood__i(excluded_obs, idata_idx).values.flatten()
-            loo_lppd_idx = scale_value * _logsumexp(log_like_idx, b_inv=len(log_like_idx))
+            #compute exact log likelihood for the excluded observation
+            log_like = wrapper.log_likelihood__i(excluded_obs, idata_idx).values.flatten()
+            loo_exact = scale_value * _logsumexp(log_like, b_inv=len(log_like))
+            #update the LOO results: set the Pareto k to 0 and replace loo_i with exact value
             khats[idx] = 0
-            loo_i[idx] = loo_lppd_idx
+            loo_i[idx] = loo_exact
+
+        #update the overall loo_refitted object with refitted values
         loo_refitted.elpd_loo = loo_i.values.sum()
-        loo_refitted.se = (n_data_points * np.var(loo_i.values)) ** 0.5
+        loo_refitted.se = np.sqrt(n_data_points * np.var(loo_i.values))
         loo_refitted.p_loo = lppd_orig - loo_refitted.elpd_loo / scale_value
         return loo_refitted
     else:


### PR DESCRIPTION
Refactored the code
1) core logic is kept same.
2) replaced np.argwhere with np.flatnonzero
3) _get_scale_value encapsulates the logic for converting the scale string

## Description
<!--
Thank you so much for your PR! To help us review your contribution, please consider the following points:

- The PR title should summarize the changes, for example "Add new group argument for the pair plot".
  Avoid non-descriptive titles such as "Addresses issue #348".

- The description should provide at least 1-2 sentences describing the pull request in detail and
  link to any relevant issues.

- Please prefix the title of incomplete contributions with [WIP] (to indicate a work in
  progress). WIPs may be useful to (1) indicate you are working on something to avoid
  duplicated work, (2) request broad review of functionality or API, or (3) seek collaborators. -->

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [ ] New features are properly documented (with an example if appropriate)?
- [ ] Includes new or updated tests to cover the new feature
- [ ] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
