### PR TITLE
Use datatree from xarray and update example to latest einstats

### DIFF
--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -550,7 +550,9 @@ class InferenceData(Mapping[str, xr.Dataset]):
         ----------
         datatree : DataTree
         """
-        return InferenceData(**{group: child.to_dataset() for group, child in datatree.children.items()})
+        return InferenceData(
+            **{group: child.to_dataset() for group, child in datatree.children.items()}
+        )
 
     def to_dict(self, groups=None, filter_groups=None):
         """Convert InferenceData to a dictionary following xarray naming conventions.

--- a/arviz/data/inference_data.py
+++ b/arviz/data/inference_data.py
@@ -532,24 +532,25 @@ class InferenceData(Mapping[str, xr.Dataset]):
         return filename
 
     def to_datatree(self):
-        """Convert InferenceData object to a :class:`~datatree.DataTree`."""
+        """Convert InferenceData object to a :class:`~xarray.DataTree`."""
         try:
-            from datatree import DataTree
-        except ModuleNotFoundError as err:
-            raise ModuleNotFoundError(
-                "datatree must be installed in order to use InferenceData.to_datatree"
+            from xarray import DataTree
+        except ImportError as err:
+            raise ImportError(
+                "xarray must be have DataTree in order to use InferenceData.to_datatree. "
+                "Update to xarray>=2024.11.0"
             ) from err
         return DataTree.from_dict({group: ds for group, ds in self.items()})
 
     @staticmethod
     def from_datatree(datatree):
-        """Create an InferenceData object from a :class:`~datatree.DataTree`.
+        """Create an InferenceData object from a :class:`~xarray.DataTree`.
 
         Parameters
         ----------
         datatree : DataTree
         """
-        return InferenceData(**{group: sub_dt.to_dataset() for group, sub_dt in datatree.items()})
+        return InferenceData(**{group: child.to_dataset() for group, child in datatree.children.items()})
 
     def to_dict(self, groups=None, filter_groups=None):
         """Convert InferenceData to a dictionary following xarray naming conventions.
@@ -1531,9 +1532,8 @@ class InferenceData(Mapping[str, xr.Dataset]):
             import xarray as xr
             from xarray_einstats.stats import XrDiscreteRV
             from scipy.stats import poisson
-            dist = XrDiscreteRV(poisson)
-            log_lik = xr.Dataset()
-            log_lik["home_points"] = dist.logpmf(obs["home_points"], np.exp(post["atts"]))
+            dist = XrDiscreteRV(poisson, np.exp(post["atts"]))
+            log_lik = dist.logpmf(obs["home_points"]).to_dataset(name="home_points")
             idata2.add_groups({"log_likelihood": log_lik})
             idata2
 

--- a/arviz/data/io_datatree.py
+++ b/arviz/data/io_datatree.py
@@ -4,7 +4,7 @@ from .inference_data import InferenceData
 
 
 def to_datatree(data):
-    """Convert InferenceData object to a :class:`~datatree.DataTree`.
+    """Convert InferenceData object to a :class:`~xarray.DataTree`.
 
     Parameters
     ----------
@@ -14,7 +14,7 @@ def to_datatree(data):
 
 
 def from_datatree(datatree):
-    """Create an InferenceData object from a :class:`~datatree.DataTree`.
+    """Create an InferenceData object from a :class:`~xarray.DataTree`.
 
     Parameters
     ----------

--- a/arviz/tests/base_tests/test_data.py
+++ b/arviz/tests/base_tests/test_data.py
@@ -1501,10 +1501,6 @@ class TestJSON:
         assert not os.path.exists(filepath)
 
 
-@pytest.mark.skipif(
-    not (importlib.util.find_spec("datatree") or "ARVIZ_REQUIRE_ALL_DEPS" in os.environ),
-    reason="test requires xarray-datatree library",
-)
 class TestDataTree:
     def test_datatree(self):
         idata = load_arviz_data("centered_eight")

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -115,6 +115,7 @@ numpydoc_xref_ignore = {
 numpydoc_xref_aliases = {
     "DataArray": ":class:`~xarray.DataArray`",
     "Dataset": ":class:`~xarray.Dataset`",
+    "DataTree": ":class:`~xarray.DataTree`",
     "Labeller": ":ref:`Labeller <labeller_api>`",
     "ndarray": ":class:`~numpy.ndarray`",
     "InferenceData": ":class:`~arviz.InferenceData`",

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -5,5 +5,5 @@ contourpy
 ujson
 dask[distributed]
 zarr>=2.5.0,<3
-xarray-datatree
+xarray>=2024.11.0
 dm-tree>=0.1.8


### PR DESCRIPTION
## Description
Fix an example that was broken with the changes in xarray-einstats
to support preliz and the new scipy distributions
and have `to/from_datatree` methods use xarray instead of xarray-datatree discontinued library.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [ ] New features are properly documented (with an example if appropriate)?
- [ ] Includes new or updated tests to cover the new feature
- [ ] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->


<!-- readthedocs-preview arviz start -->
----
📚 Documentation preview 📚: https://arviz--2458.org.readthedocs.build/en/2458/

<!-- readthedocs-preview arviz end -->