### PR TITLE
MAINT: add Apache license headers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,15 @@ repos:
   rev: 0.4.1
   hooks:
     - id: no-print-statements
+- repo: https://github.com/Lucas-C/pre-commit-hooks
+  rev: v1.5.5
+  hooks:
+    - id: insert-license
+      files: ^(src|tests)/.*\.py$
+      args:
+        - --license-filepath
+        - tools/APACHE_HEADER.txt
+        - --comment-style
+        - "#"
+        - --detect-license-in-X-top-lines=30
+        - --no-extra-eol

--- a/src/arviz/__init__.py
+++ b/src/arviz/__init__.py
@@ -1,3 +1,16 @@
+# ﻿Copyright ArviZ contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # pylint: disable=unused-import,unused-wildcard-import,wildcard-import,invalid-name
 """Expose features from _ArviZverse_ refactored packages together in the ``arviz`` namespace."""
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,14 @@
+# ﻿Copyright ArviZ contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Tests for ArviZ metapackage, will check namespace availability only."""

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -1,3 +1,16 @@
+# ﻿Copyright ArviZ contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import importlib
 import re
 

--- a/tools/APACHE_HEADER.txt
+++ b/tools/APACHE_HEADER.txt
@@ -1,0 +1,13 @@
+﻿Copyright ArviZ contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
This is an infrastructure/maintenance change for the `arviz` repository.

- Add an Apache-2.0 license header template (no years) in `tools/APACHE_HEADER.txt`.
- Add a pre-commit `insert-license` hook and apply it to Python files under `src/` and `tests/`.

part of #2475.