### PR TITLE
Emit prominent `MigrationWarning` instead of breaking `InferenceData` import

### DIFF
--- a/src/arviz/__init__.py
+++ b/src/arviz/__init__.py
@@ -27,7 +27,7 @@ _log = logging.getLogger(__name__)
 info = ""
 
 
-class MigrationWarning(FutureWarning):
+class MigrationWarning(UserWarning, FutureWarning):
     """Warning raised when a legacy name is accessed on the ``arviz`` namespace."""
 
 

--- a/src/arviz/__init__.py
+++ b/src/arviz/__init__.py
@@ -27,8 +27,8 @@ _log = logging.getLogger(__name__)
 info = ""
 
 
-class MigrationError(RuntimeError):
-    """Error raised when a legacy name is accessed on the ``arviz`` namespace."""
+class MigrationWarning(DeprecationWarning):
+    """Warning raised when a legacy name is accessed on the ``arviz`` namespace."""
 
 
 try:
@@ -104,11 +104,17 @@ _MIGRATION_GUIDE_URL = "https://python.arviz.org/en/latest/user_guide/migration_
 def __getattr__(name):
     """Guide users who expect legacy names on the ``arviz`` namespace."""
     if name == "InferenceData":
-        raise MigrationError(
+        import warnings
+        from xarray import DataTree
+
+        warnings.warn(
             "arviz.InferenceData is no longer available on the "
             "arviz package; ArviZ now uses xarray's DataTree for the same "
-            f"role. See the migration guide: {_MIGRATION_GUIDE_URL}"
+            f"role. See the migration guide: {_MIGRATION_GUIDE_URL}",
+            MigrationWarning,
         )
+
+        return DataTree
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/src/arviz/__init__.py
+++ b/src/arviz/__init__.py
@@ -27,7 +27,7 @@ _log = logging.getLogger(__name__)
 info = ""
 
 
-class MigrationWarning(DeprecationWarning):
+class MigrationWarning(FutureWarning):
     """Warning raised when a legacy name is accessed on the ``arviz`` namespace."""
 
 

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -18,6 +18,7 @@ import arviz_base
 import arviz_plots
 import arviz_stats
 import pytest
+from xarray import DataTree
 
 import arviz as az
 
@@ -33,10 +34,10 @@ def test_info_attr():
 
 def test_aliases():
     # These are xarray aliases exposed for user convenience
-    xarray_aliases = {"from_netcdf", "from_zarr"}
+    xarray_aliases = {"from_netcdf", "from_zarr", "InferenceData"}
 
     for obj_name in dir(az):
-        if not obj_name.startswith("_") and obj_name not in ["info", "MigrationError"]:
+        if not obj_name.startswith("_") and obj_name not in ["info", "MigrationWarning"]:
             obj = getattr(az, obj_name)
 
             if obj_name in xarray_aliases:
@@ -88,15 +89,15 @@ def test_incompatible_package_versions(monkeypatch):
 
 def test_inference_data_import_points_to_migration_guide():
     """Legacy arviz.InferenceData should error with a link to the migration guide."""
-    with pytest.raises(az.MigrationError, match="https://python.arviz.org/.*/migration_guide.*"):
+    with pytest.warns(az.MigrationWarning, match="https://python.arviz.org/.*/migration_guide.*"):
         from arviz import InferenceData
 
-        InferenceData
+        assert InferenceData is DataTree
 
 
 def test_inference_data_getattr_points_to_migration_guide():
     """Legacy arviz.InferenceData should error with a link to the migration guide."""
-    with pytest.raises(az.MigrationError, match="https://python.arviz.org/.*/migration_guide.*"):
+    with pytest.warns(az.MigrationWarning, match="https://python.arviz.org/.*/migration_guide.*"):
         az.InferenceData
 
 


### PR DESCRIPTION
The 1.0 release is not even a week old and I already have colleagues running into import errors :(

In today's case it's with cases where we have PyMC versions pinnend and the import in PyMC at the time was not yet ArviZ 1.0 compatible.

Please consider this PR which will still bombard users with prominent deprecation warnings upon import, but give library maintainers and dev-ops people some time to fix all the places that are not directly under the control of the end user.