### PR TITLE
Reorganize HDI API change in migration guide

### DIFF
--- a/docs/source/user_guide/migration_guide.ipynb
+++ b/docs/source/user_guide/migration_guide.ipynb
@@ -113,6 +113,16 @@
     "Defaults set via `rcParams` are not fixed rules, they’re meant to be adjusted to fit the needs of your analysis. `rcParams` offers a convenient way to establish global defaults for your workflow, while most functions that compute credible intervals also provide `ci_prob` and `ci_kind` arguments to override these settings locally.\n",
     "\n",
     "\n",
+    ":::{important}\n",
+    "The `hdi` function signature has changed accordingly. The `hdi_prob` argument\n",
+    "was renamed to `prob`, and `input_core_dims` was renamed to `dim`:\n",
+    "\n",
+    "```python\n",
+    "az.hdi(data, hdi_prob=0.95)  # ArviZ < 1.0\n",
+    "az.hdi(data, prob=0.95)      # ArviZ >= 1.0\n",
+    "```\n",
+    ":::\n",
+    "\n",
     "You can check all default settings with:"
    ]
   },
@@ -10609,29 +10619,6 @@
     "\n",
     "One recurring feedback we have received is that the documentation was OK for people very familiar with Bayesian statistics and probabilistic programming,\n",
     "but not so much for newcomers. Thus, we have added more introductory material and examples to the documentation, including a separated resource that show how to use ArviZ \"in-context\", see [EABM](https://arviz-devs.github.io/EABM/). And we attempted to make the documentation easier to navigate and understand for everyone.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "47a92cb3",
-   "metadata": {},
-   "source": [
-    "## HDI Function Changes\n",
-    "\n",
-    "In ArviZ 1.0, the `hdi()` function argument `hdi_prob` was renamed to `prob`.\n",
-    "\n",
-    "**Before (ArviZ < 1.0):**\n",
-    "```python\n",
-    "az.hdi(data, hdi_prob=0.95)\n",
-    "```\n",
-    "\n",
-    "**After (ArviZ >= 1.0):**\n",
-    "```python\n",
-    "az.hdi(data, prob=0.95)\n",
-    "```\n",
-    "\n",
-    "\n",
-    "Also note that `input_core_dims` was renamed to `dim` in ArviZ 1.0."
    ]
   }
  ],


### PR DESCRIPTION
Seems odd to have an entire section dedicated to the HDI API change. I think the guide flows better if we just call this out explictly in the guide itself as a core change. 

Open to suggestions about where this should live as well. Seemed appropriate to have it in the credible intervals section.
