### PR TITLE
chore: expand Dependabot to cover pip and pre-commit ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,17 @@ updates:
     actions:
       patterns:
         - "*"
+
+- package-ecosystem: "pip"
+  directory: "/"
+  schedule:
+    interval: "monthly"
+  cooldown:
+    default-days: 14
+
+- package-ecosystem: "pre-commit"
+  directory: "/"
+  schedule:
+    interval: "monthly"
+  cooldown:
+    default-days: 14


### PR DESCRIPTION
<!--
Before opening a PR to this repository, keep in mind the `arviz` python library only installs
arviz-base, arviz-stats and arviz-plots and exposes their functions as a common namespace.

Make sure you want to submit your PR here and to to one of these other repositories.
Some examples of PRs that should be submitted here are:

* Global documentation updates
* Issues with the `arviz` namespace not exposing elements correctly
* Infrastructure
-->
