### PR TITLE
doc: update deprecated git protocol to https in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ conda install -c conda-forge arviz arviz-plots
 The latest development version can be installed from the main branch using pip:
 
 ```
-pip install git+git://github.com/arviz-devs/arviz.git
+pip install git+https://github.com/arviz-devs/arviz.git
 ```
 
 Another option is to clone the repository and install using git and setuptools:


### PR DESCRIPTION
<!--
Before opening a PR to this repository, keep in mind the `arviz` python library only installs
arviz-base, arviz-stats and arviz-plots and exposes their functions as a common namespace.

Make sure you want to submit your PR here and to to one of these other repositories.
Some examples of PRs that should be submitted here are:

* Global documentation updates
* Issues with the `arviz` namespace not exposing elements correctly
* Infrastructure
-->
### Description
This PR updates the deprecated and unencrypted `git://` protocol link in the README to the standard, secure `https://` protocol. 

### Changes Made
* **`README.md`**: Modified the repository clone URL in the installation instructions. GitHub has deprecated unencrypted Git connections, and the `git://` port is frequently blocked by strict corporate or university firewalls. Updating to `https://` ensures new users and contributors can reliably clone and install the development build without encountering security errors or timeouts.

### Checklist
- [x] Changes purely target documentation/README; no public API architectural breakages.
- [x] Code adheres to the project style guidelines.