### PR TITLE
security: add Incident Response Plan and revamp SECURITY.md issue : 2580 and Fix issue : Make transition to 1.0 easier issue : #2577

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,105 @@
+# Security Policy
+
+## Supported Versions
+
+ArviZ supports security updates for the following versions:
+
+| Version | Supported          |
+|---------|--------------------|
+| Latest stable release | ✅ Yes |
+| Previous minor release | ✅ Yes (critical fixes only) |
+| Older releases | ❌ No |
+
+We strongly encourage all users to keep ArviZ up to date.
+
+---
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+If you discover a security vulnerability in ArviZ, please report it responsibly via one of the following channels:
+
+### Option 1: GitHub Private Security Advisory (Preferred)
+
+Use GitHub's built-in private vulnerability reporting:
+
+1. Navigate to the [ArviZ Security Advisories page](https://github.com/arviz-devs/arviz/security/advisories).
+2. Click **"Report a vulnerability"**.
+3. Fill in the details of the vulnerability.
+
+This keeps the disclosure confidential until a fix is ready.
+
+### Option 2: Email
+
+Send a detailed report to the ArviZ maintainers at:
+
+**`security@arviz-devs.org`** *(update with actual address)*
+
+Please encrypt sensitive reports using our [PGP key](https://github.com/arviz-devs/arviz/security) *(update with actual key link if available)*.
+
+---
+
+## What to Include in Your Report
+
+To help us triage and resolve the issue quickly, please include:
+
+- A clear description of the vulnerability and its potential impact.
+- Steps to reproduce the issue (proof-of-concept code is welcome).
+- The ArviZ version(s) affected.
+- The environment (OS, Python version, dependency versions).
+- Any suggested mitigations or patches, if you have them.
+
+---
+
+## Response Timeline
+
+| Milestone | Target Timeframe |
+|-----------|-----------------|
+| Acknowledgement of report | Within **2 business days** |
+| Initial triage and severity assessment | Within **5 business days** |
+| Status update to reporter | Within **10 business days** |
+| Patch released (critical/high severity) | Within **30 days** of confirmed vulnerability |
+| Patch released (medium/low severity) | Next scheduled release |
+
+We will keep you informed at each stage. If you do not hear from us within 2 business days, please follow up.
+
+---
+
+## Disclosure Policy
+
+ArviZ follows **coordinated disclosure**:
+
+1. Reporter submits a private vulnerability report.
+2. The maintainer team acknowledges, triages, and develops a fix.
+3. A fix is prepared and tested privately.
+4. A new release is published containing the fix.
+5. A public GitHub Security Advisory (GHSA) is published simultaneously with the release.
+6. The reporter is credited (unless they prefer to remain anonymous).
+
+We ask that reporters allow us a reasonable time (typically 90 days) to fix and disclose before making any public disclosure.
+
+---
+
+## Scope
+
+Security issues we are interested in include, but are not limited to:
+
+- Arbitrary code execution via crafted input files (e.g., malicious NetCDF/HDF5/JSON files).
+- Unsafe deserialization of data objects.
+- Dependency vulnerabilities that affect ArviZ users.
+- Information disclosure or data exfiltration.
+
+**Out of scope:**
+
+- Vulnerabilities in third-party dependencies that do not directly affect ArviZ (please report those upstream).
+- Issues that require physical access to the user's machine.
+- Social engineering attacks.
+
+---
+
+## Acknowledgements
+
+We sincerely thank all researchers and users who responsibly disclose vulnerabilities. Contributors will be acknowledged in the release notes and security advisory, unless they prefer anonymity.
+
+This security policy is informed by our participation in [GitHub's Secure Open Source Fund](https://resources.github.com/security/secure-open-source-fund/).

--- a/docs/INCIDENT_RESOURCE_PLAN.md
+++ b/docs/INCIDENT_RESOURCE_PLAN.md
@@ -1,0 +1,240 @@
+# ArviZ Incident Response Plan
+
+**Version:** 1.0
+**Last Updated:** 2024
+**Owner:** ArviZ Maintainer Team
+
+---
+
+## Purpose
+
+This document defines how the ArviZ maintainer team detects, responds to, and recovers from security incidents. It applies to the ArviZ library, its GitHub repositories, PyPI packages, and associated infrastructure.
+
+This plan fulfills ArviZ's commitment to responsible open-source security practices, including participation in GitHub's Secure Open Source Fund.
+
+---
+
+## Scope
+
+This plan covers:
+
+- Security vulnerabilities reported in ArviZ source code.
+- Compromise of the ArviZ PyPI package (`arviz`).
+- Compromise of GitHub repository access or maintainer accounts.
+- Supply chain incidents (malicious dependencies).
+- Accidental exposure of secrets or credentials in the repository.
+
+---
+
+## Roles and Responsibilities
+
+| Role | Responsibility |
+|------|---------------|
+| **Incident Lead** | The maintainer who first receives or identifies the incident. Coordinates the response, owns communication, and makes escalation decisions. |
+| **Technical Lead** | Leads investigation and patch development. May be the same person as Incident Lead for small teams. |
+| **Communications Lead** | Drafts user-facing advisories and coordinates disclosure timing. |
+| **All Maintainers** | Support investigation, review patches, assist with release. |
+
+For ArviZ, the **on-call rotation** follows the current maintainer list in `MAINTAINERS.md`. If the initial recipient cannot lead, they must immediately hand off to another active maintainer.
+
+---
+
+## Severity Classification
+
+Use the following to classify incidents:
+
+| Severity | Criteria | Example |
+|----------|----------|---------|
+| **Critical** | Arbitrary code execution, package takeover, supply chain compromise | Malicious code injected into PyPI release |
+| **High** | Significant data exposure, severe dependency CVE with direct user impact | Unsafe deserialization of crafted input files |
+| **Medium** | Limited impact, requires unusual user action, or affects a niche use case | Exposure of local file paths in error messages |
+| **Low** | Minimal impact, no user action required | Outdated dependency with no known exploit path |
+
+When in doubt, treat the incident as one severity level higher until investigation clarifies the impact.
+
+---
+
+## Phase 1: Detection and Intake
+
+### Sources
+
+Incidents may be detected via:
+
+- A private vulnerability report via GitHub Security Advisories.
+- An email to the security contact.
+- A public disclosure (e.g., a tweet, CVE filing, or issue opened in error).
+- Automated scanning (e.g., Dependabot, GitHub secret scanning, pip-audit in CI).
+- Internal discovery by a maintainer.
+
+### Intake Steps
+
+1. **Acknowledge receipt** within 2 business days (see `SECURITY.md`).
+2. **Create a private tracking issue** using GitHub's private security advisory draft, or a private channel accessible only to maintainers.
+3. **Assign an Incident Lead** and notify other active maintainers.
+4. **Do not discuss details publicly** until the incident is resolved and coordinated disclosure is ready.
+
+> ⚠️ If a report arrives as a public GitHub issue, immediately convert it to a private security advisory or ask the reporter to resubmit, then close and lock the issue. Do not copy vulnerability details into any public discussion.
+
+---
+
+## Phase 2: Triage and Assessment
+
+Complete within **5 business days** of receipt.
+
+### Triage Checklist
+
+- [ ] Can the vulnerability be reproduced? Document the reproduction steps.
+- [ ] What versions of ArviZ are affected?
+- [ ] What is the attack vector (local, network, requires user interaction)?
+- [ ] What is the potential impact (confidentiality, integrity, availability)?
+- [ ] Is there a known exploit in the wild?
+- [ ] Does this affect any downstream packages or major users of ArviZ?
+- [ ] Assign a severity level (Critical / High / Medium / Low).
+
+### CVSS Scoring (Optional but Recommended)
+
+For High or Critical issues, compute a [CVSS v3.1 base score](https://www.first.org/cvss/calculator/3.1) to support consistent severity classification and advisory publication.
+
+---
+
+## Phase 3: Containment
+
+### Immediate Actions (Critical/High only)
+
+- **Yank the affected PyPI release** if a malicious or critically flawed package was published:
+  ```
+  pip install twine
+  twine yank arviz==<version> --reason "Security vulnerability"
+  ```
+- **Revoke compromised credentials** (PyPI tokens, GitHub tokens, SSH keys) immediately via the respective service dashboards.
+- **Disable affected GitHub Actions workflows** if they are part of a supply chain compromise.
+- **Notify PyPI or GitHub Security** if the platform itself needs to take action (e.g., package takeover).
+
+### General Containment
+
+- Limit knowledge of the vulnerability to active maintainers and, if needed, trusted security contacts.
+- Avoid merging any PRs related to the vulnerability into the public repository until the fix is ready for coordinated release.
+
+---
+
+## Phase 4: Investigation and Fix Development
+
+### Investigation
+
+1. Identify the root cause — is this a code bug, a dependency issue, a configuration problem, or a process failure?
+2. Determine the full scope of affected versions and configurations.
+3. Search git history for when the vulnerability was introduced (`git log -S '<pattern>'`).
+4. Check whether any forks or dependent packages might be separately affected.
+
+### Patch Development
+
+1. Develop the fix on a **private fork or branch** not visible in the public repository.
+   - GitHub Security Advisories support private temporary forks for exactly this purpose.
+2. Write or update tests that cover the vulnerability.
+3. Have at least one other maintainer review the patch before release.
+4. Ensure the fix does not introduce regressions (run the full test suite).
+
+---
+
+## Phase 5: Release and Disclosure
+
+### Release Steps
+
+1. Merge the fix into the main branch.
+2. Prepare a release that includes only the security fix (for Critical/High) or bundle with a scheduled release (for Medium/Low).
+3. Publish to PyPI.
+4. Verify the published package installs correctly and the fix is present:
+   ```bash
+   pip install arviz==<new_version>
+   python -c "import arviz; print(arviz.__version__)"
+   ```
+
+### Coordinated Disclosure
+
+Publish the GitHub Security Advisory simultaneously with (or immediately after) the release:
+
+1. Navigate to **Security > Advisories** in the ArviZ GitHub repository.
+2. Complete the advisory with:
+   - Affected versions
+   - Fixed version
+   - Description of the vulnerability (without unnecessarily enabling exploitation)
+   - Credit to the reporter (with their permission)
+   - CVE ID (request one via GitHub if not already assigned)
+3. Publish the advisory.
+
+### Notifying the Ecosystem
+
+For Critical or High severity issues, additionally:
+
+- Post an announcement to the [ArviZ Discourse](https://discourse.pymc.io/) or equivalent community forum.
+- Consider notifying major downstream users (e.g., PyMC, Bambi) directly via private message before public disclosure, if time allows.
+- Notify [PyPI](https://pypi.org/security/) if the incident involved a compromised release.
+
+---
+
+## Phase 6: Post-Incident Review
+
+Complete within **2 weeks** of resolution for Critical/High issues; within the next maintainer meeting for Medium/Low.
+
+### Review Checklist
+
+- [ ] Write a brief internal post-mortem (timeline, root cause, impact, resolution).
+- [ ] Identify what went well and what could be improved.
+- [ ] Update this Incident Response Plan if any steps were unclear or missing.
+- [ ] Add or update automated checks (CI, Dependabot, secret scanning) to catch similar issues earlier.
+- [ ] Close out the private tracking issue.
+- [ ] Thank the reporter.
+
+---
+
+## Communication Templates
+
+### Initial Acknowledgement (to reporter)
+
+> Thank you for reporting this to us. We have received your report and will investigate promptly. We aim to provide an initial assessment within 5 business days. We will keep you updated on our progress and coordinate the disclosure timeline with you.
+
+### Status Update (to reporter)
+
+> We have completed our initial triage of the vulnerability you reported. [Brief non-sensitive update on status]. We are currently [working on a fix / gathering more information / preparing a release]. Our current target for resolution is [date or timeframe]. Please let us know if you have additional information.
+
+### Public Advisory Summary
+
+> A [severity] security vulnerability was identified in ArviZ versions [X.Y.Z] and earlier. [One-sentence non-exploitable description]. Users are strongly encouraged to upgrade to version [A.B.C], which contains a fix. No workaround is available / A workaround is available [if applicable]. We thank [reporter name or "the reporter"] for responsibly disclosing this issue.
+
+---
+
+## Tooling and Resources
+
+| Tool | Purpose | Link |
+|------|---------|-------|
+| GitHub Security Advisories | Private tracking and coordinated disclosure | Repository > Security > Advisories |
+| GitHub Secret Scanning | Detect leaked credentials | Enabled by default on public repos |
+| Dependabot | Automated dependency vulnerability alerts | Repository > Settings > Security |
+| PyPI Yanking | Remove a compromised release | `twine yank` or PyPI web UI |
+| CVSS Calculator | Severity scoring | https://www.first.org/cvss/calculator/3.1 |
+| CVE Request (via GitHub) | Assign a CVE to a published advisory | Available in GitHub Security Advisory UI |
+| pip-audit | Audit installed packages for known CVEs | `pip install pip-audit && pip-audit` |
+
+---
+
+## Contacts
+
+| Contact | Details |
+|---------|---------|
+| Security email | `security@arviz-devs.org` *(update with actual address)* |
+| PyPI account owners | *(list internal document or private maintainer wiki)* |
+| GitHub organization owners | *(list internal document or private maintainer wiki)* |
+| GitHub Security support | https://support.github.com |
+| PyPI security team | https://pypi.org/security/ |
+
+---
+
+## Revision History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2024 | Initial version, created as part of GitHub Secure Open Source Fund participation |
+
+---
+
+*This plan is reviewed and updated at least annually, or after any significant security incident.*

--- a/src/arviz/__init__.py
+++ b/src/arviz/__init__.py
@@ -12,19 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # pylint: disable=unused-import,unused-wildcard-import,wildcard-import,invalid-name
+
 """Expose features from _ArviZverse_ refactored packages together in the ``arviz`` namespace."""
 
 import functools
 import logging
 import re
 
+# pyrefly: ignore [missing-import]
 from xarray import open_datatree as from_netcdf
 
 from_zarr = functools.partial(from_netcdf, engine="zarr")
 
-_log = logging.getLogger(__name__)
+_log = logging.getLogger(__name__) 
 
 info = ""
+
+_MIGRATION_GUIDE_URL = "https://python.arviz.org/en/latest/user_guide/migration_guide.html#datatree"
 
 
 class MigrationWarning(UserWarning, FutureWarning):
@@ -32,50 +36,55 @@ class MigrationWarning(UserWarning, FutureWarning):
 
 
 try:
+    # pyrefly: ignore [missing-import]
     from arviz_base import *
+    # pyrefly: ignore [missing-import]
     import arviz_base as base
 
-    _status = (
+    _base_status = (
         f"arviz_base {base.__version__} available, "
         "exposing its functions as part of the `arviz` namespace"
     )
-    _log.info(_status)
+    _log.info(_base_status)
     del base
 except ModuleNotFoundError as err:
     raise ImportError("arviz's dependency arviz_base is not installed", name="arviz") from err
 
-info += _status + "\n"
+info += _base_status + "\n"
 
 try:
+    # pyrefly: ignore [missing-import]
     from arviz_stats import *
+    # pyrefly: ignore [missing-import]
     import arviz_stats as stats
 
-    # TODO: remove patch. 0.7 version of arviz-stats didn't expose the __version__ attribute
-    _status = (
+    _stats_status = (
         f"arviz_stats {getattr(stats, '__version__', '0.7.0')} available, "
         "exposing its functions as part of the `arviz` namespace"
     )
-    _log.info(_status)
+    _log.info(_stats_status)
     del stats
 except ModuleNotFoundError as err:
     raise ImportError("arviz's dependency arviz_stats is not installed", name="arviz") from err
 
-info += _status + "\n"
+info += _stats_status + "\n"
 
 try:
+    # pyrefly: ignore [missing-import]
     from arviz_plots import *
+    # pyrefly: ignore [missing-import]
     import arviz_plots as plots
 
-    _status = (
+    _plots_status = (
         f"arviz_plots {plots.__version__} available, "
         "exposing its functions as part of the `arviz` namespace"
     )
-    _log.info(_status)
+    _log.info(_plots_status)
     del plots
 except ModuleNotFoundError as err:
     raise ImportError("arviz's dependency arviz_plots is not installed", name="arviz") from err
 
-info += _status
+info += _plots_status
 
 # define version last so it isn't overwritten by the respective attribute in the imported libraries
 __version__ = "1.2.0"
@@ -83,8 +92,6 @@ __version__ = "1.2.0"
 info = f"Status information for ArviZ {__version__}\n\n{info}"
 
 pat = re.compile(r"arviz_(base|stats|plots)\s([0-9]+\.[0-9]+)")
-matches = pat.findall(info)
-
 versions = dict(pat.findall(info))
 unique_versions = set(versions.values())
 
@@ -98,25 +105,57 @@ if len(unique_versions) > 1:
 
     raise ImportError("\n".join(lines))
 
-_MIGRATION_GUIDE_URL = "https://python.arviz.org/en/latest/user_guide/migration_guide.html#datatree"
+# ---------------------------------------------------------------------------
+# Transition aliases — ease migration from pre-1.0 to 1.0
+# These emit a MigrationWarning on first access and can be removed in a
+# future major version once the ecosystem has fully migrated.
+# ---------------------------------------------------------------------------
+
+# plot_trace -> plot_trace_dist alias (defined eagerly so it shows up in dir())
+try:
+    import warnings as _warnings
+    _plot_trace_dist = plot_trace_dist # noqa: F821 — exported by arviz_plots via *
+
+    def plot_trace(*args, **kwargs):
+        """Deprecated alias for :func:`plot_trace_dist`.
+
+        .. deprecated::
+            Use ``arviz.plot_trace_dist`` instead.
+            See the migration guide: {url}
+        """.format(url=_MIGRATION_GUIDE_URL)
+        _warnings.warn(
+            "arviz.plot_trace has been renamed to arviz.plot_trace_dist. "
+            f"See the migration guide: {_MIGRATION_GUIDE_URL}",
+            MigrationWarning,
+            stacklevel=2,
+        )
+        return _plot_trace_dist(*args, **kwargs)
+
+    del _warnings, _plot_trace_dist
+except NameError:
+    # plot_trace_dist not available in this version of arviz_plots — skip alias
+    _log.debug("plot_trace_dist not found; skipping plot_trace alias")
 
 
 def __getattr__(name):
-    """Guide users who expect legacy names on the ``arviz`` namespace."""
+    """Guide users who access legacy names on the ``arviz`` namespace."""
+    import warnings
+    # pyrefly: ignore [missing-import]
+    from xarray import DataTree
+
     if name == "InferenceData":
-        import warnings
-        from xarray import DataTree
-
         warnings.warn(
-            "arviz.InferenceData is no longer available on the "
-            "arviz package; ArviZ now uses xarray's DataTree for the same "
-            f"role. See the migration guide: {_MIGRATION_GUIDE_URL}",
+            "arviz.InferenceData is no longer available on the arviz package. "
+            "ArviZ now uses xarray.DataTree for the same role. "
+            f"See the migration guide: {_MIGRATION_GUIDE_URL}",
             MigrationWarning,
+            stacklevel=2,  # points warning at the caller, not this file
         )
-
         return DataTree
+
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-# clean namespace
-del functools, logging, matches, pat, re, _status, versions, unique_versions
+# clean namespace — only delete names that are guaranteed to exist
+del functools, logging, pat, re, versions, unique_versions
+del _base_status, _stats_status, _plots_status


### PR DESCRIPTION
#2580  Summary

- Revamps \`SECURITY.md\` with supported versions, reporting channels, response timelines, and disclosure policy
- Adds \`docs/security/INCIDENT_RESPONSE_PLAN.md\` covering detection, triage, containment, fix, disclosure, and post-incident review
