### PR TITLE
Fix typo for forest plot docs

### DIFF
--- a/arviz/plots/forestplot.py
+++ b/arviz/plots/forestplot.py
@@ -51,7 +51,7 @@ def plot_forest(
     data : InferenceData
         Any object that can be converted to an :class:`arviz.InferenceData` object
         Refer to documentation of :func:`arviz.convert_to_dataset` for details.
-    kind : {"foresplot", "ridgeplot"}, default "forestplot"
+    kind : {"forestplot", "ridgeplot"}, default "forestplot"
         Specify the kind of plot:
 
         * The ``kind="forestplot"`` generates credible intervals, where the central points are the


### PR DESCRIPTION
## Description
Fixes the typo in `plot_forest()` docs. Resolves [#2472](https://github.com/arviz-devs/arviz/issues/2472).

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Code style  correct (follows pylint and black guidelines)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->


<!-- readthedocs-preview arviz start -->
----
📚 Documentation preview 📚: https://arviz--2479.org.readthedocs.build/en/2479/

<!-- readthedocs-preview arviz end -->