### PR TITLE
Use system cache directory for timestamp file

### DIFF
--- a/arviz/__init__.py
+++ b/arviz/__init__.py
@@ -57,8 +57,6 @@ def _warn_once_per_day():
         )
         _atomic_write_text(stamp_file, today.isoformat())
 
-        stamp_file.write_text(today.isoformat())
-
 
 _warn_once_per_day()
 

--- a/arviz/__init__.py
+++ b/arviz/__init__.py
@@ -23,8 +23,9 @@ def _warn_once_per_day():
     import datetime
     from warnings import warn
     from pathlib import Path
+    from platformdirs import user_cache_dir
 
-    warning_dir = Path.home() / "arviz_data"
+    warning_dir = Path(user_cache_dir("arviz", "arviz"))
     warning_dir.mkdir(exist_ok=True)
 
     stamp_file = warning_dir / "daily_warning"

--- a/arviz/data/example_data/data_remote.json
+++ b/arviz/data/example_data/data_remote.json
@@ -9,14 +9,14 @@
     {
         "name": "rugby",
         "filename": "rugby.nc",
-        "url": "http://figshare.com/ndownloader/files/44916469",
+        "url": "http://ndownloader.figshare.com/files/44916469",
         "checksum": "f4a5e699a8a4cc93f722eb97929dd7c4895c59a2183f05309f5082f3f81eb228",
         "description": "The Six Nations Championship is a yearly rugby competition between Italy, Ireland, Scotland, England, France and Wales. Fifteen games are played each year, representing all combinations of the six teams.\n\nThis example uses and includes results from 2014 - 2017, comprising 60 total games. It models latent parameters for each team's attack and defense, as well as a global parameter for home team advantage.\n\nSee https://github.com/arviz-devs/arviz_example_data/blob/main/code/rugby/rugby.ipynb for the whole model specification."
     },
     {
         "name": "rugby_field",
         "filename": "rugby_field.nc",
-        "url": "http://figshare.com/ndownloader/files/44667112",
+        "url": "http://ndownloader.figshare.com/files/44667112",
         "checksum": "53a99da7ac40d82cd01bb0b089263b9633ee016f975700e941b4c6ea289a1fb0",
         "description": "A variant of the 'rugby' example dataset. The Six Nations Championship is a yearly rugby competition between Italy, Ireland, Scotland, England, France and Wales. Fifteen games are played each year, representing all combinations of the six teams.\n\nThis example uses and includes results from 2014 - 2017, comprising 60 total games. It models latent parameters for each team's attack and defense, with each team having different values depending on them being home or away team.\n\nSee https://github.com/arviz-devs/arviz_example_data/blob/main/code/rugby_field/rugby_field.ipynb for the whole model specification."
     },

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ h5netcdf>=1.0.2
 h5py
 typing_extensions>=4.1.0
 xarray-einstats>=0.3
+platformdirs


### PR DESCRIPTION
This PR moves the timestamp file to the system cache directory using `platformdirs` and handles empty/corrupt files gracefully.

Fixes #2520