### PR TITLE
Enhance API documentation with usage guidelines

### DIFF
--- a/docs/source/api.md
+++ b/docs/source/api.md
@@ -9,3 +9,19 @@ The complete API is described at the following pages:
 * {doc}`arviz-base API <arviz_base:api/index>`
 * {doc}`arviz-stats API <arviz_stats:api/index>`
 * {doc}`arviz-plots API <arviz_plots:api/index>`
+
+## How to use the API effectively
+
+Most users will interact with ArviZ through the top-level `arviz` namespace.
+
+For example:
+
+```python
+import arviz as az
+
+summary = az.summary(idata)
+az.plot_trace(idata)
+```
+Even though ArviZ is internally structured into multiple submodules (arviz_base, arviz_stats, arviz_plots), users typically do not need to import from these directly.
+
+This design helps keep the user interface simple while maintaining modularity internally.


### PR DESCRIPTION
This PR enhances the API documentation by adding a short section explaining how users typically interact with ArviZ through the top-level `arviz` namespace.

While going through the docs, I noticed that the API structure (arviz_base, arviz_stats, arviz_plots) might be slightly confusing for new users. This addition aims to clarify that most functionality is accessed via `import arviz as az`, along with a simple example.

The goal is to improve clarity and make the documentation more beginner-friendly without changing existing content.

Happy to refine the wording or placement based on feedback.
