### PR TITLE
Create parent directories for cache

### DIFF
--- a/arviz/__init__.py
+++ b/arviz/__init__.py
@@ -1,6 +1,6 @@
 # pylint: disable=wildcard-import,invalid-name,wrong-import-position
 """ArviZ is a library for exploratory analysis of Bayesian models."""
-__version__ = "0.23.3"
+__version__ = "0.23.4"
 
 import logging
 import os


### PR DESCRIPTION
Hi,

I'm really sorry, but my recent PR (#2523) seems to have broken ArviZ since the parent directories appear to be missing on Windows (see [log](https://github.com/fau-advanced-separations/CADET-Process/actions/runs/21588907871/job/62463288624#step:8:89). This PR aims to fix this by adding the `parents=True` flag.

Again, I'm really sorry for causing this. :see_no_evil: 