### PR TITLE
Fix az.compare stacking weights not sum up to one

### DIFF
--- a/arviz/stats/stats.py
+++ b/arviz/stats/stats.py
@@ -1,7 +1,6 @@
 # pylint: disable=too-many-lines
 """Statistical functions in ArviZ."""
 
-import itertools
 import warnings
 from copy import deepcopy
 from typing import List, Optional, Tuple, Union, Mapping, cast, Callable


### PR DESCRIPTION
## Description
<!--
Thank you so much for your PR! To help us review your contribution, please consider the following points:

- The PR title should summarize the changes, for example "Add new group argument for the pair plot".
  Avoid non-descriptive titles such as "Addresses issue #348".

- The description should provide at least 1-2 sentences describing the pull request in detail and
  link to any relevant issues.

- Please prefix the title of incomplete contributions with [WIP] (to indicate a work in
  progress). WIPs may be useful to (1) indicate you are working on something to avoid
  duplicated work, (2) request broad review of functionality or API, or (3) seek collaborators. -->

While using `az.compare(models, method="stacking")`, I encountered the same problem as mentioned in #2359, where the `weights` column in the returned dataframe sums up to greater than 1.

My assumption is that `scipy.optimize.minimize` [converts our dict-type constraints to a list of `NonLinearConstraint`](https://github.com/scipy/scipy/blob/main/scipy/optimize/_constraints.py#L607), which over-complicates the problem in `az.compare`, since the sum of weights is a linear combination.  
Moreover, by removing the `np.concatenate` operation in `w_fuller` and using vectorized operations, we can increase the efficiency of the optimizer.  
In my extreme use case of comparing 54 models, I was able to reduce computation time by 14.3% (543s -> 465s) while getting the correct weight sum (3.636 -> 1.000).

However, I was not able to synthesize some test data to capture this behavior. Although we already have [some test cases that asserts sum of weights should be 1](https://github.com/arviz-devs/arviz/blob/main/arviz/tests/base_tests/test_stats.py#L203), the models are too simple to produce a failure.

## Checklist
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format
- [ ] Includes new or updated tests to cover the new feature
- [x] Code style correct (follows pylint and black guidelines)
- [ ] Changes are listed in [changelog](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0xx-unreleased)

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->


<!-- readthedocs-preview arviz start -->
----
📚 Documentation preview 📚: https://arviz--2492.org.readthedocs.build/en/2492/

<!-- readthedocs-preview arviz end -->