### PR TITLE
Update permissions for GHA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,7 @@
 name: Publish library
 
+permissions: {}
+
 on:
   push:
     branches:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,7 @@
 name: Run tests
+
+permissions: {}
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
<!--
Before opening a PR to this repository, keep in mind the `arviz` python library only installs
arviz-base, arviz-stats and arviz-plots and exposes their functions as a common namespace.

Make sure you want to submit your PR here and to to one of these other repositories.
Some examples of PRs that should be submitted here are:

* Global documentation updates
* Issues with the `arviz` namespace not exposing elements correctly
* Infrastructure
-->

There is already a repo-level setting that sets the default permission of actions to only read
things so it shouldn't make any difference in practice. It does make things more robust in case
we inadvertedly modify the settings.
