### PR TITLE
Add Apache 2.0 license headers to missing Python files

### DIFF
--- a/docs/scripts/global_objinv.py
+++ b/docs/scripts/global_objinv.py
@@ -1,3 +1,16 @@
+# ﻿Copyright ArviZ contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Script to extract entries from arvizverse and create a global objects.inv.
 
 Having a global objects.inv allows downstream docs and examples to use

--- a/docs/scripts/homepage_miniatures.py
+++ b/docs/scripts/homepage_miniatures.py
@@ -1,3 +1,16 @@
+# ﻿Copyright ArviZ contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Script to generate the miniatures used for the website homepage grid.
 
 Due to the html structure of the page, the 6 figures below should aim for a 2/1 ratio.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,3 +1,16 @@
+# ﻿Copyright ArviZ contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #!/usr/bin/env python3
 #
 # ArviZ documentation build configuration file, created by


### PR DESCRIPTION
This PR adds Apache License 2.0 headers to Python source files that were missing them.

Changes:
   Added license headers to multiple .py files in the arviz module
   Ensured consistency with project licensing
Notes:
   No functional code changes were made
   All tests pass successfully
