### PR TITLE
fix minor typing issue in `stats.stats.compare`

### DIFF
--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -251,11 +251,11 @@ def compare(
             {"type": "ineq", "fun": np.sum},
         ]
 
-        weights = minimize(
+        minimize_result = minimize(
             fun=log_score, x0=theta, jac=gradient, bounds=bounds, constraints=constraints
         )
 
-        weights = w_fuller(weights["x"])
+        weights = w_fuller(minimize_result["x"])
         ses = ics["se"]
 
     elif method.lower() == "bb-pseudo-bma":


### PR DESCRIPTION
## Description
I noticed in https://github.com/scipy/scipy-stubs/pull/881#issuecomment-3287359942 that there's a minor mypy issue in `arviz.stats.stats.compare` where the `weights` name is used for multiple types. That's affects how mypy infers the `weights` type as, which is what *eventually* led to these two reported mypy errors. As you can see, the error messages are rather confusing, and are reported at a different location. So I figured I'd spare you the debugging effort, and might as well fix it myself 🤷🏻 

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [ ] New features are properly documented (with an example if appropriate)?
- [ ] Includes new or updated tests to cover the new feature
- [ ] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->


<!-- readthedocs-preview arviz start -->
----
📚 Documentation preview 📚: https://arviz--2477.org.readthedocs.build/en/2477/

<!-- readthedocs-preview arviz end -->