### PR TITLE
docs: fix typo "Bbokeh" → "Bokeh" in docstring guide

### DIFF
--- a/docs/source/contributing/docstrings.md
+++ b/docs/source/contributing/docstrings.md
@@ -37,6 +37,6 @@ For example, let's add {func}`~arviz_stats.hdi` and {func}`~arviz_plots.plot_ppc
 ## Kwargs parameters
 
 All the kwargs parameters in the {doc}`arviz_plots:api/index` modules are passed to the
-Matplotlib or Bbokeh functions. While writing their description, the functions to which they are
+Matplotlib or Bokeh functions. While writing their description, the functions to which they are
 being passed must be mentioned. In order to check or add those functions, the process is the same
 for all the kwargs arguments.


### PR DESCRIPTION
Fixes a typo in docs/source/contributing/docstrings.md where "Bbokeh" appears instead of "Bokeh".

- Docs-only change
- Single character fix (double-B → single-B)
- No behavior impact

Bokeh is a well-known Python plotting library and should be capitalized correctly.

Checklist
- [x] One file only
- [x] Single typo fix
- [x] No reformatting or wording changes