### PR TITLE
Pin GitHub Actions by SHA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,11 +19,11 @@ jobs:
       attestations: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: hynek/build-and-inspect-python-package@v2
+      - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e # v2.17.0
         with:
           # Prove that the packages were built in the context of this workflow.
           attest-build-provenance-github: true
@@ -41,12 +41,12 @@ jobs:
       id-token: write
     steps:
       - name: Download Distribution Artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           # The build-and-inspect-python-package action invokes upload-artifact.
           # These are the correct arguments from that action.
           name: Packages
           path: dist
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         # Implicitly attests that the packages were uploaded in the context of this workflow.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,9 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies


### PR DESCRIPTION
<!--
Before opening a PR to this repository, keep in mind the `arviz` python library only installs
arviz-base, arviz-stats and arviz-plots and exposes their functions as a common namespace.

Make sure you want to submit your PR here and to to one of these other repositories.
Some examples of PRs that should be submitted here are:

* Global documentation updates
* Issues with the `arviz` namespace not exposing elements correctly
* Infrastructure
-->

Pinning the SHAs is considered best security practice against supply-chain attacks, and they will be auto-updated by dependabot PRs.