### PR TITLE
fix for numpyro potential energy sign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Maintenance and fixes
 - Fix numpyro jax incompatibility. ([2465](https://github.com/arviz-devs/arviz/pull/2465))
 - Avoid closing unloaded files in `from_netcdf()` ([2463](https://github.com/arviz-devs/arviz/issues/2463))
+- Fix sign error in lp parsed in from_numpyro ([2468](https://github.com/arviz-devs/arviz/issues/2468))
 
 ### Deprecation
 

--- a/arviz/data/io_numpyro.py
+++ b/arviz/data/io_numpyro.py
@@ -241,9 +241,14 @@ class NumPyroConverter:
                 continue
             name = rename_key.get(stat, stat)
             value = value.copy()
-            data[name] = value
+            if stat == "potential_energy":
+                data[name] = -value
+            else:
+                data[name] = value
             if stat == "num_steps":
                 data["tree_depth"] = np.log2(value).astype(int) + 1
+            if stat == "potential_energy":
+                data[name] = -value
         return dict_to_dataset(
             data,
             library=self.numpyro,

--- a/arviz/data/io_numpyro.py
+++ b/arviz/data/io_numpyro.py
@@ -247,8 +247,6 @@ class NumPyroConverter:
                 data[name] = value
             if stat == "num_steps":
                 data["tree_depth"] = np.log2(value).astype(int) + 1
-            if stat == "potential_energy":
-                data[name] = -value
         return dict_to_dataset(
             data,
             library=self.numpyro,

--- a/arviz/tests/external_tests/test_data_numpyro.py
+++ b/arviz/tests/external_tests/test_data_numpyro.py
@@ -47,12 +47,7 @@ class TestDataNumPyro:
         return predictions
 
     def get_inference_data(
-        self,
-        data,
-        eight_schools_params,
-        predictions_data,
-        predictions_params,
-        infer_dims=False,
+        self, data, eight_schools_params, predictions_data, predictions_params, infer_dims=False
     ):
         posterior_samples = data.obj.get_samples()
         model = data.obj.sampler.model
@@ -63,11 +58,7 @@ class TestDataNumPyro:
             PRNGKey(2), eight_schools_params["J"], eight_schools_params["sigma"]
         )
         dims = {"theta": ["school"], "eta": ["school"], "obs": ["school"]}
-        pred_dims = {
-            "theta": ["school_pred"],
-            "eta": ["school_pred"],
-            "obs": ["school_pred"],
-        }
+        pred_dims = {"theta": ["school_pred"], "eta": ["school_pred"], "obs": ["school_pred"]}
         if infer_dims:
             dims = None
             pred_dims = None
@@ -170,10 +161,7 @@ class TestDataNumPyro:
             coords={"school": np.arange(eight_schools_params["J"])},
             dims={"theta": ["school"], "eta": ["school"]},
         )
-        test_dict = {
-            "posterior_predictive": ["obs"],
-            "prior": ["mu", "tau", "eta", "obs"],
-        }
+        test_dict = {"posterior_predictive": ["obs"], "prior": ["mu", "tau", "eta", "obs"]}
         fails = check_multiple_attrs(test_dict, idata)
         assert not fails, f"prior and posterior_predictive: {fails}"
 

--- a/arviz/tests/external_tests/test_data_numpyro.py
+++ b/arviz/tests/external_tests/test_data_numpyro.py
@@ -1,4 +1,4 @@
-# pylint: disable=no-member, invalid-name, redefined-outer-name
+# pylint: disable=no-member, invalid-name, redefined-outer-name, too-many-public-methods
 from collections import namedtuple
 import numpy as np
 import pytest


### PR DESCRIPTION
Closes https://github.com/arviz-devs/arviz/issues/2468 by flipping the sign of "potential_energy" when renaming to `lp`.

## Checklist

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes new or updated tests to cover the new feature
- [x] Code style  correct (follows pylint and black guidelines)
- [x] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)




<!-- readthedocs-preview arviz start -->
----
📚 Documentation preview 📚: https://arviz--2470.org.readthedocs.build/en/2470/

<!-- readthedocs-preview arviz end -->