### PR TITLE
chore: expand dependabot to cover pip and pre-commit ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,25 @@ updates:
     actions:
       patterns:
         - "*"
+
+- package-ecosystem: "pip"
+  directory: "/"
+  schedule:
+    interval: "monthly"
+  cooldown:
+    default-days: 14
+  groups:
+    pip:
+      patterns:
+        - "*"
+
+- package-ecosystem: "pre-commit"
+  directory: "/"
+  schedule:
+    interval: "monthly"
+  cooldown:
+    default-days: 14
+  groups:
+    pre-commit:
+      patterns:
+        - "*"


### PR DESCRIPTION
## Summary
Closes #2608

## What does this change?
Expands `.github/dependabot.yml` to include pip and pre-commit 
ecosystems alongside the existing github-actions configuration.

## Changes made
Added configuration blocks for:
- `package-ecosystem: "pip"` 
- `package-ecosystem: "pre-commit"`

Both use monthly schedules and cooldown settings matching the 
existing GitHub Actions cadence to avoid overwhelming maintainers 
with PRs.