### PR TITLE
Added a NaN check in dotplot.py to avoid a deadloop in the matplot backend

### DIFF
--- a/arviz/plots/dotplot.py
+++ b/arviz/plots/dotplot.py
@@ -1,5 +1,5 @@
 """Plot distribution as dot plot or quantile dot plot."""
-import warnings
+
 import numpy as np
 
 
@@ -149,6 +149,7 @@ def plot_dot(
         raise ValueError("marker argument is valid only for matplotlib backend")
 
     values = np.ravel(values)
+    values = values[np.isfinite(values)]
     values.sort()
 
     if hdi_prob is None:
@@ -194,11 +195,6 @@ def plot_dot(
     backend = backend.lower()
 
     plot = get_plotting_function("plot_dot", "dotplot", backend)
-    # Check for NaN values in the values array
-    if np.any(np.isnan(values)):
-        values = values[~np.isnan(values)]
-        dot_plot_args["values"] = values
-        warnings.warn("NaN values detected. Only graphing non NaN values")
     ax = plot(**dot_plot_args)
 
     return ax


### PR DESCRIPTION
## Description
In the dotplot.py file I added a check to see if the values array has any NaNs and removed them locally if it does. Reasoning for this is because the backend matplot dot_plot function would get a NaN binwidth causing a deadloop.
<img width="638" height="549" alt="Screenshot 2025-10-01 140325" src="https://github.com/user-attachments/assets/aa267e60-35e3-4934-944c-98c702d98005" />
```import arviz
from numpy import nan

arviz.plot_dot([0.81449801, 0.8748649 ,        nan,        nan,        nan], show=False)
```
The above plot uses this code
closes #2471

## Checklist

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [x] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [x] Code style  correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)



<!-- readthedocs-preview arviz start -->
----
📚 Documentation preview 📚: https://arviz--2483.org.readthedocs.build/en/2483/

<!-- readthedocs-preview arviz end -->